### PR TITLE
[codex] Document optional capabilities after setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@ Run the [install script](install.sh) using cURL:
 bash <(curl -s https://raw.githubusercontent.com/JBallin/ballin-scripts/main/install.sh)
 ```
 
+After setup, see the [optional capabilities guide](docs/optional-capabilities.md)
+for integrations and additional update automation.
+
 ## Scripts
 
 ##### `ballin` - Show available commands

--- a/docs/optional-capabilities.md
+++ b/docs/optional-capabilities.md
@@ -41,15 +41,14 @@ brew install node
 With this option, Homebrew manages Node.js updates along with your other formulae.
 The `up.nvm` setting does not apply.
 
-The installer's missing-Node detection and guidance are tracked separately in
-[#60](https://github.com/JBallin/ballin-scripts/issues/60); this guide is the
-canonical reference for choosing and setting up a Node.js installation method.
-
 ## Mac App Store apps
 
-Follow the official
-[`mas` installation instructions](https://github.com/mas-cli/mas#installation) to
-add Mac App Store support.
+Install [`mas`](https://github.com/mas-cli/mas) with Homebrew to add Mac App
+Store support:
+
+```shell
+brew install mas
+```
 
 When `mas` is available, `up` updates installed App Store apps and `gu` includes
 the installed-app list in your backup. No configuration setting is required.
@@ -66,4 +65,4 @@ Change a setting with `ballin_config set up.<name> true` or
 | `up.gu` | `false` | Runs `gu` to back up your development environment. Enable it when you want each update to also modify your backup gist. |
 | `up.softwareupdate` | `true` | Installs available macOS updates with `softwareupdate`. |
 | `up.nvm` | `false` | Installs the latest Node.js LTS release through a configured nvm installation. See [Node.js](#nodejs) for the setup and tradeoffs. |
-| `up.npm` | `false` | Updates all globally installed npm packages. This is separate from the npm version bundled with Node.js; many tools can instead stay project-local or run through `npx`. |
+| `up.npm` | `false` | Runs `npm update -g` across globally installed packages. This is a separate update step from the npm version supplied with Node.js. It defaults to `false` because it can change all global tools at once, while many tools can instead stay project-local or run through `npx`. |

--- a/docs/optional-capabilities.md
+++ b/docs/optional-capabilities.md
@@ -1,16 +1,18 @@
 # Optional capabilities
 
-`ballin-scripts` works with a few optional tools and settings. The defaults keep
-updates predictable, while letting you opt in to broader automation.
+This guide covers choices for the required Node.js setup, plus optional tools
+and settings that extend `ballin-scripts`. The defaults keep updates predictable
+while letting you opt in to broader automation.
 
 ## Node.js
 
-Node.js is required by `ballin-scripts`. For a development environment, the
-recommended setup is [nvm](https://github.com/nvm-sh/nvm)
+Node.js is required by `ballin-scripts`; install it using whichever method fits
+your environment. For development, we recommend [nvm](https://github.com/nvm-sh/nvm)
 with the latest Node.js long-term support (LTS) release. It supports switching
-versions and project-specific `.nvmrc` files without a system-wide installation.
+versions, project-specific `.nvmrc` files, and a user-local installation.
 
-Follow nvm's official [installation and shell setup instructions](https://github.com/nvm-sh/nvm#installing-and-updating),
+Follow nvm's official
+[installation and shell setup instructions](https://github.com/nvm-sh/nvm#installing-and-updating),
 then install Node.js LTS:
 
 ```shell
@@ -25,9 +27,10 @@ ballin_config set up.nvm true
 ```
 
 `up.nvm` runs `nvm install --lts`; it does not update nvm itself. It defaults to
-`false` because it assumes you want the LTS release, and installing a new Node.js
-version does not migrate your globally installed npm packages automatically. If
-nvm cannot be loaded, `up` warns and continues with its remaining updates.
+`false` because enabling it opts into the LTS release, and installing a new
+Node.js version does not migrate your globally installed npm packages
+automatically. If nvm cannot be loaded, `up` warns and continues with its
+remaining updates.
 
 For a simpler setup, install Homebrew's current Node.js release instead:
 
@@ -44,8 +47,9 @@ canonical reference for choosing and setting up a Node.js installation method.
 
 ## Mac App Store apps
 
-Follow the official [`mas` installation instructions](https://github.com/mas-cli/mas#installation)
-to add Mac App Store support.
+Follow the official
+[`mas` installation instructions](https://github.com/mas-cli/mas#installation) to
+add Mac App Store support.
 
 When `mas` is available, `up` updates installed App Store apps and `gu` includes
 the installed-app list in your backup. No configuration setting is required.

--- a/docs/optional-capabilities.md
+++ b/docs/optional-capabilities.md
@@ -1,0 +1,65 @@
+# Optional capabilities
+
+`ballin-scripts` works with a few optional tools and settings. The defaults keep
+updates predictable, while letting you opt in to broader automation.
+
+## Node.js
+
+Node.js is required by `ballin-scripts`. For a development environment, the
+recommended setup is [nvm](https://github.com/nvm-sh/nvm)
+with the latest Node.js long-term support (LTS) release. It supports switching
+versions and project-specific `.nvmrc` files without a system-wide installation.
+
+Follow nvm's official [installation and shell setup instructions](https://github.com/nvm-sh/nvm#installing-and-updating),
+then install Node.js LTS:
+
+```shell
+nvm install --lts
+```
+
+After installing `ballin-scripts`, optionally let `up` install newer LTS
+releases:
+
+```shell
+ballin_config set up.nvm true
+```
+
+`up.nvm` runs `nvm install --lts`; it does not update nvm itself. It defaults to
+`false` because it assumes you want the LTS release, and installing a new Node.js
+version does not migrate your globally installed npm packages automatically. If
+nvm cannot be loaded, `up` warns and continues with its remaining updates.
+
+For a simpler setup, install Homebrew's current Node.js release instead:
+
+```shell
+brew install node
+```
+
+With this option, Homebrew manages Node.js updates along with your other formulae.
+The `up.nvm` setting does not apply.
+
+The installer's missing-Node detection and guidance are tracked separately in
+[#60](https://github.com/JBallin/ballin-scripts/issues/60); this guide is the
+canonical reference for choosing and setting up a Node.js installation method.
+
+## Mac App Store apps
+
+Follow the official [`mas` installation instructions](https://github.com/mas-cli/mas#installation)
+to add Mac App Store support.
+
+When `mas` is available, `up` updates installed App Store apps and `gu` includes
+the installed-app list in your backup. No configuration setting is required.
+
+## `up` settings
+
+Change a setting with `ballin_config set up.<name> true` or
+`ballin_config set up.<name> false`.
+
+| Setting | Default | Behavior |
+| --- | --- | --- |
+| `up.cleanup` | `true` | Runs `brew cleanup` after upgrading Homebrew packages. |
+| `up.ballin` | `true` | Updates `ballin-scripts` when `up` runs. |
+| `up.gu` | `false` | Runs `gu` to back up your development environment. Enable it when you want each update to also modify your backup gist. |
+| `up.softwareupdate` | `true` | Installs available macOS updates with `softwareupdate`. |
+| `up.nvm` | `false` | Installs the latest Node.js LTS release through a configured nvm installation. See [Node.js](#nodejs) for the setup and tradeoffs. |
+| `up.npm` | `false` | Updates all globally installed npm packages. This is separate from the npm version bundled with Node.js; many tools can instead stay project-local or run through `npx`. |

--- a/install.sh
+++ b/install.sh
@@ -3,6 +3,7 @@ printf '%s\n' "🏀 let's ball..."
 
 repo_dir="$HOME/.ballin-scripts"
 ballin_config="$repo_dir/bin/ballin_config"
+optional_capabilities_url='https://github.com/JBallin/ballin-scripts/blob/main/docs/optional-capabilities.md'
 
 ################################## CLONE REPO ##################################
 (
@@ -41,21 +42,25 @@ else
 
 
 ########################## CREATE/UPDATE CONFIG FILE #########################
-(
-  cd "$repo_dir/config"
-  if [ ! -f '../ballin.config.json' ]; then
-    # create config
-    cp '.defaultConfig.json' '../ballin.config.json'
+initial_setup=false
+if [ ! -f "$repo_dir/ballin.config.json" ]; then
+  # create config
+  if cp "$repo_dir/config/.defaultConfig.json" "$repo_dir/ballin.config.json"; then
+    initial_setup=true
     printf '\n%s\n' "🧠 Created 'ballin.config.json' file in root using default settings"
   else
-    # ballin_update reruns this installer after pulling changes; add any new
-    # default options to the existing config without overwriting user settings.
-    UPDATE_RESULT=$(node "$repo_dir/config/updateConfig.js")
-    if [ -n "$UPDATE_RESULT" ]; then
-      printf '\n🙌 %s\n' "$UPDATE_RESULT"
-    fi
+    printf '\n⚠️  ERROR: Unable to create ballin.config.json\n'
+    exit 1
   fi
-)
+else
+  # ballin_update reruns this installer after pulling changes; add any new
+  # default options to the existing config without overwriting user settings.
+  UPDATE_RESULT=$(node "$repo_dir/config/updateConfig.js")
+  if [ -n "$UPDATE_RESULT" ]; then
+    printf '\n🙌 %s\n' "$UPDATE_RESULT"
+    printf '\nOptional capabilities: %s\n' "$optional_capabilities_url"
+  fi
+fi
 
 
 #################################### GIST ####################################
@@ -167,6 +172,10 @@ done
     fi
   done
   printf '\n💪 symlinked binaries into %s\n' "$bin_dir"
+
+  if [ "$initial_setup" = true ]; then
+    printf '\nOptional capabilities: %s\n' "$optional_capabilities_url"
+  fi
 
   printf '\n%s\n' '😎 ballin!'
 fi

--- a/install.sh
+++ b/install.sh
@@ -42,25 +42,27 @@ else
 
 
 ########################## CREATE/UPDATE CONFIG FILE #########################
-initial_setup=false
+config_existed=true
 if [ ! -f "$repo_dir/ballin.config.json" ]; then
-  # create config
-  if cp "$repo_dir/config/.defaultConfig.json" "$repo_dir/ballin.config.json"; then
-    initial_setup=true
+  config_existed=false
+fi
+
+(
+  cd "$repo_dir/config"
+  if [ ! -f '../ballin.config.json' ]; then
+    # create config
+    cp '.defaultConfig.json' '../ballin.config.json'
     printf '\n%s\n' "🧠 Created 'ballin.config.json' file in root using default settings"
   else
-    printf '\n⚠️  ERROR: Unable to create ballin.config.json\n'
-    exit 1
+    # ballin_update reruns this installer after pulling changes; add any new
+    # default options to the existing config without overwriting user settings.
+    UPDATE_RESULT=$(node "$repo_dir/config/updateConfig.js")
+    if [ -n "$UPDATE_RESULT" ]; then
+      printf '\n🙌 %s\n' "$UPDATE_RESULT"
+      printf '\nOptional capabilities: %s\n' "$optional_capabilities_url"
+    fi
   fi
-else
-  # ballin_update reruns this installer after pulling changes; add any new
-  # default options to the existing config without overwriting user settings.
-  UPDATE_RESULT=$(node "$repo_dir/config/updateConfig.js")
-  if [ -n "$UPDATE_RESULT" ]; then
-    printf '\n🙌 %s\n' "$UPDATE_RESULT"
-    printf '\nOptional capabilities: %s\n' "$optional_capabilities_url"
-  fi
-fi
+)
 
 
 #################################### GIST ####################################
@@ -173,7 +175,7 @@ done
   done
   printf '\n💪 symlinked binaries into %s\n' "$bin_dir"
 
-  if [ "$initial_setup" = true ]; then
+  if [ "$config_existed" = false ] && [ -f "$repo_dir/ballin.config.json" ]; then
     printf '\nOptional capabilities: %s\n' "$optional_capabilities_url"
   fi
 


### PR DESCRIPTION
## Summary

- add a concise guide for Node.js setup choices, the optional `mas` integration, and configurable `up` behavior
- link the guide from the README and successful initial installation output
- show the guide during updates only when new configuration options are reported

## Why

Supported integrations and optional update behavior were difficult to discover without reading the config or source. This gives users one durable reference while keeping installer and README output compact. The Node guidance links upstream installation instructions and documents only the choices and behavior relevant to `ballin-scripts`.

Missing-Node detection and its install-time error flow remain separate work owned by #60.

Closes #84.

## Validation

- `npm test` (21 passing)
- `bash -n install.sh`
- `bash -n bin/up`
- `git diff --check`
- documented defaults and commands checked against the current source