### PR TITLE
[codex] Add gu cache and status regression coverage

### DIFF
--- a/bin/gu
+++ b/bin/gu
@@ -155,6 +155,8 @@ else
 	(
     cd "$HOME"
 
+    bash_completion_dir="${BALLIN_GU_BASH_COMPLETION_DIR:-/usr/local/etc/bash_completion.d}"
+
     ### SHELL
     if [ -f .bash_profile ]; then
       u 'bash_profile.sh' 'cat .bash_profile'
@@ -172,8 +174,11 @@ else
       u 'zshrc.sh' 'cat .zshrc'
     fi
     # BASH COMPLETIONS
-    if [ -d /usr/local/etc/bash_completion.d ]; then
-      u 'bash_completions' 'ls /usr/local/etc/bash_completion.d'
+    if [ -d "$bash_completion_dir" ]; then
+      bash_completions_list() {
+        ls "$bash_completion_dir"
+      }
+      u 'bash_completions' 'bash_completions_list'
     fi
 
     ### BREW

--- a/test/gu.test.js
+++ b/test/gu.test.js
@@ -5,55 +5,44 @@ const os = require('os');
 const path = require('path');
 
 const guPath = path.join(__dirname, '..', 'bin', 'gu');
+const snapshotFileName = 'zshrc.sh';
+// Expose only the basic commands gu needs; package managers remain unavailable.
+const requiredCommands = [
+  'bash',
+  'cat',
+  'cmp',
+  'cp',
+  'mkdir',
+  'mktemp',
+  'rm',
+  'tail',
+];
 
 describe('gu', () => {
-  let homeDir;
-  let binDir;
-  let cacheDir;
-  let gistDir;
-  let readLogPath;
-  let tempWorkDir;
-  let uploadLogPath;
+  let testHomeDir;
+  let testBinDir;
+  let guCacheDir;
+  let fakeGistDir;
+  let gistReadLogPath;
+  let scratchDir;
+  let gistUploadLogPath;
 
-  const fileName = 'zshrc.sh';
-
-  const installCommand = (command) => {
+  const linkRequiredCommand = (command) => {
     const commandPath = process.env.PATH
       .split(path.delimiter)
       .map((directory) => path.join(directory, command))
       .find((candidate) => fs.existsSync(candidate));
 
     assert.exists(commandPath, `${command} is required to run the gu test harness`);
-    fs.symlinkSync(commandPath, path.join(binDir, command));
+    fs.symlinkSync(commandPath, path.join(testBinDir, command));
   };
 
-  beforeEach(() => {
-    homeDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ballin-gu-'));
-    binDir = path.join(homeDir, 'bin');
-    cacheDir = path.join(homeDir, '.ballin-scripts', '.gu-cache');
-    gistDir = path.join(homeDir, 'gist');
-    readLogPath = path.join(homeDir, 'gist-reads.log');
-    tempWorkDir = path.join(homeDir, 'tmp');
-    uploadLogPath = path.join(homeDir, 'gist-uploads.log');
+  const writeTestExecutable = (name, contents) => {
+    fs.writeFileSync(path.join(testBinDir, name), contents, { mode: 0o755 });
+  };
 
-    fs.mkdirSync(binDir);
-    fs.mkdirSync(path.join(homeDir, '.ballin-scripts'));
-    fs.mkdirSync(path.join(homeDir, 'Library', 'Application Support'), { recursive: true });
-    fs.mkdirSync(gistDir);
-    fs.mkdirSync(tempWorkDir);
-    [
-      'bash',
-      'cat',
-      'cmp',
-      'cp',
-      'mkdir',
-      'mktemp',
-      'rm',
-      'tail',
-    ].forEach(installCommand);
-    fs.writeFileSync(
-      path.join(binDir, 'ballin_config'),
-      `#!/usr/bin/env bash
+  const installFakeBallinConfigCommand = () => {
+    writeTestExecutable('ballin_config', `#!/usr/bin/env bash
 if [ "$1" != 'get' ]; then
   printf '%s\\n' 'Unexpected ballin_config action' >&2
   exit 2
@@ -65,12 +54,12 @@ else
   printf '%s\\n' 'Unexpected ballin_config call' >&2
   exit 2
 fi
-`,
-      { mode: 0o755 },
-    );
-    fs.writeFileSync(
-      path.join(binDir, 'gist'),
-      `#!/usr/bin/env bash
+`);
+  };
+
+  const installFakeGistCommand = () => {
+    // Store the fake remote Gist as ordinary files inside the temporary test home.
+    writeTestExecutable('gist', `#!/usr/bin/env bash
 if [ "$2" != 'test-gist-id' ]; then
   printf '%s\\n' 'Unexpected Gist ID' >&2
   exit 2
@@ -82,10 +71,10 @@ if [ "$1" = '-r' ]; then
     printf '%s\\n' 'Unexpected gist read arguments' >&2
     exit 2
   fi
-  printf '%s\\n' "$3" >> "$GIST_TEST_READ_LOG"
-  gist_file="$GIST_TEST_DIR/$3"
-  if [ -f "$gist_file" ]; then
-    cat "$gist_file"
+  printf '%s\\n' "$3" >> "$FAKE_GIST_READ_LOG"
+  fake_gist_file="$FAKE_GIST_STORAGE_DIR/$3"
+  if [ -f "$fake_gist_file" ]; then
+    cat "$fake_gist_file"
   else
     exit 1
   fi
@@ -96,70 +85,85 @@ elif [ "$1" = '-u' ]; then
   fi
   cache_file="$3"
   file_name="\${cache_file##*/}"
-  cp "$cache_file" "$GIST_TEST_DIR/$file_name"
-  printf '%s\\n' "$file_name" >> "$GIST_TEST_UPLOAD_LOG"
+  cp "$cache_file" "$FAKE_GIST_STORAGE_DIR/$file_name"
+  printf '%s\\n' "$file_name" >> "$FAKE_GIST_UPLOAD_LOG"
 else
   printf '%s\\n' 'Unexpected gist call' >&2
   exit 2
 fi
-`,
-      { mode: 0o755 },
-    );
+`);
+  };
+
+  beforeEach(() => {
+    testHomeDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ballin-gu-'));
+    testBinDir = path.join(testHomeDir, 'bin');
+    guCacheDir = path.join(testHomeDir, '.ballin-scripts', '.gu-cache');
+    fakeGistDir = path.join(testHomeDir, 'fake-gist');
+    gistReadLogPath = path.join(testHomeDir, 'fake-gist-reads.log');
+    scratchDir = path.join(testHomeDir, 'tmp');
+    gistUploadLogPath = path.join(testHomeDir, 'fake-gist-uploads.log');
+
+    [
+      testBinDir,
+      path.join(testHomeDir, '.ballin-scripts'),
+      path.join(testHomeDir, 'Library', 'Application Support'),
+      fakeGistDir,
+      scratchDir,
+    ].forEach((directory) => fs.mkdirSync(directory, { recursive: true }));
+    requiredCommands.forEach(linkRequiredCommand);
+    installFakeBallinConfigCommand();
+    installFakeGistCommand();
   });
 
   afterEach(() => {
-    fs.rmSync(homeDir, { recursive: true, force: true });
+    fs.rmSync(testHomeDir, { recursive: true, force: true });
   });
 
+  // Pass a complete child environment so real tools and credentials are not inherited.
   const runGu = () => spawnSync(guPath, [], {
     encoding: 'utf8',
     env: {
-      HOME: homeDir,
-      PATH: binDir,
-      TMPDIR: tempWorkDir,
-      BALLIN_GU_BASH_COMPLETION_DIR: path.join(homeDir, 'bash-completion.d'),
-      GIST_TEST_DIR: gistDir,
-      GIST_TEST_READ_LOG: readLogPath,
-      GIST_TEST_UPLOAD_LOG: uploadLogPath,
+      HOME: testHomeDir,
+      PATH: testBinDir,
+      TMPDIR: scratchDir,
+      BALLIN_GU_BASH_COMPLETION_DIR: path.join(testHomeDir, 'bash-completion.d'),
+      FAKE_GIST_STORAGE_DIR: fakeGistDir,
+      FAKE_GIST_READ_LOG: gistReadLogPath,
+      FAKE_GIST_UPLOAD_LOG: gistUploadLogPath,
     },
   });
 
-  const snapshotPath = () => path.join(homeDir, '.zshrc');
-  const cachePath = () => path.join(cacheDir, fileName);
-  const gistPath = () => path.join(gistDir, fileName);
+  const snapshotPath = () => path.join(testHomeDir, '.zshrc');
+  const cachedSnapshotPath = () => path.join(guCacheDir, snapshotFileName);
+  const fakeGistFilePath = () => path.join(fakeGistDir, snapshotFileName);
   const writeSnapshot = (content) => fs.writeFileSync(snapshotPath(), content);
-  const seedCache = (content) => {
-    fs.mkdirSync(cacheDir, { recursive: true });
-    fs.writeFileSync(cachePath(), content);
+  const seedGuCache = (content) => {
+    fs.mkdirSync(guCacheDir, { recursive: true });
+    fs.writeFileSync(cachedSnapshotPath(), content);
   };
-  const seedGist = (content) => fs.writeFileSync(gistPath(), content);
-  const assertSucceeded = (result) => {
+  const seedFakeGist = (content) => fs.writeFileSync(fakeGistFilePath(), content);
+  const assertGuSucceeded = (result) => {
     assert.equal(result.status, 0);
     assert.equal(result.stderr, '');
-    assert.deepEqual(fs.readdirSync(tempWorkDir), []);
+    assert.deepEqual(fs.readdirSync(scratchDir), []);
   };
-  const reads = () => (
-    fs.existsSync(readLogPath)
-      ? fs.readFileSync(readLogPath, 'utf8').trim().split('\n')
-      : []
+  const readLogLines = (logPath) => (
+    fs.existsSync(logPath) ? fs.readFileSync(logPath, 'utf8').trim().split('\n') : []
   );
-  const uploads = () => (
-    fs.existsSync(uploadLogPath)
-      ? fs.readFileSync(uploadLogPath, 'utf8').trim().split('\n')
-      : []
-  );
+  const gistReads = () => readLogLines(gistReadLogPath);
+  const gistUploads = () => readLogLines(gistUploadLogPath);
 
   it('creates and uploads the first snapshot when cache and Gist are missing', () => {
     writeSnapshot('alias hello="world"\n');
 
     const result = runGu();
 
-    assertSucceeded(result);
+    assertGuSucceeded(result);
     assert.equal(result.stdout, '💾 zshrc\n');
-    assert.equal(fs.readFileSync(cachePath(), 'utf8'), 'alias hello="world"\n');
-    assert.equal(fs.readFileSync(gistPath(), 'utf8'), 'alias hello="world"\n');
-    assert.deepEqual(reads(), [fileName]);
-    assert.deepEqual(uploads(), [fileName]);
+    assert.equal(fs.readFileSync(cachedSnapshotPath(), 'utf8'), 'alias hello="world"\n');
+    assert.equal(fs.readFileSync(fakeGistFilePath(), 'utf8'), 'alias hello="world"\n');
+    assert.deepEqual(gistReads(), [snapshotFileName]);
+    assert.deepEqual(gistUploads(), [snapshotFileName]);
   });
 
   it('uses the current new-file icon for a first empty snapshot', () => {
@@ -167,96 +171,96 @@ fi
 
     const result = runGu();
 
-    assertSucceeded(result);
+    assertGuSucceeded(result);
     assert.equal(result.stdout, '💾 zshrc\n');
-    assert.equal(fs.readFileSync(cachePath(), 'utf8'), 'empty\n');
-    assert.equal(fs.readFileSync(gistPath(), 'utf8'), 'empty\n');
-    assert.deepEqual(reads(), [fileName]);
-    assert.deepEqual(uploads(), [fileName]);
+    assert.equal(fs.readFileSync(cachedSnapshotPath(), 'utf8'), 'empty\n');
+    assert.equal(fs.readFileSync(fakeGistFilePath(), 'utf8'), 'empty\n');
+    assert.deepEqual(gistReads(), [snapshotFileName]);
+    assert.deepEqual(gistUploads(), [snapshotFileName]);
   });
 
   it('hydrates a missing cache from unchanged Gist content', () => {
     writeSnapshot('export EDITOR=vim\n');
-    seedGist('export EDITOR=vim\n');
+    seedFakeGist('export EDITOR=vim\n');
 
     const result = runGu();
 
-    assertSucceeded(result);
+    assertGuSucceeded(result);
     assert.equal(result.stdout, '✔ zshrc\n');
-    assert.equal(fs.readFileSync(cachePath(), 'utf8'), 'export EDITOR=vim\n');
-    assert.deepEqual(reads(), [fileName]);
-    assert.deepEqual(uploads(), []);
+    assert.equal(fs.readFileSync(cachedSnapshotPath(), 'utf8'), 'export EDITOR=vim\n');
+    assert.deepEqual(gistReads(), [snapshotFileName]);
+    assert.deepEqual(gistUploads(), []);
   });
 
   it('compares against hydrated Gist content before uploading a change', () => {
     writeSnapshot('new value\n');
-    seedGist('old value\n');
+    seedFakeGist('old value\n');
 
     const result = runGu();
 
-    assertSucceeded(result);
+    assertGuSucceeded(result);
     assert.equal(result.stdout, '✚ zshrc\n');
-    assert.equal(fs.readFileSync(cachePath(), 'utf8'), 'new value\n');
-    assert.equal(fs.readFileSync(gistPath(), 'utf8'), 'new value\n');
-    assert.deepEqual(reads(), [fileName]);
-    assert.deepEqual(uploads(), [fileName]);
+    assert.equal(fs.readFileSync(cachedSnapshotPath(), 'utf8'), 'new value\n');
+    assert.equal(fs.readFileSync(fakeGistFilePath(), 'utf8'), 'new value\n');
+    assert.deepEqual(gistReads(), [snapshotFileName]);
+    assert.deepEqual(gistUploads(), [snapshotFileName]);
   });
 
   it('reports unchanged non-empty output without uploading it', () => {
     writeSnapshot('set -o vi\n');
-    seedCache('set -o vi\n');
+    seedGuCache('set -o vi\n');
 
     const result = runGu();
 
-    assertSucceeded(result);
+    assertGuSucceeded(result);
     assert.equal(result.stdout, '✔ zshrc\n');
-    assert.deepEqual(uploads(), []);
+    assert.deepEqual(gistUploads(), []);
   });
 
   it('reports and uploads changed non-empty output', () => {
     writeSnapshot('export COLOR=blue\n');
-    seedCache('export COLOR=red\n');
+    seedGuCache('export COLOR=red\n');
 
     const result = runGu();
 
-    assertSucceeded(result);
+    assertGuSucceeded(result);
     assert.equal(result.stdout, '✚ zshrc\n');
-    assert.equal(fs.readFileSync(cachePath(), 'utf8'), 'export COLOR=blue\n');
-    assert.deepEqual(uploads(), [fileName]);
+    assert.equal(fs.readFileSync(cachedSnapshotPath(), 'utf8'), 'export COLOR=blue\n');
+    assert.deepEqual(gistUploads(), [snapshotFileName]);
   });
 
   it('reports and uploads non-empty output becoming empty', () => {
     writeSnapshot('');
-    seedCache('old content\n');
+    seedGuCache('old content\n');
 
     const result = runGu();
 
-    assertSucceeded(result);
+    assertGuSucceeded(result);
     assert.equal(result.stdout, '✖︎ zshrc\n');
-    assert.equal(fs.readFileSync(cachePath(), 'utf8'), 'empty\n');
-    assert.deepEqual(uploads(), [fileName]);
+    assert.equal(fs.readFileSync(cachedSnapshotPath(), 'utf8'), 'empty\n');
+    assert.deepEqual(gistUploads(), [snapshotFileName]);
   });
 
   it('hides unchanged empty output and does not upload it', () => {
     writeSnapshot('');
-    seedCache('empty\n');
+    seedGuCache('empty\n');
 
     const result = runGu();
 
-    assertSucceeded(result);
+    assertGuSucceeded(result);
     assert.equal(result.stdout, '');
-    assert.deepEqual(uploads(), []);
+    assert.deepEqual(gistUploads(), []);
   });
 
   it('preserves the current changed icon when empty becomes non-empty', () => {
     writeSnapshot('restored\n');
-    seedCache('empty\n');
+    seedGuCache('empty\n');
 
     const result = runGu();
 
-    assertSucceeded(result);
+    assertGuSucceeded(result);
     assert.equal(result.stdout, '✚ zshrc\n');
-    assert.deepEqual(uploads(), [fileName]);
+    assert.deepEqual(gistUploads(), [snapshotFileName]);
   });
 
   it('preserves multiple trailing blank lines', () => {
@@ -264,9 +268,9 @@ fi
 
     const result = runGu();
 
-    assertSucceeded(result);
-    assert.equal(fs.readFileSync(cachePath(), 'utf8'), 'line\n\n\n');
-    assert.equal(fs.readFileSync(gistPath(), 'utf8'), 'line\n\n\n');
+    assertGuSucceeded(result);
+    assert.equal(fs.readFileSync(cachedSnapshotPath(), 'utf8'), 'line\n\n\n');
+    assert.equal(fs.readFileSync(fakeGistFilePath(), 'utf8'), 'line\n\n\n');
   });
 
   it('normalizes output missing its final newline', () => {
@@ -274,9 +278,9 @@ fi
 
     const result = runGu();
 
-    assertSucceeded(result);
-    assert.equal(fs.readFileSync(cachePath(), 'utf8'), 'line\n');
-    assert.equal(fs.readFileSync(gistPath(), 'utf8'), 'line\n');
+    assertGuSucceeded(result);
+    assert.equal(fs.readFileSync(cachedSnapshotPath(), 'utf8'), 'line\n');
+    assert.equal(fs.readFileSync(fakeGistFilePath(), 'utf8'), 'line\n');
   });
 
   it('uploads a normalized snapshot only once when a later run is unchanged', () => {
@@ -285,9 +289,9 @@ fi
     const firstResult = runGu();
     const secondResult = runGu();
 
-    assertSucceeded(firstResult);
-    assertSucceeded(secondResult);
+    assertGuSucceeded(firstResult);
+    assertGuSucceeded(secondResult);
     assert.equal(secondResult.stdout, '✔ zshrc\n');
-    assert.deepEqual(uploads(), [fileName]);
+    assert.deepEqual(gistUploads(), [snapshotFileName]);
   });
 });

--- a/test/gu.test.js
+++ b/test/gu.test.js
@@ -1,0 +1,288 @@
+const { assert } = require('chai');
+const { spawnSync } = require('child_process');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const guPath = path.join(__dirname, '..', 'bin', 'gu');
+
+describe('gu', () => {
+  let homeDir;
+  let binDir;
+  let cacheDir;
+  let gistDir;
+  let readLogPath;
+  let uploadLogPath;
+
+  const fileName = 'zshrc.sh';
+
+  const installCommand = (command) => {
+    const commandPath = process.env.PATH
+      .split(path.delimiter)
+      .map((directory) => path.join(directory, command))
+      .find((candidate) => fs.existsSync(candidate));
+
+    assert.exists(commandPath, `${command} is required to run the gu test harness`);
+    fs.symlinkSync(commandPath, path.join(binDir, command));
+  };
+
+  beforeEach(() => {
+    homeDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ballin-gu-'));
+    binDir = path.join(homeDir, 'bin');
+    cacheDir = path.join(homeDir, '.ballin-scripts', '.gu-cache');
+    gistDir = path.join(homeDir, 'gist');
+    readLogPath = path.join(homeDir, 'gist-reads.log');
+    uploadLogPath = path.join(homeDir, 'gist-uploads.log');
+
+    fs.mkdirSync(binDir);
+    fs.mkdirSync(path.join(homeDir, '.ballin-scripts'));
+    fs.mkdirSync(path.join(homeDir, 'Library', 'Application Support'), { recursive: true });
+    fs.mkdirSync(gistDir);
+    [
+      'bash',
+      'cat',
+      'cmp',
+      'cp',
+      'mkdir',
+      'mktemp',
+      'rm',
+      'tail',
+    ].forEach(installCommand);
+    fs.writeFileSync(
+      path.join(binDir, 'ballin_config'),
+      `#!/usr/bin/env bash
+if [ "$1" != 'get' ]; then
+  printf '%s\\n' 'Unexpected ballin_config action' >&2
+  exit 2
+elif [ "$2" = 'gu.id' ]; then
+  printf '%s\\n' 'test-gist-id'
+elif [ "$2" = 'gu.url' ]; then
+  printf '%s\\n' 'https://example.test/gists'
+else
+  printf '%s\\n' 'Unexpected ballin_config call' >&2
+  exit 2
+fi
+`,
+      { mode: 0o755 },
+    );
+    fs.writeFileSync(
+      path.join(binDir, 'gist'),
+      `#!/usr/bin/env bash
+if [ "$2" != 'test-gist-id' ]; then
+  printf '%s\\n' 'Unexpected Gist ID' >&2
+  exit 2
+fi
+if [ "$1" = '-r' ]; then
+  if [ "$#" -eq 2 ]; then
+    exit 0
+  elif [ "$#" -ne 3 ]; then
+    printf '%s\\n' 'Unexpected gist read arguments' >&2
+    exit 2
+  fi
+  printf '%s\\n' "$3" >> "$GIST_TEST_READ_LOG"
+  gist_file="$GIST_TEST_DIR/$3"
+  if [ -f "$gist_file" ]; then
+    cat "$gist_file"
+  else
+    exit 1
+  fi
+elif [ "$1" = '-u' ]; then
+  if [ "$#" -ne 3 ]; then
+    printf '%s\\n' 'Unexpected gist upload arguments' >&2
+    exit 2
+  fi
+  cache_file="$3"
+  file_name="\${cache_file##*/}"
+  cp "$cache_file" "$GIST_TEST_DIR/$file_name"
+  printf '%s\\n' "$file_name" >> "$GIST_TEST_UPLOAD_LOG"
+else
+  printf '%s\\n' 'Unexpected gist call' >&2
+  exit 2
+fi
+`,
+      { mode: 0o755 },
+    );
+  });
+
+  afterEach(() => {
+    fs.rmSync(homeDir, { recursive: true, force: true });
+  });
+
+  const runGu = () => spawnSync(guPath, [], {
+    encoding: 'utf8',
+    env: {
+      HOME: homeDir,
+      PATH: binDir,
+      BALLIN_GU_BASH_COMPLETION_DIR: path.join(homeDir, 'bash-completion.d'),
+      GIST_TEST_DIR: gistDir,
+      GIST_TEST_READ_LOG: readLogPath,
+      GIST_TEST_UPLOAD_LOG: uploadLogPath,
+    },
+  });
+
+  const snapshotPath = () => path.join(homeDir, '.zshrc');
+  const cachePath = () => path.join(cacheDir, fileName);
+  const gistPath = () => path.join(gistDir, fileName);
+  const writeSnapshot = (content) => fs.writeFileSync(snapshotPath(), content);
+  const seedCache = (content) => {
+    fs.mkdirSync(cacheDir, { recursive: true });
+    fs.writeFileSync(cachePath(), content);
+  };
+  const seedGist = (content) => fs.writeFileSync(gistPath(), content);
+  const assertSucceeded = (result) => {
+    assert.equal(result.status, 0);
+    assert.equal(result.stderr, '');
+  };
+  const reads = () => (
+    fs.existsSync(readLogPath)
+      ? fs.readFileSync(readLogPath, 'utf8').trim().split('\n')
+      : []
+  );
+  const uploads = () => (
+    fs.existsSync(uploadLogPath)
+      ? fs.readFileSync(uploadLogPath, 'utf8').trim().split('\n')
+      : []
+  );
+
+  it('creates and uploads the first snapshot when cache and Gist are missing', () => {
+    writeSnapshot('alias hello="world"\n');
+
+    const result = runGu();
+
+    assertSucceeded(result);
+    assert.equal(result.stdout, '💾 zshrc\n');
+    assert.equal(fs.readFileSync(cachePath(), 'utf8'), 'alias hello="world"\n');
+    assert.equal(fs.readFileSync(gistPath(), 'utf8'), 'alias hello="world"\n');
+    assert.deepEqual(reads(), [fileName]);
+    assert.deepEqual(uploads(), [fileName]);
+  });
+
+  it('uses the current new-file icon for a first empty snapshot', () => {
+    writeSnapshot('');
+
+    const result = runGu();
+
+    assertSucceeded(result);
+    assert.equal(result.stdout, '💾 zshrc\n');
+    assert.equal(fs.readFileSync(cachePath(), 'utf8'), 'empty\n');
+    assert.equal(fs.readFileSync(gistPath(), 'utf8'), 'empty\n');
+    assert.deepEqual(reads(), [fileName]);
+    assert.deepEqual(uploads(), [fileName]);
+  });
+
+  it('hydrates a missing cache from unchanged Gist content', () => {
+    writeSnapshot('export EDITOR=vim\n');
+    seedGist('export EDITOR=vim\n');
+
+    const result = runGu();
+
+    assertSucceeded(result);
+    assert.equal(result.stdout, '✔ zshrc\n');
+    assert.equal(fs.readFileSync(cachePath(), 'utf8'), 'export EDITOR=vim\n');
+    assert.deepEqual(reads(), [fileName]);
+    assert.deepEqual(uploads(), []);
+  });
+
+  it('compares against hydrated Gist content before uploading a change', () => {
+    writeSnapshot('new value\n');
+    seedGist('old value\n');
+
+    const result = runGu();
+
+    assertSucceeded(result);
+    assert.equal(result.stdout, '✚ zshrc\n');
+    assert.equal(fs.readFileSync(cachePath(), 'utf8'), 'new value\n');
+    assert.equal(fs.readFileSync(gistPath(), 'utf8'), 'new value\n');
+    assert.deepEqual(reads(), [fileName]);
+    assert.deepEqual(uploads(), [fileName]);
+  });
+
+  it('reports unchanged non-empty output without uploading it', () => {
+    writeSnapshot('set -o vi\n');
+    seedCache('set -o vi\n');
+
+    const result = runGu();
+
+    assertSucceeded(result);
+    assert.equal(result.stdout, '✔ zshrc\n');
+    assert.deepEqual(uploads(), []);
+  });
+
+  it('reports and uploads changed non-empty output', () => {
+    writeSnapshot('export COLOR=blue\n');
+    seedCache('export COLOR=red\n');
+
+    const result = runGu();
+
+    assertSucceeded(result);
+    assert.equal(result.stdout, '✚ zshrc\n');
+    assert.equal(fs.readFileSync(cachePath(), 'utf8'), 'export COLOR=blue\n');
+    assert.deepEqual(uploads(), [fileName]);
+  });
+
+  it('reports and uploads non-empty output becoming empty', () => {
+    writeSnapshot('');
+    seedCache('old content\n');
+
+    const result = runGu();
+
+    assertSucceeded(result);
+    assert.equal(result.stdout, '✖︎ zshrc\n');
+    assert.equal(fs.readFileSync(cachePath(), 'utf8'), 'empty\n');
+    assert.deepEqual(uploads(), [fileName]);
+  });
+
+  it('hides unchanged empty output and does not upload it', () => {
+    writeSnapshot('');
+    seedCache('empty\n');
+
+    const result = runGu();
+
+    assertSucceeded(result);
+    assert.equal(result.stdout, '');
+    assert.deepEqual(uploads(), []);
+  });
+
+  it('preserves the current changed icon when empty becomes non-empty', () => {
+    writeSnapshot('restored\n');
+    seedCache('empty\n');
+
+    const result = runGu();
+
+    assertSucceeded(result);
+    assert.equal(result.stdout, '✚ zshrc\n');
+    assert.deepEqual(uploads(), [fileName]);
+  });
+
+  it('preserves multiple trailing blank lines', () => {
+    writeSnapshot('line\n\n\n');
+
+    const result = runGu();
+
+    assertSucceeded(result);
+    assert.equal(fs.readFileSync(cachePath(), 'utf8'), 'line\n\n\n');
+    assert.equal(fs.readFileSync(gistPath(), 'utf8'), 'line\n\n\n');
+  });
+
+  it('normalizes output missing its final newline', () => {
+    writeSnapshot('line');
+
+    const result = runGu();
+
+    assertSucceeded(result);
+    assert.equal(fs.readFileSync(cachePath(), 'utf8'), 'line\n');
+    assert.equal(fs.readFileSync(gistPath(), 'utf8'), 'line\n');
+  });
+
+  it('uploads a normalized snapshot only once when a later run is unchanged', () => {
+    writeSnapshot('stable without newline');
+
+    const firstResult = runGu();
+    const secondResult = runGu();
+
+    assertSucceeded(firstResult);
+    assertSucceeded(secondResult);
+    assert.equal(secondResult.stdout, '✔ zshrc\n');
+    assert.deepEqual(uploads(), [fileName]);
+  });
+});

--- a/test/gu.test.js
+++ b/test/gu.test.js
@@ -12,6 +12,7 @@ describe('gu', () => {
   let cacheDir;
   let gistDir;
   let readLogPath;
+  let tempWorkDir;
   let uploadLogPath;
 
   const fileName = 'zshrc.sh';
@@ -32,12 +33,14 @@ describe('gu', () => {
     cacheDir = path.join(homeDir, '.ballin-scripts', '.gu-cache');
     gistDir = path.join(homeDir, 'gist');
     readLogPath = path.join(homeDir, 'gist-reads.log');
+    tempWorkDir = path.join(homeDir, 'tmp');
     uploadLogPath = path.join(homeDir, 'gist-uploads.log');
 
     fs.mkdirSync(binDir);
     fs.mkdirSync(path.join(homeDir, '.ballin-scripts'));
     fs.mkdirSync(path.join(homeDir, 'Library', 'Application Support'), { recursive: true });
     fs.mkdirSync(gistDir);
+    fs.mkdirSync(tempWorkDir);
     [
       'bash',
       'cat',
@@ -113,6 +116,7 @@ fi
     env: {
       HOME: homeDir,
       PATH: binDir,
+      TMPDIR: tempWorkDir,
       BALLIN_GU_BASH_COMPLETION_DIR: path.join(homeDir, 'bash-completion.d'),
       GIST_TEST_DIR: gistDir,
       GIST_TEST_READ_LOG: readLogPath,
@@ -132,6 +136,7 @@ fi
   const assertSucceeded = (result) => {
     assert.equal(result.status, 0);
     assert.equal(result.stderr, '');
+    assert.deepEqual(fs.readdirSync(tempWorkDir), []);
   };
   const reads = () => (
     fs.existsSync(readLogPath)


### PR DESCRIPTION
## Summary

- add an isolated `gu` harness with temporary HOME, PATH, cache, and Gist state
- characterize cache hydration, comparison, empty transitions, status icons, newline normalization, and upload gating
- record and assert stubbed Gist reads and writes
- add a narrow bash-completion directory override so tests cannot inspect real system paths

## Why

`gu` cache and status behavior contains subtle normalization and state-transition rules that were previously protected mainly by manual checks. Capturing the current contract first makes the behavior-preserving state cleanup in #76 and the intentional status change in #77 safer.

The bash-completion override preserves the existing `/usr/local/etc/bash_completion.d` default. Discovering the active Homebrew prefix is intentionally tracked separately in #100.

## Impact

Production cache and status behavior is unchanged. Tests run the public `bin/gu` entrypoint without accessing the user's real home, Gist, package managers, or completion directories.

## Validation

- `npm test` — 57 passing
- `bash -n bin/gu`
- `node --check test/gu.test.js`
- `git diff --check`

Closes #97

Related: #78, #76, #77, #98, #100