### PR TITLE
[gu] add zprofile backup support

### DIFF
--- a/bin/gu
+++ b/bin/gu
@@ -144,17 +144,17 @@ else
     if [ -f .bash_profile ]; then
       u 'bash_profile.sh' 'cat .bash_profile'
     fi
-    if [ -f .zshrc ]; then
-      u 'zshrc.sh' 'cat .zshrc'
-    fi
-    if [ -f .zprofile ]; then
-      u 'zprofile.sh' 'cat .zprofile'
+    if [ -f .bashrc ]; then
+      u 'bashrc.sh' 'cat .bashrc'
     fi
     if [ -f .profile ]; then
       u 'profile.sh' 'cat .profile'
     fi
-    if [ -f .bashrc ]; then
-      u 'bashrc.sh' 'cat .bashrc'
+    if [ -f .zprofile ]; then
+      u 'zprofile.sh' 'cat .zprofile'
+    fi
+    if [ -f .zshrc ]; then
+      u 'zshrc.sh' 'cat .zshrc'
     fi
     # BASH COMPLETIONS
     if [ -d /usr/local/etc/bash_completion.d ]; then

--- a/bin/gu
+++ b/bin/gu
@@ -37,6 +37,7 @@ file_suggestions='
   vimrc
   vs_extensions
   vs_settings.json
+  zprofile.sh
   zshrc.sh'
 
 ### TODO handle error when $id fails github API (check res code) (either nonexistant, deleted gist, skipped init etc)
@@ -145,6 +146,9 @@ else
     fi
     if [ -f .zshrc ]; then
       u 'zshrc.sh' 'cat .zshrc'
+    fi
+    if [ -f .zprofile ]; then
+      u 'zprofile.sh' 'cat .zprofile'
     fi
     if [ -f .profile ]; then
       u 'profile.sh' 'cat .profile'


### PR DESCRIPTION
## Summary
- back up `~/.zprofile` as `zprofile.sh` during `gu`
- include `zprofile.sh` in the `gu read` filename suggestions

## Why
Zsh login-shell configuration commonly lives in `~/.zprofile`, but `gu` only captured `~/.zshrc`. This adds the missing profile alongside the existing shell dotfile backups.

## Impact
Users with a `~/.zprofile` will have it stored in their backup gist and can discover/read it consistently with the other shell files.

## Validation
- `bash -n bin/gu`
- `git diff --check`
- `npm test` (18 passing)