### PR TITLE
[up] don't "ask" during brew upgrade

### DIFF
--- a/bin/up
+++ b/bin/up
@@ -3,7 +3,8 @@
 ### HOMEBREW
 if [ -x "$(command -v brew)" ]; then
   export HOMEBREW_NO_ENV_HINTS=1
-  brew upgrade --no-ask
+  export HOMEBREW_NO_ASK=1
+  brew upgrade
   if [ "$(ballin_config get up.cleanup)" = 'true' ]; then
     brew cleanup
   fi

--- a/bin/up
+++ b/bin/up
@@ -3,7 +3,7 @@
 ### HOMEBREW
 if [ -x "$(command -v brew)" ]; then
   export HOMEBREW_NO_ENV_HINTS=1
-  brew upgrade
+  brew upgrade --no-ask
   if [ "$(ballin_config get up.cleanup)" = 'true' ]; then
     brew cleanup
   fi


### PR DESCRIPTION
Use env var instead of flag for backwards compatibility with older brew versions.

Fixes #80.
