### PR TITLE
[codex] Clarify optional capabilities description

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ Run the [install script](install.sh) using cURL:
 bash <(curl -s https://raw.githubusercontent.com/JBallin/ballin-scripts/main/install.sh)
 ```
 
-See the [optional capabilities guide](docs/optional-capabilities.md) for Node.js
-setup, optional tools, and update settings.
+See the [optional capabilities guide](docs/optional-capabilities.md) for
+additional setup and configuration.
 
 ## Scripts
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ bash <(curl -s https://raw.githubusercontent.com/JBallin/ballin-scripts/main/ins
 ```
 
 After setup, see the [optional capabilities guide](docs/optional-capabilities.md)
-for integrations and additional update automation.
+for Node.js setup choices, optional tools, and update settings.
 
 ## Scripts
 

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ Run the [install script](install.sh) using cURL:
 bash <(curl -s https://raw.githubusercontent.com/JBallin/ballin-scripts/main/install.sh)
 ```
 
-After setup, see the [optional capabilities guide](docs/optional-capabilities.md)
-for Node.js setup choices, optional tools, and update settings.
+See the [optional capabilities guide](docs/optional-capabilities.md) for Node.js
+setup, optional tools, and update settings.
 
 ## Scripts
 


### PR DESCRIPTION
## Summary

Replace the README's narrow “integrations and additional update automation” description with a broader pointer to additional setup and configuration.

## Why

The README only needs to help users discover the guide. Keeping the description broad is clearer, more durable, and avoids duplicating the guide's contents.

## Validation

- `git diff --check`
- documentation-only wording change