### PR TITLE
docs: clarify config help output ordering

### DIFF
--- a/config/index.js
+++ b/config/index.js
@@ -77,6 +77,7 @@ const configAction = (request, keys, value, other) => {
   if (request === 'get' || !request) return getConfig(keys, value);
   if (request === 'set') return setConfig(keys, value, other);
   if (process.env.NODE_ENV !== 'test') {
+    // exec() is async, so actionErr is returned before the help output is printed.
     exec('ballin', (error, stdout) => console.log(stdout)); // eslint-disable-line no-console
   }
   return configMessages.actionErr;


### PR DESCRIPTION
## Summary

Add a comment explaining the ordering of help output and error messages in `configAction`.

Because `exec()` is asynchronous, `actionErr` is returned before the `ballin` help output is printed. This can be surprising when reading the code since the `exec()` call appears before the `return` statement.

No functional changes are included in this PR.

## Motivation

The current behavior is intentional, but the execution order is not immediately obvious when reading the implementation. Documenting the asynchronous behavior helps future contributors understand why the output order differs from the statement order.