### PR TITLE
[codex] Fix gu cache consistency and quiet Homebrew output

### DIFF
--- a/bin/gu
+++ b/bin/gu
@@ -96,17 +96,12 @@ else
 
       input_file="$(mktemp)"
       $input > "$input_file"
-      # Normalize the temp file before comparing so it matches gist/cache format.
       # Add "empty" because gist rejects empty files.
       if [ ! -s "$input_file" ]; then
         echo "empty" > "$input_file"
       fi
-      # Ensure a final newline to match gist output format.
-      if [ "$(tail -c 1 "$input_file")" != "" ]; then
-        printf '\n' >> "$input_file"
-      fi
 
-      # Check for changes against the normalized cache.
+      # Check for changes against the cached output.
       if [ "$is_new" == 1 ] && cmp -s "$input_file" "$cache_file"; then
         is_changed=1
       else

--- a/bin/gu
+++ b/bin/gu
@@ -103,7 +103,7 @@ else
       if [ ! -s "$input_file" ]; then
         echo "empty" > "$input_file"
       fi
-      # Ensure non-empty files end with a newline to match gist text output.
+      # Match gist text output so caches seeded by gist -r compare cleanly.
       if [ "$(tail -c 1 "$input_file")" != "" ]; then
         printf '\n' >> "$input_file"
       fi

--- a/bin/gu
+++ b/bin/gu
@@ -81,8 +81,10 @@ else
     local cache_file="$HOME/.ballin-scripts/.gu-cache/$file_name"
     local input=$2
     local input_file
+    local input_file_with_newline
     local is_changed
     local is_new=1
+    local is_seeded_from_gist=0
     local is_empty=1
 
     update_cache() {
@@ -91,6 +93,8 @@ else
         # set is_new to true if the $file_name doesn't exist yet in gist, otherwise create $cache_file with current gist_content
         if ! gist -r "$id" "$file_name" > "$cache_file"; then
           is_new=0
+        else
+          is_seeded_from_gist=1
         fi
       fi
 
@@ -107,6 +111,18 @@ else
       # Check for changes against the cached output.
       if [ "$is_new" == 1 ] && cmp -s "$input_file" "$cache_file"; then
         is_changed=1
+      elif [ "$is_seeded_from_gist" == 1 ] && [ "$(tail -c 1 "$input_file")" != "" ]; then
+        # gist -r adds a final newline; fix the local cache without uploading.
+        input_file_with_newline="$(mktemp)"
+        cp "$input_file" "$input_file_with_newline"
+        printf '\n' >> "$input_file_with_newline"
+        if cmp -s "$input_file_with_newline" "$cache_file"; then
+          is_changed=1
+        else
+          is_changed=0
+        fi
+        cp "$input_file" "$cache_file"
+        rm -f "$input_file_with_newline"
       else
         cp "$input_file" "$cache_file"
         is_changed=0

--- a/bin/gu
+++ b/bin/gu
@@ -81,10 +81,8 @@ else
     local cache_file="$HOME/.ballin-scripts/.gu-cache/$file_name"
     local input=$2
     local input_file
-    local input_file_with_newline
     local is_changed
     local is_new=1
-    local is_seeded_from_gist=0
     local is_empty=1
 
     update_cache() {
@@ -93,8 +91,6 @@ else
         # set is_new to true if the $file_name doesn't exist yet in gist, otherwise create $cache_file with current gist_content
         if ! gist -r "$id" "$file_name" > "$cache_file"; then
           is_new=0
-        else
-          is_seeded_from_gist=1
         fi
       fi
 
@@ -107,22 +103,14 @@ else
       if [ ! -s "$input_file" ]; then
         echo "empty" > "$input_file"
       fi
+      # Ensure non-empty files end with a newline to match gist text output.
+      if [ "$(tail -c 1 "$input_file")" != "" ]; then
+        printf '\n' >> "$input_file"
+      fi
 
       # Check for changes against the cached output.
       if [ "$is_new" == 1 ] && cmp -s "$input_file" "$cache_file"; then
         is_changed=1
-      elif [ "$is_seeded_from_gist" == 1 ] && [ "$(tail -c 1 "$input_file")" != "" ]; then
-        # gist -r adds a final newline; fix the local cache without uploading.
-        input_file_with_newline="$(mktemp)"
-        cp "$input_file" "$input_file_with_newline"
-        printf '\n' >> "$input_file_with_newline"
-        if cmp -s "$input_file_with_newline" "$cache_file"; then
-          is_changed=1
-        else
-          is_changed=0
-        fi
-        cp "$input_file" "$cache_file"
-        rm -f "$input_file_with_newline"
       else
         cp "$input_file" "$cache_file"
         is_changed=0

--- a/bin/gu
+++ b/bin/gu
@@ -76,11 +76,11 @@ else
   )
 
   # TODO: consider refactor to pass command arrays as $input instead of a string for safer execution.
-  # TODO: only execute $input once
   u() {
     local file_name=$1
     local cache_file="$HOME/.ballin-scripts/.gu-cache/$file_name"
     local input=$2
+    local input_file
     local is_changed
     local is_new=1
     local is_empty=1
@@ -94,20 +94,22 @@ else
         fi
       fi
 
-      # check for changes (mark as no changes if input is empty and file is already labeled 'empty')
-      if [ "$is_new" == 1 ] && [ "$($input)" == "$(cat "$cache_file")" ] || ([ "$($input)" == "" ] && [ "$(cat "$cache_file")" == "empty" ]); then
+      input_file="$(mktemp)"
+      $input > "$input_file"
+      # Normalize the temp file before comparing so it matches gist/cache format.
+      if [ ! -s "$input_file" ]; then
+        echo "empty" > "$input_file"
+      fi
+      sed -i '' -e '$a\' "$input_file"
+
+      # Check for changes against the normalized cache.
+      if [ "$is_new" == 1 ] && cmp -s "$input_file" "$cache_file"; then
         is_changed=1
       else
-        $input > "$cache_file"
+        cp "$input_file" "$cache_file"
         is_changed=0
       fi
-
-      # add "empty" if $cache_file empty so that gist doesnt give empty error
-      if [ ! -s "$cache_file" ]; then
-        echo "empty" > "$cache_file"
-      fi
-      # add newline to end of $file_name (if not already there), to match gist format
-      sed -i '' -e '$a\' "$cache_file"
+      rm -f "$input_file"
 
       if [ "$(cat "$cache_file")" == 'empty' ]; then
         is_empty=0
@@ -167,10 +169,16 @@ else
 
     ### BREW
     if [ -x "$(command -v brew)" ]; then
+      export HOMEBREW_NO_AUTO_UPDATE=1
+      export HOMEBREW_NO_ENV_HINTS=1
       u 'brew_list' 'brew list --formula'
       u 'brew_leaves' 'brew leaves'
       u 'brew_cask' 'brew list --cask'
-      u 'brew_services' 'brew services list'
+      # Suppress stderr warnings when no services are installed while preserving stdout service rows.
+      brew_services_list() {
+        brew services list 2> /dev/null
+      }
+      u 'brew_services' 'brew_services_list'
       u 'Brewfile' 'brew bundle dump --file=-'
     fi
 

--- a/bin/gu
+++ b/bin/gu
@@ -95,7 +95,10 @@ else
       fi
 
       input_file="$(mktemp)"
-      $input > "$input_file"
+      if ! $input > "$input_file"; then
+        rm -f "$input_file"
+        return 1
+      fi
       # Add "empty" because gist rejects empty files.
       if [ ! -s "$input_file" ]; then
         echo "empty" > "$input_file"
@@ -137,7 +140,7 @@ else
         fi
       fi
     }
-    update_cache
+    if ! update_cache; then return 1; fi
     if [ "$is_changed" == 0 ]; then gist -u "$id" "$cache_file" > /dev/null; fi
     output_file_change
   }
@@ -173,9 +176,16 @@ else
       u 'brew_list' 'brew list --formula'
       u 'brew_leaves' 'brew leaves'
       u 'brew_cask' 'brew list --cask'
-      # Suppress stderr warnings when no services are installed while preserving stdout service rows.
+      # Suppress no-services stderr warnings while preserving stdout rows and real errors.
       brew_services_list() {
-        brew services list 2> /dev/null
+        local err_file
+        err_file="$(mktemp)"
+        if ! brew services list 2> "$err_file"; then
+          cat "$err_file" >&2
+          rm -f "$err_file"
+          return 1
+        fi
+        rm -f "$err_file"
       }
       u 'brew_services' 'brew_services_list'
       u 'Brewfile' 'brew bundle dump --file=-'

--- a/bin/gu
+++ b/bin/gu
@@ -97,9 +97,11 @@ else
       input_file="$(mktemp)"
       $input > "$input_file"
       # Normalize the temp file before comparing so it matches gist/cache format.
+      # Add "empty" because gist rejects empty files.
       if [ ! -s "$input_file" ]; then
         echo "empty" > "$input_file"
       fi
+      # Add a final newline to match gist output format.
       sed -i '' -e '$a\' "$input_file"
 
       # Check for changes against the normalized cache.

--- a/bin/gu
+++ b/bin/gu
@@ -101,7 +101,7 @@ else
       if [ ! -s "$input_file" ]; then
         echo "empty" > "$input_file"
       fi
-      # Add a final newline to match gist output format.
+      # Ensure a final newline to match gist output format.
       sed -i '' -e '$a\' "$input_file"
 
       # Check for changes against the normalized cache.

--- a/bin/gu
+++ b/bin/gu
@@ -102,7 +102,9 @@ else
         echo "empty" > "$input_file"
       fi
       # Ensure a final newline to match gist output format.
-      sed -i '' -e '$a\' "$input_file"
+      if [ "$(tail -c 1 "$input_file")" != "" ]; then
+        printf '\n' >> "$input_file"
+      fi
 
       # Check for changes against the normalized cache.
       if [ "$is_new" == 1 ] && cmp -s "$input_file" "$cache_file"; then

--- a/bin/gu
+++ b/bin/gu
@@ -81,7 +81,7 @@ else
     local cache_file="$HOME/.ballin-scripts/.gu-cache/$file_name"
     local input=$2
     local input_file
-    # State flags follow shell status convention: 0 means yes, 1 means no.
+    # State flags follow shell status convention: 0 means true, 1 means false.
     local is_changed
     local is_new=1
     local is_empty=1

--- a/bin/gu
+++ b/bin/gu
@@ -81,6 +81,7 @@ else
     local cache_file="$HOME/.ballin-scripts/.gu-cache/$file_name"
     local input=$2
     local input_file
+    # State flags follow shell status convention: 0 means yes, 1 means no.
     local is_changed
     local is_new=1
     local is_empty=1
@@ -95,6 +96,7 @@ else
       fi
 
       input_file="$(mktemp)"
+      # Capture once, and leave the existing cache untouched if the command fails.
       if ! $input > "$input_file"; then
         rm -f "$input_file"
         return 1
@@ -144,6 +146,7 @@ else
         fi
       fi
     }
+    # Do not upload stale cache content when the snapshot command fails.
     if ! update_cache; then return 1; fi
     if [ "$is_changed" == 0 ]; then gist -u "$id" "$cache_file" > /dev/null; fi
     output_file_change

--- a/bin/up
+++ b/bin/up
@@ -2,6 +2,7 @@
 
 ### HOMEBREW
 if [ -x "$(command -v brew)" ]; then
+  export HOMEBREW_NO_ENV_HINTS=1
   brew upgrade
   if [ "$(ballin_config get up.cleanup)" = 'true' ]; then
     brew cleanup


### PR DESCRIPTION
## Summary

- Keep `gu` quiet during Brew inventory collection by disabling Homebrew auto-update/env hints.
- Suppress only successful `brew services list` stderr so the no-services warning does not display while real service rows are still captured from stdout.
- Surface real command errors and avoid overwriting cached/gist files when a captured command fails.
- Run each `gu` inventory command once by capturing output to a temporary file before comparison/cache writes.
- Preserve trailing blank lines while normalizing non-empty tracked output to end with a final newline for gist storage.
- Use `empty` as the placeholder for truly empty gist files.
- Hide Homebrew env-hint footer text during `up` while preserving normal upgrade/cleanup/doctor output.

## Why

`gu` is meant to snapshot local configuration state, so Homebrew auto-update chatter and service warnings can make terminal output noisy and risk polluting captured output. The `u` helper also re-ran expensive commands during comparison and cache updates.

The command output is stored in a temp file instead of a Bash variable. That keeps the single-execution optimization while avoiding command substitution's trailing-newline trimming. Non-empty outputs are explicitly newline-terminated before comparison/storage, matching gist text output and avoiding `.gu-cache` bootstrap mismatches from `gist -r`.

If a command fails, `gu` now leaves the existing cache/gist entry alone instead of converting empty stdout into the `empty` placeholder.

`up` should still perform real Homebrew update work, but the repeated environment-variable hint footer is not useful once users know it exists.

## Validation

- `bash -n bin/gu`
- `bash -n bin/up`
- Verified a temp-file cache write preserves multiple trailing blank lines with `cmp`.
- Verified a source without a final newline normalizes to the newline-terminated gist/cache form.
- Verified empty output still stores the `empty` placeholder and compares cleanly on subsequent runs.
- Verified a failing captured command surfaces stderr and leaves the existing cache untouched.
- Ran `gu` locally, moved `.gu-cache` aside, reran `gu` to bootstrap cache from the gist, then reran `gu` once more to confirm the hydrated cache stays clean.
- Ran `gu` locally and confirmed the Homebrew services warning is suppressed when there are no services to list.
- Installed and started `redis` with `brew services`, then ran `gu` to confirm real service rows are still captured from stdout.
- Ran `up` locally and confirmed Homebrew env-hint footer output is suppressed while normal update output remains visible.