### PR TITLE
[codex] Detect missing Node.js during installation

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -31,6 +31,14 @@ if [[ ":$PATH:" != *":$bin_dir:"* ]]; then
   l3='and open a new terminal window and run this installation again.'
   printf '\n⚠️  ERROR: %s\n%s\n%s\n' "$l1" "$l2" "$l3"
   unset l1 l2 l3
+# Check that Node.js is available before running configuration commands
+elif [ ! -x "$(command -v node)" ]; then
+  printf '\n⚠️  ERROR: Node.js is required.\n'
+  printf '\nRecommended: install Node.js LTS with nvm.\n'
+  printf 'Setup guide: %s\n' "$optional_capabilities_url"
+  printf '\nAlternatively:\n  brew install node\n'
+  printf '\nThen run this installer again.\n'
+  exit 1
 # Check that either gist or brew is installed
 elif [ ! -x "$(command -v gist)" ] && [ ! -x "$(command -v brew)" ]; then
   l1="Can't find Homebrew, which is needed to download 'gist'."

--- a/test/install.test.js
+++ b/test/install.test.js
@@ -1,0 +1,44 @@
+const { assert } = require('chai');
+const { spawnSync } = require('child_process');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const installPath = path.join(__dirname, '..', 'install.sh');
+
+describe('install', () => {
+  let homeDir;
+  let binDir;
+  let repoDir;
+
+  beforeEach(() => {
+    homeDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ballin-install-'));
+    binDir = path.join(homeDir, '.local', 'bin');
+    repoDir = path.join(homeDir, '.ballin-scripts');
+    fs.mkdirSync(binDir, { recursive: true });
+    fs.mkdirSync(repoDir);
+    fs.symlinkSync('/bin/bash', path.join(binDir, 'bash'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(homeDir, { recursive: true, force: true });
+  });
+
+  it('stops with guidance when Node.js is unavailable', () => {
+    const result = spawnSync(installPath, [], {
+      encoding: 'utf8',
+      env: {
+        HOME: homeDir,
+        PATH: binDir,
+      },
+    });
+
+    assert.equal(result.status, 1);
+    assert.include(result.stdout, 'Node.js is required');
+    assert.include(result.stdout, 'Node.js LTS with nvm');
+    assert.include(result.stdout, 'docs/optional-capabilities.md');
+    assert.include(result.stdout, 'brew install node');
+    assert.include(result.stdout, 'run this installer again');
+    assert.isFalse(fs.existsSync(path.join(repoDir, 'ballin.config.json')));
+  });
+});


### PR DESCRIPTION
## Summary

- check for Node.js before configuration or Gist setup begins
- print concise guidance recommending Node.js LTS through nvm, linking the canonical setup guide, and showing `brew install node` as the alternative
- exit cleanly and tell the user to run the installer again
- add an isolated installer regression test for the missing-Node path

## Why

`ballin_config` and config migration require Node.js. Without an early prerequisite check, installation could continue until a later Node-dependent command failed with less useful context.

The installer does not choose, install, or prompt for a Node management method; detailed setup remains in the optional-capabilities guide.

Closes #60.

## Validation

- `npm test` (22 passing)
- `bash -n install.sh`
- `git diff --check`
- Validated that the installer properly shows the error with no node