### PR TITLE
[codex] Improve nvm update handling in up

### DIFF
--- a/bin/up
+++ b/bin/up
@@ -21,8 +21,8 @@ fi
 ### NVM
 # update nvm-installed Node.js LTS
 if [ "$(ballin_config get up.nvm)" = 'true' ]; then
+  progress 'Updating Node.js LTS'
   if [ -s "$NVM_DIR/nvm.sh" ]; then
-    progress 'Updating Node.js LTS'
     # nvm is a shell function; loading it here only affects this script.
     \. "$NVM_DIR/nvm.sh"
     nvm install --lts

--- a/bin/up
+++ b/bin/up
@@ -19,11 +19,17 @@ if [ -x "$(command -v brew)" ]; then
 fi
 
 ### NVM
-# update nvm-installed LTS node
-if [ -s "$NVM_DIR/nvm.sh" ] && [ "$(ballin_config get up.nvm)" = 'true' ]; then
-  progress 'Updating Node.js LTS'
-  \. "$NVM_DIR/nvm.sh"
-  nvm install --lts
+# update nvm-installed Node.js LTS
+if [ "$(ballin_config get up.nvm)" = 'true' ]; then
+  if [ -s "$NVM_DIR/nvm.sh" ]; then
+    progress 'Updating Node.js LTS'
+    # nvm is a shell function; loading it here only affects this script.
+    \. "$NVM_DIR/nvm.sh"
+    nvm install --lts
+  else
+    printf '\n⚠️  Skipping Node.js LTS update: unable to load nvm.\n' >&2
+    printf '%s\n' 'Set NVM_DIR to your nvm installation or disable this update with: ballin_config set up.nvm false' >&2
+  fi
 fi
 
 ### NPM

--- a/bin/up
+++ b/bin/up
@@ -23,7 +23,8 @@ fi
 if [ "$(ballin_config get up.nvm)" = 'true' ]; then
   progress 'Updating Node.js LTS'
   if [ -s "$NVM_DIR/nvm.sh" ]; then
-    # nvm is a shell function; loading it here only affects this script.
+    # nvm is a shell function and is not inherited by this Bash process.
+    # Load it here; changes remain local to this script.
     \. "$NVM_DIR/nvm.sh"
     nvm install --lts
   else

--- a/bin/up
+++ b/bin/up
@@ -23,8 +23,8 @@ fi
 if [ "$(ballin_config get up.nvm)" = 'true' ]; then
   progress 'Updating Node.js LTS'
   if [ -s "$NVM_DIR/nvm.sh" ]; then
-    # nvm is a shell function and is not inherited by this Bash process.
-    # Load it here; changes remain local to this script.
+    # `up` runs in a new Bash process, so it cannot rely on the parent shell's
+    # `nvm` function. Source nvm here; it affects only this `up` process.
     \. "$NVM_DIR/nvm.sh"
     nvm install --lts
   else

--- a/test/up.test.js
+++ b/test/up.test.js
@@ -78,9 +78,10 @@ fi
   });
 
   it('does not load nvm when the integration is disabled', () => {
-    installNvmStub(path.join(tempDir, '.nvm'));
+    const nvmDir = path.join(tempDir, 'custom-nvm');
+    installNvmStub(nvmDir);
 
-    const result = runUp({ TEST_UP_NVM: 'false' });
+    const result = runUp({ NVM_DIR: nvmDir, TEST_UP_NVM: 'false' });
 
     assert.equal(result.status, 0);
     assert.notInclude(result.stdout, 'Updating Node.js LTS');

--- a/test/up.test.js
+++ b/test/up.test.js
@@ -70,6 +70,7 @@ fi
     const result = runUp();
 
     assert.equal(result.status, 0);
+    assert.include(result.stdout, 'Updating Node.js LTS');
     assert.include(result.stderr, 'unable to load nvm');
     assert.include(result.stderr, 'Set NVM_DIR');
     assert.include(result.stderr, 'ballin_config set up.nvm false');

--- a/test/up.test.js
+++ b/test/up.test.js
@@ -1,0 +1,89 @@
+const { assert } = require('chai');
+const { spawnSync } = require('child_process');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const upPath = path.join(__dirname, '..', 'bin', 'up');
+
+describe('up', () => {
+  let tempDir;
+  let binDir;
+  let logPath;
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ballin-up-'));
+    binDir = path.join(tempDir, 'bin');
+    logPath = path.join(tempDir, 'nvm.log');
+    fs.mkdirSync(binDir);
+    fs.writeFileSync(
+      path.join(binDir, 'ballin_config'),
+      `#!/usr/bin/env bash
+if [ "$2" = 'up.nvm' ]; then
+  printf '%s\\n' "\${TEST_UP_NVM:-false}"
+else
+  printf '%s\\n' 'false'
+fi
+`,
+      { mode: 0o755 },
+    );
+  });
+
+  afterEach(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  const runUp = (env = {}) => spawnSync(upPath, [], {
+    encoding: 'utf8',
+    env: {
+      HOME: tempDir,
+      PATH: `${binDir}:/usr/bin:/bin`,
+      NVM_TEST_LOG: logPath,
+      TEST_UP_NVM: 'true',
+      ...env,
+    },
+  });
+
+  const installNvmStub = (nvmDir) => {
+    fs.mkdirSync(nvmDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(nvmDir, 'nvm.sh'),
+      `nvm() {
+  printf '%s\\n' "$*" >> "$NVM_TEST_LOG"
+}
+`,
+    );
+  };
+
+  it('loads nvm from NVM_DIR and updates Node.js LTS', () => {
+    const nvmDir = path.join(tempDir, 'custom-nvm');
+    installNvmStub(nvmDir);
+
+    const result = runUp({ NVM_DIR: nvmDir });
+
+    assert.equal(result.status, 0);
+    assert.include(result.stdout, 'Updating Node.js LTS');
+    assert.equal(fs.readFileSync(logPath, 'utf8'), 'install --lts\n');
+  });
+
+  it('warns when nvm is enabled but cannot be loaded', () => {
+    const result = runUp();
+
+    assert.equal(result.status, 0);
+    assert.include(result.stderr, 'unable to load nvm');
+    assert.include(result.stderr, 'Set NVM_DIR');
+    assert.include(result.stderr, 'ballin_config set up.nvm false');
+    assert.isFalse(fs.existsSync(logPath));
+  });
+
+  it('does not load nvm when the integration is disabled', () => {
+    installNvmStub(path.join(tempDir, '.nvm'));
+
+    const result = runUp({ TEST_UP_NVM: 'false' });
+
+    assert.equal(result.status, 0);
+    assert.notInclude(result.stdout, 'Updating Node.js LTS');
+    assert.notInclude(result.stderr, 'unable to load nvm');
+    assert.isFalse(fs.existsSync(logPath));
+  });
+});


### PR DESCRIPTION
## Summary

- check `up.nvm` before attempting to load nvm
- explain why `up` sources `nvm.sh` and warn when nvm is unavailable
- add focused tests for enabled, unavailable, and disabled nvm updates

## Why

nvm is a shell function, so the Bash process running `up` must source `nvm.sh` before calling it. Previously, `up.nvm=true` could be skipped silently when nvm was unavailable. The new warning makes that configuration problem actionable while preserving the existing nonfatal behavior.

This was prompted by the optional-capabilities work in #84 and contributes focused update-script coverage toward #78 without closing either issue.

## Validation

- `npm test` (21 passing)
- `bash -n bin/up`
- `git diff --check`
- `up` (with `up.nvm` enabled) with nvm available (updates nvm node) and nvm unavailable but brew installed node (shows error message)