### PR TITLE
fix: resetConfig output

### DIFF
--- a/test/config.test.js
+++ b/test/config.test.js
@@ -102,5 +102,10 @@ describe('config', () => {
     it('("set", "gu.id", "123") should set gu.id to "123"', () => {
       setTest('gu.id', '123', configAction);
     });
+    it('("reset") should reset config', () => {
+      setTest('gu.id', '123', configAction);
+      assert.include(configAction('reset'), 'Config has been reset FROM:');
+      assert.isNull(getConfig('gu.id'));
+    });
   });
 });


### PR DESCRIPTION
* Output previous config and new (default config) 
* Add unit test
* Other minor refactor/fixes

### Intent
Allows for resetting config without losing the previous config, so that one could add back their existing config to the reset config. Another benefit is added safety to avoid accidentally resetting the config.

### Related Note
`ballin_update` will pull in (and output) new configs but doesn't remove any configs that were removed.