### PR TITLE
[codex] Run tests with an isolated config fixture

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,11 +12,9 @@
 $ cd $HOME/.ballin-scripts
 $ ballin_update # Update project/config
 $ git checkout -b $BRANCH_NAME
-$ cp ballin.config.json ../Desktop # Stash config
 $ npm install
 # MAKE CHANGES
 $ npm test
-$ mv ../Desktop/ballin.config.json . # Restore config
 $ git push fork $BRANCH_NAME
 ```
 

--- a/config/index.js
+++ b/config/index.js
@@ -2,7 +2,13 @@ const fs = require('fs');
 const { exec } = require('child_process');
 const path = require('path');
 
-const configPath = path.join(__dirname, '..', 'ballin.config.json');
+const userConfigPath = path.join(__dirname, '..', 'ballin.config.json');
+const configPath = process.env.NODE_ENV === 'test'
+  ? process.env.BALLIN_TEST_CONFIG_PATH
+  : userConfigPath;
+if (!configPath) {
+  throw new Error('BALLIN_TEST_CONFIG_PATH must be set when NODE_ENV=test');
+}
 const defaultConfigPath = path.join(__dirname, '.defaultConfig.json');
 const stringify = (obj) => JSON.stringify(obj, null, 2);
 

--- a/config/index.js
+++ b/config/index.js
@@ -3,12 +3,7 @@ const { exec } = require('child_process');
 const path = require('path');
 
 const userConfigPath = path.join(__dirname, '..', 'ballin.config.json');
-const configPath = process.env.NODE_ENV === 'test'
-  ? process.env.BALLIN_TEST_CONFIG_PATH
-  : userConfigPath;
-if (!configPath) {
-  throw new Error('BALLIN_TEST_CONFIG_PATH must be set when NODE_ENV=test');
-}
+const configPath = process.env.BALLIN_TEST_CONFIG_PATH || userConfigPath;
 const defaultConfigPath = path.join(__dirname, '.defaultConfig.json');
 const stringify = (obj) => JSON.stringify(obj, null, 2);
 

--- a/config/updateConfig.js
+++ b/config/updateConfig.js
@@ -1,12 +1,10 @@
 /* eslint-disable no-console */
 
 const fs = require('fs');
-const path = require('path');
-const { stringify } = require('.');
+const { configPath, fetchConfig, stringify } = require('.');
 const defaultConfig = require('./.defaultConfig.json');
-const userConfig = require('../ballin.config.json');
 
-const userConfigPath = path.join(__dirname, '..', 'ballin.config.json');
+const { configObj: userConfig } = fetchConfig();
 const updates = [];
 
 Object.keys(defaultConfig).forEach((key) => {
@@ -27,7 +25,7 @@ Object.keys(defaultConfig).forEach((key) => {
 });
 
 if (updates.length) {
-  fs.writeFileSync(userConfigPath, stringify(userConfig), 'utf-8');
+  fs.writeFileSync(configPath, stringify(userConfig), 'utf-8');
   console.log('New configuration options have been added! Here are the updates:');
   updates.forEach((update) => {
     console.log(update);

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "Useful scripts to save time",
   "scripts": {
-    "test": "eslint . && NODE_ENV=test mocha"
+    "test": "eslint . && NODE_ENV=test mocha --require test/setup.js"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,12 @@
   "version": "1.0.0",
   "description": "Useful scripts to save time",
   "scripts": {
-    "test": "eslint . && NODE_ENV=test mocha --require test/setup.js"
+    "test": "eslint . && mocha"
+  },
+  "mocha": {
+    "require": [
+      "test/setup.js"
+    ]
   },
   "repository": {
     "type": "git",

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -1,5 +1,8 @@
 const { assert } = require('chai');
+const { spawnSync } = require('child_process');
 const fs = require('fs');
+const path = require('path');
+const defaultConfig = require('../config/.defaultConfig.json');
 const {
   getConfig,
   setConfig,
@@ -20,6 +23,27 @@ const setTest = (keys, value) => {
 
 describe('config', () => {
   let savedConfig;
+
+  it('uses the isolated test config fixture', () => {
+    assert.equal(configPath, process.env.BALLIN_TEST_CONFIG_PATH);
+    assert.notEqual(configPath, path.join(__dirname, '..', 'ballin.config.json'));
+  });
+
+  it('does not fall back to the user config in the test environment', () => {
+    const result = spawnSync(process.execPath, ['-e', "require('./config')"], {
+      cwd: path.join(__dirname, '..'),
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        BALLIN_TEST_CONFIG_PATH: '',
+        NODE_ENV: 'test',
+      },
+    });
+
+    assert.notEqual(result.status, 0);
+    assert.include(result.stderr, 'BALLIN_TEST_CONFIG_PATH must be set when NODE_ENV=test');
+  });
+
   before('fetchConfigJSON should return a String', () => {
     assert.isString(fetchConfigJSON());
   });
@@ -38,8 +62,8 @@ describe('config', () => {
     it('("up") should return an Object', () => {
       assert.isObject(getConfig('up'));
     });
-    it('("gu.id") should return a String', () => {
-      assert.isString(getConfig('gu.id'));
+    it('("gu.id") should return null by default', () => {
+      assert.isNull(getConfig('gu.id'));
     });
     it('("up.cleanup") should return true or false', () => {
       assert.include(['true', 'false'], getConfig('up.cleanup'));
@@ -93,8 +117,8 @@ describe('config', () => {
     it('("set") should return a setConfig error', () => {
       assert.equal(configAction('set'), configMessages.setArgsErr);
     });
-    it('("get", "gu.id") should return a Number', () => {
-      assert.isString(configAction('get', 'gu.id'));
+    it('("get", "gu.id") should return null by default', () => {
+      assert.isNull(configAction('get', 'gu.id'));
     });
     it('("wrong") should return an invalid error', () => {
       assert.equal(configAction('wrong'), configMessages.actionErr);
@@ -106,6 +130,21 @@ describe('config', () => {
       setTest('gu.id', '123', configAction);
       assert.include(configAction('reset'), 'Config has been reset...\nFROM:');
       assert.isNull(getConfig('gu.id'));
+    });
+  });
+
+  describe('updateConfig', () => {
+    it('updates the isolated fixture', () => {
+      fs.writeFileSync(configPath, '{}', 'utf8');
+
+      const result = spawnSync(process.execPath, ['-e', "require('./config/updateConfig')"], {
+        cwd: path.join(__dirname, '..'),
+        encoding: 'utf8',
+        env: process.env,
+      });
+
+      assert.equal(result.status, 0);
+      assert.deepEqual(fetchConfig().configObj, defaultConfig);
     });
   });
 });

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -29,8 +29,8 @@ describe('config', () => {
     assert.notEqual(configPath, path.join(__dirname, '..', 'ballin.config.json'));
   });
 
-  it('does not fall back to the user config in the test environment', () => {
-    const result = spawnSync(process.execPath, ['-e', "require('./config')"], {
+  it('does not treat NODE_ENV=test as a fixture run by itself', () => {
+    const result = spawnSync(process.execPath, ['-p', "require('./config').configPath"], {
       cwd: path.join(__dirname, '..'),
       encoding: 'utf8',
       env: {
@@ -40,8 +40,8 @@ describe('config', () => {
       },
     });
 
-    assert.notEqual(result.status, 0);
-    assert.include(result.stderr, 'BALLIN_TEST_CONFIG_PATH must be set when NODE_ENV=test');
+    assert.equal(result.status, 0);
+    assert.equal(result.stdout.trim(), path.join(__dirname, '..', 'ballin.config.json'));
   });
 
   before('fetchConfigJSON should return a String', () => {

--- a/test/setup.js
+++ b/test/setup.js
@@ -1,0 +1,34 @@
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ballin-config-'));
+const configPath = path.join(tempDir, 'ballin.config.json');
+const defaultConfigPath = path.join(__dirname, '..', 'config', '.defaultConfig.json');
+const previousConfigPath = process.env.BALLIN_TEST_CONFIG_PATH;
+
+const cleanup = () => {
+  fs.rmSync(tempDir, { recursive: true, force: true });
+};
+
+try {
+  fs.copyFileSync(defaultConfigPath, configPath);
+} catch (error) {
+  cleanup();
+  throw error;
+}
+
+process.env.BALLIN_TEST_CONFIG_PATH = configPath;
+process.once('exit', cleanup);
+
+exports.mochaHooks = {
+  afterAll() {
+    cleanup();
+    process.removeListener('exit', cleanup);
+    if (previousConfigPath === undefined) {
+      delete process.env.BALLIN_TEST_CONFIG_PATH;
+    } else {
+      process.env.BALLIN_TEST_CONFIG_PATH = previousConfigPath;
+    }
+  },
+};

--- a/test/setup.js
+++ b/test/setup.js
@@ -6,6 +6,7 @@ const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ballin-config-'));
 const configPath = path.join(tempDir, 'ballin.config.json');
 const defaultConfigPath = path.join(__dirname, '..', 'config', '.defaultConfig.json');
 const previousConfigPath = process.env.BALLIN_TEST_CONFIG_PATH;
+const previousNodeEnv = process.env.NODE_ENV;
 
 const cleanup = () => {
   fs.rmSync(tempDir, { recursive: true, force: true });
@@ -19,6 +20,7 @@ try {
 }
 
 process.env.BALLIN_TEST_CONFIG_PATH = configPath;
+process.env.NODE_ENV = 'test';
 process.once('exit', cleanup);
 
 exports.mochaHooks = {
@@ -29,6 +31,11 @@ exports.mochaHooks = {
       delete process.env.BALLIN_TEST_CONFIG_PATH;
     } else {
       process.env.BALLIN_TEST_CONFIG_PATH = previousConfigPath;
+    }
+    if (previousNodeEnv === undefined) {
+      delete process.env.NODE_ENV;
+    } else {
+      process.env.NODE_ENV = previousNodeEnv;
     }
   },
 };


### PR DESCRIPTION
## Summary

- create a temporary `ballin.config.json` fixture before the test suite loads
- configure Mocha in `package.json` so both `npm test` and direct `mocha` runs load the fixture automatically
- route config reads and writes, including `updateConfig`, through the isolated fixture when the test bootstrap supplies `BALLIN_TEST_CONFIG_PATH`
- leave normal config behavior unchanged when unrelated workflows set `NODE_ENV=test`
- restore test environment and config state, and remove the fixture after the suite or on process exit
- remove the obsolete contributor instructions to stash and restore the real config

## Why

The config tests previously depended on an ignored, user-specific `ballin.config.json` in the repository root and mutated that file during the suite. This prevented tests from running in a fresh checkout and risked changing a developer's real configuration.

The fixture starts from the checked-in default config, so tests now exercise fresh-install behavior and are suitable for the planned CI follow-up in #35.

Closes #68.

## Validation

- `npm test` — 25 passing
- direct `mocha` with no preconfigured test environment — 25 passing
- both commands from a temporary fresh-checkout copy with no root `ballin.config.json` — 25 passing
- regression test confirms `NODE_ENV=test` alone retains the normal config path
- intentional failing-test probe confirmed the temporary fixture is still removed
- verified the real config checksum remained unchanged
- `git diff --check`