### PR TITLE
Use appropriate bin directory for installer symlinks

### DIFF
--- a/bin/ballin_uninstall
+++ b/bin/ballin_uninstall
@@ -3,10 +3,11 @@
 ### DELETE SYMLINKS
 printf '\n%s\n' "It's been real..."
 
-bin_dirs=('/usr/local/bin')
+# Check the standard Intel and Apple Silicon locations even if brew is absent.
+bin_dirs=('/usr/local/bin' '/opt/homebrew/bin')
 if [ -x "$(command -v brew)" ]; then
   brew_bin_dir="$(brew --prefix)/bin"
-  if [ "$brew_bin_dir" != '/usr/local/bin' ]; then
+  if [ "$brew_bin_dir" != '/usr/local/bin' ] && [ "$brew_bin_dir" != '/opt/homebrew/bin' ]; then
     bin_dirs+=("$brew_bin_dir")
   fi
 fi

--- a/bin/ballin_uninstall
+++ b/bin/ballin_uninstall
@@ -2,8 +2,22 @@
 
 ### DELETE SYMLINKS
 printf '\n%s\n' "It's been real..."
+
+bin_dirs=('/usr/local/bin')
+if [ -x "$(command -v brew)" ]; then
+  brew_bin_dir="$(brew --prefix)/bin"
+  if [ "$brew_bin_dir" != '/usr/local/bin' ]; then
+    bin_dirs+=("$brew_bin_dir")
+  fi
+fi
+
 for bin in "$HOME/.ballin-scripts/bin/"*; do
-  rm "/usr/local/bin/${bin##*/}"
+  for bin_dir in "${bin_dirs[@]}"; do
+    link="$bin_dir/${bin##*/}"
+    if [ -L "$link" ] && [ "$(readlink "$link")" = "$bin" ]; then
+      rm "$link"
+    fi
+  done
 done
 printf '%s\n' 'Deleted symlinked binaries'
 

--- a/bin/ballin_uninstall
+++ b/bin/ballin_uninstall
@@ -3,8 +3,8 @@
 ### DELETE SYMLINKS
 printf '\n%s\n' "It's been real..."
 
-# Check the standard Intel and Apple Silicon locations even if brew is absent.
-bin_dirs=('/usr/local/bin' '/opt/homebrew/bin')
+# Include current and legacy install locations so upgrades remain uninstallable.
+bin_dirs=("$HOME/.local/bin" '/usr/local/bin' '/opt/homebrew/bin')
 if [ -x "$(command -v brew)" ]; then
   brew_bin_dir="$(brew --prefix)/bin"
   if [ "$brew_bin_dir" != '/usr/local/bin' ] && [ "$brew_bin_dir" != '/opt/homebrew/bin' ]; then

--- a/install.sh
+++ b/install.sh
@@ -14,10 +14,16 @@ printf '%s\n' "🏀 let's ball..."
 
 
 ############################## CHECK INITIAL SETUP #############################
-# Check that /usr/local/bin is in $PATH
-if [[ ! $PATH  = *"/usr/local/bin:"* ]]; then
-  l1="usr/local/bin doesn't seem to be in your path."
-  l2='Run: echo \"export PATH=/usr/local/bin:$PATH\" > $HOME/.bash_profile'
+if [ -x "$(command -v brew)" ]; then
+  bin_dir="$(brew --prefix)/bin"
+else
+  bin_dir='/usr/local/bin'
+fi
+
+# Check that the directory used for commands is in $PATH
+if [[ ":$PATH:" != *":$bin_dir:"* ]]; then
+  l1="$bin_dir doesn't seem to be in your path."
+  l2="Add 'export PATH=\"$bin_dir:\$PATH\"' to your shell profile."
   l3='and open a new terminal window and run this installation again.'
   printf '\n⚠️  ERROR: %s\n%s\n%s\n' "$l1" "$l2" "$l3"
   unset l1 l2 l3
@@ -145,10 +151,18 @@ done
   )
 
   ############################## SYMLINK BINARIES ##############################
+  if ! mkdir -p "$bin_dir"; then
+    printf '\n⚠️  ERROR: Unable to create %s\n' "$bin_dir"
+    exit 1
+  fi
+
   for bin in "$HOME/.ballin-scripts/bin/"*; do
-    ln -sf "$bin" '/usr/local/bin'
+    if ! ln -sfn "$bin" "$bin_dir/${bin##*/}"; then
+      printf '\n⚠️  ERROR: Unable to symlink binaries into %s\n' "$bin_dir"
+      exit 1
+    fi
   done
-  printf '\n%s\n' '💪 symlinked binaries'
+  printf '\n💪 symlinked binaries into %s\n' "$bin_dir"
 
   printf '\n%s\n' '😎 ballin!'
 fi

--- a/install.sh
+++ b/install.sh
@@ -17,8 +17,8 @@ printf '%s\n' "🏀 let's ball..."
 if [ -x "$(command -v brew)" ]; then
   bin_dir="$(brew --prefix)/bin"
 else
-  # Only used without brew; default to the supported Apple Silicon Brew path.
-  bin_dir='/opt/homebrew/bin'
+  # Use a conventional user-owned bin directory when Homebrew is unavailable.
+  bin_dir="$HOME/.local/bin"
 fi
 
 # Check that the directory used for commands is in $PATH

--- a/install.sh
+++ b/install.sh
@@ -17,7 +17,8 @@ printf '%s\n' "🏀 let's ball..."
 if [ -x "$(command -v brew)" ]; then
   bin_dir="$(brew --prefix)/bin"
 else
-  bin_dir='/usr/local/bin'
+  # Apple Silicon is the only supported Mac architecture, so use its Brew path.
+  bin_dir='/opt/homebrew/bin'
 fi
 
 # Check that the directory used for commands is in $PATH

--- a/install.sh
+++ b/install.sh
@@ -17,7 +17,7 @@ printf '%s\n' "🏀 let's ball..."
 if [ -x "$(command -v brew)" ]; then
   bin_dir="$(brew --prefix)/bin"
 else
-  # Apple Silicon is the only supported Mac architecture, so use its Brew path.
+  # Only used without brew; default to the supported Apple Silicon Brew path.
   bin_dir='/opt/homebrew/bin'
 fi
 


### PR DESCRIPTION
## Summary
- Use `$(brew --prefix)/bin` for command symlinks when Homebrew is available instead of assuming `/usr/local/bin`
- Preserve installation without Homebrew by falling back to the conventional user-owned `$HOME/.local/bin` directory
- Validate that the selected bin directory is on `PATH` and provide shell-profile instructions when it is not
- Create the selected bin directory when needed and report clear errors if directory creation or symlinking fails
- Create or replace command symlinks in the selected bin directory
- Update uninstall logic to check `$HOME/.local/bin`, the standard Apple Silicon and legacy Intel Homebrew locations, and any custom prefix reported by Homebrew
- Only remove symlinks that point to the current Ballin Scripts installation

## Decisions
- Homebrew remains optional. Ballin Scripts already supports environments without it when `gist` is installed separately, so requiring Homebrew solely to choose a symlink destination would remove existing functionality unnecessarily.
- When Homebrew is installed, its reported prefix is the source of truth. This supports Apple Silicon, Intel, and custom Homebrew prefixes without architecture-specific assumptions.
- Without Homebrew, `$HOME/.local/bin` is used because it is a conventional user-owned executable directory, requires no elevated permissions, and does not assume a nonexistent Homebrew installation.
- The installer remains responsible for explaining how to add the selected directory to `PATH`; this implementation detail is intentionally not added to the README.
- The uninstaller checks current and legacy destinations so installations created by older versions can still be cleaned up safely.

## Testing
- Tested locally using `./install.sh` and `ballin_uninstall`
- Ran `bash -n install.sh bin/ballin_uninstall`
- Ran `git diff --check`
- Ran `npm test` with a temporary ignored `ballin.config.json` test fixture: 18 tests passing

Fixes #65