### PR TITLE
[gu] make VS Code CLI lookup portable

### DIFF
--- a/bin/gu
+++ b/bin/gu
@@ -205,7 +205,6 @@ else
       vscode_dir="$HOME/Library/Application Support/${vscode_paths[$i]}/User"
 
       if [ -d "$vscode_dir" ]; then
-        vscode_cmd="/usr/local/bin/${vscode_binaries[$i]}"
         vscode_prefix="${vscode_prefixes[$i]}"
         cd "$vscode_dir"
         for file in "${vscode_files[@]}"; do
@@ -213,7 +212,9 @@ else
             u "${vscode_prefix}_${file%.json}" "cat $file"
           fi
         done
-        u "${vscode_prefix}_extensions" "$vscode_cmd --list-extensions"
+        if command -v "${vscode_binaries[$i]}" > /dev/null; then
+          u "${vscode_prefix}_extensions" "${vscode_binaries[$i]} --list-extensions"
+        fi
         cd - > /dev/null
       fi
     done


### PR DESCRIPTION
## Summary

- Check for the VS Code and VS Code Insiders CLI binaries through `PATH` with `command -v`.
- Pass the simple command name to `u` instead of a hard-coded or resolved executable path.
- Skip extension backup when the corresponding CLI is unavailable.

## Why

`gu` previously built the CLI path under `/usr/local/bin`, which assumes the conventional Intel Homebrew prefix. Apple Silicon Homebrew normally installs binaries under `/opt/homebrew/bin`, so extension backup could fail even when `code` or `code-insiders` was installed correctly.

Using `command -v` as an availability check avoids coupling this logic to a particular Homebrew prefix. Passing `code` or `code-insiders` to `u` then lets Bash perform normal `PATH` lookup when the command runs. This supports Intel and Apple Silicon Homebrew installations as well as direct app-bundle `PATH` entries such as `/Applications/Visual Studio Code.app/Contents/Resources/app/bin`, whose resolved executable path contains spaces.

The availability check also prevents `gu` from attempting extension backup when a VS Code settings directory exists but its shell CLI has not been installed.

## Validation

- `bash -n bin/gu`
- `git diff --check`
- Ran a command string through a `PATH` containing `/Applications/Visual Studio Code.app/Contents/Resources/app/bin` and confirmed Bash found and executed `code` successfully