### PR TITLE
[up] add nvm (LTS node)

### DIFF
--- a/bin/up
+++ b/bin/up
@@ -13,6 +13,13 @@ if [ -x "$(command -v brew)" ]; then
 fi
 
 
+### NVM
+# update nvm-installed LTS node
+if [ -s "$NVM_DIR/nvm.sh" ] && [ $(ballin_config get up.nvm) == 'true' ]; then
+  \. "$NVM_DIR/nvm.sh"
+  nvm install --lts
+fi
+
 ### NPM
 # update all global npm binaries
 if [ -x "$(command -v npm)" ] && [ $(ballin_config get up.npm) == 'true' ]; then

--- a/config/.defaultConfig.json
+++ b/config/.defaultConfig.json
@@ -4,7 +4,8 @@
     "ballin": "true",
     "gu": "false",
     "softwareupdate": "true",
-    "npm": "false"
+    "npm": "false",
+    "nvm": "false"
   },
   "gu": {
     "id": null,


### PR DESCRIPTION
### Purpose
Keep node and npm updated.

### Notes
* Assumes user exported `$NVM_DIR`.
* Should work for both brew and curl installed nvm.
* Opt-in config given that it assumes users use LTS and don't want globals moved over (otherwise would've included `--reinstall-packages-from`).