### PR TITLE
[up] default npm: false

### DIFF
--- a/config/.defaultConfig.json
+++ b/config/.defaultConfig.json
@@ -4,7 +4,7 @@
     "ballin": "true",
     "gu": "false",
     "softwareupdate": "true",
-    "npm": "true"
+    "npm": "false"
   },
   "gu": {
     "id": null,


### PR DESCRIPTION
Users likely want to keep npm coupled with node, rather than updating npm to latest. Further, users likely don't need to use npm globals (prefer `npx` etc.).