### PR TITLE
[bug] gu - check for apm before saving .atom

### DIFF
--- a/bin/gu
+++ b/bin/gu
@@ -200,7 +200,7 @@ else
     fi
 
     ### ATOM
-    if [ -d .atom ]; then
+    if [ -x "$(command -v apm)" ] && [ -d .atom ]; then
       u 'apm' 'apm list --installed --no-color'
       # TODO: 'font size'/'show panel' change shouldn't trigger update
       # always back up dark theme so that a theme change doesn't trigger a gu update


### PR DESCRIPTION
Fix bug where user previously installed Atom, which created `~/.atom`, but then uninstalled Atom - which leaves `~/.atom` behind.
* The script shows an error that `apm` command doesn't exist, so it should check to make sure the command exists.
* The script should still check for `.atom` given that the script also relies on that folder being present.