### PR TITLE
Fix formatting of install script command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 Run the [install script](install.sh) using cURL:
 
 ```shell
-$ bash <(curl -s https://raw.githubusercontent.com/JBallin/ballin-scripts/main/install.sh)
+bash <(curl -s https://raw.githubusercontent.com/JBallin/ballin-scripts/main/install.sh)
 ```
 
 ## Scripts


### PR DESCRIPTION
Remove `$` initially added to document this should be ran in the shell, but I think it's better to make the command copy and past-able without the `$`.