### PR TITLE
[codex] Fix invalid nested config paths

### DIFF
--- a/config/index.js
+++ b/config/index.js
@@ -31,7 +31,7 @@ const getNestedValue = (configObj, keys) => {
 
   for (let index = 0; index < keysArr.length; index += 1) {
     if (value === null || typeof value !== 'object') {
-      return { missingKeys: keysArr.slice(0, index).join('.') };
+      return { missingKeys: keysArr.slice(0, index + 1).join('.') };
     }
     if (!hasOwn(value, keysArr[index])) {
       return { missingKeys: keysArr.slice(0, index + 1).join('.') };
@@ -77,7 +77,7 @@ const setConfig = (keys, val, other) => {
     return configMessages.setDneErr(missingKeys);
   }
   if (nestedObj === null || typeof nestedObj !== 'object') {
-    return configMessages.setDneErr(topLevelKeys.join('.'));
+    return configMessages.setDneErr(keys);
   }
   // { cleanup: 'false', ballin: 'true' }
   if (!hasOwn(nestedObj, keyToSet)) {

--- a/config/index.js
+++ b/config/index.js
@@ -6,6 +6,7 @@ const userConfigPath = path.join(__dirname, '..', 'ballin.config.json');
 const configPath = process.env.BALLIN_TEST_CONFIG_PATH || userConfigPath;
 const defaultConfigPath = path.join(__dirname, '.defaultConfig.json');
 const stringify = (obj) => JSON.stringify(obj, null, 2);
+const hasOwn = (obj, key) => Object.prototype.hasOwnProperty.call(obj, key);
 
 const configMessages = {
   actionErr: 'INVALID: ballin_config accepts "", "get", "set", or "reset"',
@@ -24,14 +25,29 @@ const fetchConfig = () => {
   return { configObj, configJSON };
 };
 
-// TODO: guard against deep missing paths in getConfig/setConfig
-//       (e.g., "gu.foo.bar" → return DNE instead of throw)
+const getNestedValue = (configObj, keys) => {
+  const keysArr = keys.split('.');
+  let value = configObj;
+
+  for (let index = 0; index < keysArr.length; index += 1) {
+    if (value === null || typeof value !== 'object') {
+      return { missingKeys: keysArr.slice(0, index).join('.') };
+    }
+    if (!hasOwn(value, keysArr[index])) {
+      return { missingKeys: keysArr.slice(0, index + 1).join('.') };
+    }
+    value = value[keysArr[index]];
+  }
+
+  return { value };
+};
+
 const getConfig = (keys, val) => {
   if (val) return configMessages.getArgsErr;
   const { configObj, configJSON } = fetchConfig();
   if (keys !== undefined) {
-    const res = keys.split('.').reduce((result, key) => result[key], configObj);
-    return res !== undefined ? res : configMessages.getKeysDneErr(keys);
+    const { value, missingKeys } = getNestedValue(configObj, keys);
+    return missingKeys === undefined ? value : configMessages.getKeysDneErr(missingKeys);
   }
   return configJSON;
 };
@@ -54,17 +70,25 @@ const setConfig = (keys, val, other) => {
   // 'true'
   const topLevelKeys = keysArr;
   // [ 'up' ]
-  const nestedObj = topLevelKeys.reduce((res, key) => res[key], configObj);
+  const { value: nestedObj, missingKeys } = topLevelKeys.length
+    ? getNestedValue(configObj, topLevelKeys.join('.'))
+    : { value: configObj };
+  if (missingKeys !== undefined) {
+    return configMessages.setDneErr(missingKeys);
+  }
+  if (nestedObj === null || typeof nestedObj !== 'object') {
+    return configMessages.setDneErr(topLevelKeys.join('.'));
+  }
   // { cleanup: 'false', ballin: 'true' }
+  if (!hasOwn(nestedObj, keyToSet)) {
+    return configMessages.setDneErr(keys);
+  }
   const prevVal = nestedObj[keyToSet];
   // 'false'
 
   // make sure prevVal isn't an object (gu.id defaults to null)
   if (typeof prevVal === 'object' && prevVal !== null) {
     return configMessages.setObjErr(keys, prevVal);
-  }
-  if (prevVal === undefined) {
-    return configMessages.setDneErr(keys);
   }
   nestedObj[keyToSet] = val;
   fs.writeFileSync(configPath, stringify(configObj), 'utf8');

--- a/config/index.js
+++ b/config/index.js
@@ -6,6 +6,7 @@ const userConfigPath = path.join(__dirname, '..', 'ballin.config.json');
 const configPath = process.env.BALLIN_TEST_CONFIG_PATH || userConfigPath;
 const defaultConfigPath = path.join(__dirname, '.defaultConfig.json');
 const stringify = (obj) => JSON.stringify(obj, null, 2);
+// Only JSON-owned keys count; inherited properties are not config entries.
 const hasOwn = (obj, key) => Object.prototype.hasOwnProperty.call(obj, key);
 
 const configMessages = {
@@ -25,18 +26,18 @@ const fetchConfig = () => {
   return { configObj, configJSON };
 };
 
+// Return the value, or the first path prefix that cannot be resolved.
 const getNestedValue = (configObj, keys) => {
   const keysArr = keys.split('.');
   let value = configObj;
 
   for (let index = 0; index < keysArr.length; index += 1) {
-    if (value === null || typeof value !== 'object') {
-      return { missingKeys: keysArr.slice(0, index + 1).join('.') };
+    const key = keysArr[index];
+    const resolvedKeys = keysArr.slice(0, index + 1).join('.');
+    if (value === null || typeof value !== 'object' || !hasOwn(value, key)) {
+      return { missingKeys: resolvedKeys };
     }
-    if (!hasOwn(value, keysArr[index])) {
-      return { missingKeys: keysArr.slice(0, index + 1).join('.') };
-    }
-    value = value[keysArr[index]];
+    value = value[key];
   }
 
   return { value };
@@ -65,13 +66,11 @@ const setConfig = (keys, val, other) => {
     return configMessages.setArgsErr;
   }
   const keysArr = keys.split('.');
-  // ex: 'up.cleanup' -> [ 'up', 'cleanup' ]
   const keyToSet = keysArr.pop();
-  // 'true'
-  const topLevelKeys = keysArr;
-  // [ 'up' ]
-  const { value: nestedObj, missingKeys } = topLevelKeys.length
-    ? getNestedValue(configObj, topLevelKeys.join('.'))
+  const parentKeys = keysArr;
+  // Resolve the parent first: setConfig updates existing leaves and never creates paths.
+  const { value: nestedObj, missingKeys } = parentKeys.length
+    ? getNestedValue(configObj, parentKeys.join('.'))
     : { value: configObj };
   if (missingKeys !== undefined) {
     return configMessages.setDneErr(missingKeys);
@@ -79,14 +78,12 @@ const setConfig = (keys, val, other) => {
   if (nestedObj === null || typeof nestedObj !== 'object') {
     return configMessages.setDneErr(keys);
   }
-  // { cleanup: 'false', ballin: 'true' }
   if (!hasOwn(nestedObj, keyToSet)) {
     return configMessages.setDneErr(keys);
   }
   const prevVal = nestedObj[keyToSet];
-  // 'false'
 
-  // make sure prevVal isn't an object (gu.id defaults to null)
+  // Objects are containers, but null is a valid leaf value (for example, gu.id).
   if (typeof prevVal === 'object' && prevVal !== null) {
     return configMessages.setObjErr(keys, prevVal);
   }

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -79,8 +79,9 @@ describe('config', () => {
       assert.equal(getConfig('gu.missing.nested'), configMessages.getKeysDneErr('gu.missing'));
     });
     it('should reject traversal through primitive and null values', () => {
-      assert.equal(getConfig('up.cleanup.nested'), configMessages.getKeysDneErr('up.cleanup'));
-      assert.equal(getConfig('gu.id.nested'), configMessages.getKeysDneErr('gu.id'));
+      assert.equal(getConfig('up.cleanup.nested'), configMessages.getKeysDneErr('up.cleanup.nested'));
+      assert.equal(getConfig('gu.id.nested'), configMessages.getKeysDneErr('gu.id.nested'));
+      assert.equal(getConfig('up.cleanup.nested.deeper'), configMessages.getKeysDneErr('up.cleanup.nested'));
     });
     it('should not treat inherited properties as config keys', () => {
       assert.equal(getConfig('constructor'), configMessages.getKeysDneErr('constructor'));
@@ -126,8 +127,9 @@ describe('config', () => {
     it('should reject primitive and null traversal without changing config', () => {
       const configBeforeSet = fetchConfigJSON();
 
-      assert.equal(setConfig('up.cleanup.nested', 'test'), configMessages.setDneErr('up.cleanup'));
-      assert.equal(setConfig('gu.id.nested', 'test'), configMessages.setDneErr('gu.id'));
+      assert.equal(setConfig('up.cleanup.nested', 'test'), configMessages.setDneErr('up.cleanup.nested'));
+      assert.equal(setConfig('gu.id.nested', 'test'), configMessages.setDneErr('gu.id.nested'));
+      assert.equal(setConfig('up.cleanup.nested.deeper', 'test'), configMessages.setDneErr('up.cleanup.nested'));
       assert.equal(fetchConfigJSON(), configBeforeSet);
     });
     it('should reject inherited paths without changing config', () => {

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -74,6 +74,17 @@ describe('config', () => {
     it('should return an error if given keys that don\'t exist', () => {
       assert.equal(getConfig('wrong'), 'INVALID: "wrong" doesn\'t exist in config');
     });
+    it('should report the first missing portion of a nested path', () => {
+      assert.equal(getConfig('test.nested'), configMessages.getKeysDneErr('test'));
+      assert.equal(getConfig('gu.missing.nested'), configMessages.getKeysDneErr('gu.missing'));
+    });
+    it('should reject traversal through primitive and null values', () => {
+      assert.equal(getConfig('up.cleanup.nested'), configMessages.getKeysDneErr('up.cleanup'));
+      assert.equal(getConfig('gu.id.nested'), configMessages.getKeysDneErr('gu.id'));
+    });
+    it('should not treat inherited properties as config keys', () => {
+      assert.equal(getConfig('constructor'), configMessages.getKeysDneErr('constructor'));
+    });
   });
 
   describe('setConfig', () => {
@@ -104,6 +115,26 @@ describe('config', () => {
       const keys = 'up';
       const val = 'true';
       assert.include(setConfig(keys, val), 'INVALID: "up" is not a bottom-level value, it returns');
+    });
+    it('should report the first missing portion without changing config', () => {
+      const configBeforeSet = fetchConfigJSON();
+
+      assert.equal(setConfig('test.nested', 'test'), configMessages.setDneErr('test'));
+      assert.equal(setConfig('gu.missing.nested', 'test'), configMessages.setDneErr('gu.missing'));
+      assert.equal(fetchConfigJSON(), configBeforeSet);
+    });
+    it('should reject primitive and null traversal without changing config', () => {
+      const configBeforeSet = fetchConfigJSON();
+
+      assert.equal(setConfig('up.cleanup.nested', 'test'), configMessages.setDneErr('up.cleanup'));
+      assert.equal(setConfig('gu.id.nested', 'test'), configMessages.setDneErr('gu.id'));
+      assert.equal(fetchConfigJSON(), configBeforeSet);
+    });
+    it('should reject inherited paths without changing config', () => {
+      const configBeforeSet = fetchConfigJSON();
+
+      assert.equal(setConfig('__proto__.nested', 'test'), configMessages.setDneErr('__proto__'));
+      assert.equal(fetchConfigJSON(), configBeforeSet);
     });
   });
 

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -15,6 +15,17 @@ const {
 const fetchConfigJSON = () => fetchConfig().configJSON;
 
 const currentConfigJSON = fetchConfigJSON();
+const invalidPathCases = [
+  ['missing', 'missing'],
+  ['test.nested', 'test'],
+  ['gu.missing.nested', 'gu.missing'],
+  ['up.cleanup.nested', 'up.cleanup.nested'],
+  ['up.cleanup.nested.deeper', 'up.cleanup.nested'],
+  ['gu.id.nested', 'gu.id.nested'],
+  ['gu.id.nested.deeper', 'gu.id.nested'],
+  ['constructor', 'constructor'],
+  ['__proto__.nested', '__proto__'],
+];
 
 const setTest = (keys, value) => {
   setConfig(keys, value);
@@ -71,20 +82,25 @@ describe('config', () => {
     it('() should return a String', () => {
       assert.isString(getConfig());
     });
-    it('should return an error if given keys that don\'t exist', () => {
-      assert.equal(getConfig('wrong'), 'INVALID: "wrong" doesn\'t exist in config');
+    invalidPathCases.forEach(([keys, missingKeys]) => {
+      it(`should report "${missingKeys}" for invalid path "${keys}"`, () => {
+        assert.equal(getConfig(keys), configMessages.getKeysDneErr(missingKeys));
+      });
     });
-    it('should report the first missing portion of a nested path', () => {
-      assert.equal(getConfig('test.nested'), configMessages.getKeysDneErr('test'));
-      assert.equal(getConfig('gu.missing.nested'), configMessages.getKeysDneErr('gu.missing'));
-    });
-    it('should reject traversal through primitive and null values', () => {
-      assert.equal(getConfig('up.cleanup.nested'), configMessages.getKeysDneErr('up.cleanup.nested'));
-      assert.equal(getConfig('gu.id.nested'), configMessages.getKeysDneErr('gu.id.nested'));
-      assert.equal(getConfig('up.cleanup.nested.deeper'), configMessages.getKeysDneErr('up.cleanup.nested'));
-    });
-    it('should not treat inherited properties as config keys', () => {
-      assert.equal(getConfig('constructor'), configMessages.getKeysDneErr('constructor'));
+    it('should reject traversal through every JSON primitive type', () => {
+      const configObj = JSON.parse(fetchConfigJSON());
+      configObj.testValues = {
+        boolean: false,
+        number: 0,
+        string: 'value',
+        null: null,
+      };
+      fs.writeFileSync(configPath, JSON.stringify(configObj), 'utf8');
+
+      ['boolean', 'number', 'string', 'null'].forEach((key) => {
+        const keys = `testValues.${key}.nested`;
+        assert.equal(getConfig(keys), configMessages.getKeysDneErr(keys));
+      });
     });
   });
 
@@ -117,27 +133,53 @@ describe('config', () => {
       const val = 'true';
       assert.include(setConfig(keys, val), 'INVALID: "up" is not a bottom-level value, it returns');
     });
-    it('should report the first missing portion without changing config', () => {
+    invalidPathCases.forEach(([keys, missingKeys]) => {
+      it(`should reject invalid path "${keys}" without changing config`, () => {
+        const configBeforeSet = fetchConfigJSON();
+
+        assert.equal(setConfig(keys, 'test'), configMessages.setDneErr(missingKeys));
+        assert.equal(fetchConfigJSON(), configBeforeSet);
+      });
+    });
+    it('should reject every JSON primitive type without changing config', () => {
+      const configObj = JSON.parse(fetchConfigJSON());
+      configObj.testValues = {
+        boolean: false,
+        number: 0,
+        string: 'value',
+        null: null,
+      };
+      fs.writeFileSync(configPath, JSON.stringify(configObj), 'utf8');
       const configBeforeSet = fetchConfigJSON();
 
-      assert.equal(setConfig('test.nested', 'test'), configMessages.setDneErr('test'));
-      assert.equal(setConfig('gu.missing.nested', 'test'), configMessages.setDneErr('gu.missing'));
-      assert.equal(fetchConfigJSON(), configBeforeSet);
+      ['boolean', 'number', 'string', 'null'].forEach((key) => {
+        const keys = `testValues.${key}.nested`;
+        assert.equal(setConfig(keys, 'test'), configMessages.setDneErr(keys));
+        assert.equal(fetchConfigJSON(), configBeforeSet);
+      });
     });
-    it('should reject primitive and null traversal without changing config', () => {
-      const configBeforeSet = fetchConfigJSON();
+  });
 
-      assert.equal(setConfig('up.cleanup.nested', 'test'), configMessages.setDneErr('up.cleanup.nested'));
-      assert.equal(setConfig('gu.id.nested', 'test'), configMessages.setDneErr('gu.id.nested'));
-      assert.equal(setConfig('up.cleanup.nested.deeper', 'test'), configMessages.setDneErr('up.cleanup.nested'));
-      assert.equal(fetchConfigJSON(), configBeforeSet);
+  it('CLI invalid get/set commands exit cleanly without changing config', () => {
+    const configBeforeSet = fetchConfigJSON();
+    const cliPath = path.join(__dirname, '..', 'bin', 'ballin_config');
+    const getResult = spawnSync(process.execPath, [cliPath, 'get', 'up.nvm.nested'], {
+      encoding: 'utf8',
+      env: process.env,
     });
-    it('should reject inherited paths without changing config', () => {
-      const configBeforeSet = fetchConfigJSON();
+    const setResult = spawnSync(process.execPath, [cliPath, 'set', 'up.nvm.nested', 'test'], {
+      encoding: 'utf8',
+      env: process.env,
+    });
+    const expectedOutput = `${configMessages.getKeysDneErr('up.nvm.nested')}\n`;
 
-      assert.equal(setConfig('__proto__.nested', 'test'), configMessages.setDneErr('__proto__'));
-      assert.equal(fetchConfigJSON(), configBeforeSet);
-    });
+    assert.equal(getResult.status, 0);
+    assert.equal(getResult.stdout, expectedOutput);
+    assert.equal(getResult.stderr, '');
+    assert.equal(setResult.status, 0);
+    assert.equal(setResult.stdout, expectedOutput);
+    assert.equal(setResult.stderr, '');
+    assert.equal(fetchConfigJSON(), configBeforeSet);
   });
 
   describe('configAction', () => {


### PR DESCRIPTION
## Summary

- safely traverse dotted config paths in both `getConfig` and `setConfig`
- report the first missing or non-object path prefix with the existing `INVALID` response
- prevent invalid sets and inherited-property paths from modifying configuration
- add permutation and CLI regression coverage for missing, primitive, `null`, and inherited path segments

## Root cause

Both helpers dereferenced every path segment directly. A missing intermediate segment therefore caused the next property access to throw instead of returning the existing validation message.

## Impact

Invalid nested `get` and `set` requests now terminate normally without JavaScript stack traces. Invalid `set` requests leave the config file byte-for-byte unchanged, and valid behavior remains intact.

## Validation

- `npm test` — 45 passing
- `git diff --check`
- CLI regression verifies exit code 0, empty stderr, correct output, and unchanged config for invalid nested `get` and `set`

Closes #20