### PR TITLE
[codex] Define gu snapshot failure behavior

### DIFF
--- a/bin/gu
+++ b/bin/gu
@@ -69,6 +69,10 @@ elif [ -n "$1" ]; then
 else
   # no arguments given -> run gistUpdater
 
+  # Snapshot commands are independent: remember failures, continue the run, and
+  # return nonzero only after every eligible snapshot has been attempted.
+  snapshot_failure_file="$(mktemp)"
+
   # create cache folder if doesn't exist
   (
     cd "$HOME/.ballin-scripts"
@@ -91,6 +95,7 @@ else
       if [ ! -f "$cache_file" ]; then
         # set is_new to true if the $file_name doesn't exist yet in gist, otherwise create $cache_file with current gist_content
         if ! gist -r "$id" "$file_name" > "$cache_file"; then
+          rm -f "$cache_file"
           is_new=0
         fi
       fi
@@ -146,8 +151,13 @@ else
         fi
       fi
     }
-    # Do not upload stale cache content when the snapshot command fails.
-    if ! update_cache; then return 1; fi
+    # Do not upload stale cache content or print normal status when the input
+    # command fails. Its own stderr is preserved; this line adds snapshot context.
+    if ! update_cache; then
+      printf 'gu: failed to snapshot %s\n' "$file_name" >&2
+      printf 'failed\n' > "$snapshot_failure_file"
+      return 0
+    fi
     if [ "$is_changed" == 0 ]; then gist -u "$id" "$cache_file" > /dev/null; fi
     output_file_change
   }
@@ -288,5 +298,12 @@ else
     if [ -x "$(command -v mas)" ]; then
       u 'mas' 'mas list'
     fi
+
+    if [ -s "$snapshot_failure_file" ]; then
+      exit 1
+    fi
 	)
+  gu_status=$?
+  rm -f "$snapshot_failure_file"
+  exit "$gu_status"
 fi

--- a/bin/gu
+++ b/bin/gu
@@ -153,10 +153,11 @@ else
     }
     # Do not upload stale cache content or print normal status when the input
     # command fails. Its own stderr is preserved; this line adds snapshot context.
+    # Record and return the failure; without set -e, later snapshots still run.
     if ! update_cache; then
       printf 'gu: failed to snapshot %s\n' "$file_name" >&2
       printf 'failed\n' > "$snapshot_failure_file"
-      return 0
+      return 1
     fi
     if [ "$is_changed" == 0 ]; then gist -u "$id" "$cache_file" > /dev/null; fi
     output_file_change

--- a/test/gu.test.js
+++ b/test/gu.test.js
@@ -26,6 +26,7 @@ describe('gu', () => {
   let gistReadLogPath;
   let scratchDir;
   let gistUploadLogPath;
+  let realCatPath;
 
   const linkRequiredCommand = (command) => {
     const commandPath = process.env.PATH
@@ -94,6 +95,24 @@ fi
 `);
   };
 
+  const installControllableCatCommand = () => {
+    const catPath = fs.realpathSync(path.join(testBinDir, 'cat'));
+    fs.unlinkSync(path.join(testBinDir, 'cat'));
+    writeTestExecutable('cat', `#!/usr/bin/env bash
+IFS=':' read -r -a failed_paths <<< "$FAKE_CAT_FAILURE_PATHS"
+for failed_path in "\${failed_paths[@]}"; do
+  if [ -n "$failed_path" ] && [ "$1" = "$failed_path" ]; then
+    if [ "$FAKE_CAT_EMIT_STDERR" = 'true' ]; then
+      printf 'cat: simulated failure reading %s\n' "$1" >&2
+    fi
+    exit 23
+  fi
+done
+"$REAL_CAT" "$@"
+`);
+    return catPath;
+  };
+
   beforeEach(() => {
     testHomeDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ballin-gu-'));
     testBinDir = path.join(testHomeDir, 'bin');
@@ -111,6 +130,7 @@ fi
       scratchDir,
     ].forEach((directory) => fs.mkdirSync(directory, { recursive: true }));
     requiredCommands.forEach(linkRequiredCommand);
+    realCatPath = installControllableCatCommand();
     installFakeBallinConfigCommand();
     installFakeGistCommand();
   });
@@ -120,7 +140,7 @@ fi
   });
 
   // Pass a complete child environment so real tools and credentials are not inherited.
-  const runGu = () => spawnSync(guPath, [], {
+  const runGu = ({ failedPaths = [], emitUnderlyingStderr = false } = {}) => spawnSync(guPath, [], {
     encoding: 'utf8',
     env: {
       HOME: testHomeDir,
@@ -130,6 +150,9 @@ fi
       FAKE_GIST_STORAGE_DIR: fakeGistDir,
       FAKE_GIST_READ_LOG: gistReadLogPath,
       FAKE_GIST_UPLOAD_LOG: gistUploadLogPath,
+      FAKE_CAT_FAILURE_PATHS: failedPaths.join(':'),
+      FAKE_CAT_EMIT_STDERR: emitUnderlyingStderr ? 'true' : 'false',
+      REAL_CAT: realCatPath,
     },
   });
 
@@ -293,5 +316,83 @@ fi
     assertGuSucceeded(secondResult);
     assert.equal(secondResult.stdout, '✔ zshrc\n');
     assert.deepEqual(gistUploads(), [snapshotFileName]);
+  });
+
+  it('preserves failed snapshot state, adds context, and continues later snapshots', () => {
+    const gitconfigPath = path.join(testHomeDir, '.gitconfig');
+    writeSnapshot('new zsh value\n');
+    fs.writeFileSync(gitconfigPath, 'new git value\n');
+    seedGuCache('old zsh value\n');
+    seedFakeGist('old zsh value\n');
+
+    const result = runGu({
+      failedPaths: ['.zshrc'],
+      emitUnderlyingStderr: true,
+    });
+
+    assert.equal(result.status, 1);
+    assert.equal(result.stdout, '💾 gitconfig\n');
+    assert.equal(
+      result.stderr,
+      'cat: simulated failure reading .zshrc\n'
+        + 'gu: failed to snapshot zshrc.sh\n',
+    );
+    assert.equal(fs.readFileSync(cachedSnapshotPath(), 'utf8'), 'old zsh value\n');
+    assert.equal(fs.readFileSync(fakeGistFilePath(), 'utf8'), 'old zsh value\n');
+    assert.equal(
+      fs.readFileSync(path.join(guCacheDir, 'gitconfig'), 'utf8'),
+      'new git value\n',
+    );
+    assert.deepEqual(gistUploads(), ['gitconfig']);
+    assert.deepEqual(fs.readdirSync(scratchDir), []);
+  });
+
+  it('reports a silent command failure without leaving failed Gist hydration behind', () => {
+    writeSnapshot('not captured\n');
+
+    const result = runGu({ failedPaths: ['.zshrc'] });
+
+    assert.equal(result.status, 1);
+    assert.equal(result.stdout, '');
+    assert.equal(result.stderr, 'gu: failed to snapshot zshrc.sh\n');
+    assert.isFalse(fs.existsSync(cachedSnapshotPath()));
+    assert.isFalse(fs.existsSync(fakeGistFilePath()));
+    assert.deepEqual(gistReads(), [snapshotFileName]);
+    assert.deepEqual(gistUploads(), []);
+    assert.deepEqual(fs.readdirSync(scratchDir), []);
+  });
+
+  it('recovers cleanly on the next successful invocation', () => {
+    writeSnapshot('recovered\n');
+    seedGuCache('before failure\n');
+    seedFakeGist('before failure\n');
+
+    const failedResult = runGu({ failedPaths: ['.zshrc'] });
+    const recoveredResult = runGu();
+
+    assert.equal(failedResult.status, 1);
+    assertGuSucceeded(recoveredResult);
+    assert.equal(recoveredResult.stdout, '✚ zshrc\n');
+    assert.equal(fs.readFileSync(cachedSnapshotPath(), 'utf8'), 'recovered\n');
+    assert.equal(fs.readFileSync(fakeGistFilePath(), 'utf8'), 'recovered\n');
+    assert.deepEqual(gistUploads(), [snapshotFileName]);
+  });
+
+  it('returns one predictable failure status after multiple snapshot failures', () => {
+    const gitconfigPath = path.join(testHomeDir, '.gitconfig');
+    writeSnapshot('zsh value\n');
+    fs.writeFileSync(gitconfigPath, 'git value\n');
+
+    const result = runGu({ failedPaths: ['.zshrc', '.gitconfig'] });
+
+    assert.equal(result.status, 1);
+    assert.equal(result.stdout, '');
+    assert.equal(
+      result.stderr,
+      'gu: failed to snapshot zshrc.sh\n'
+        + 'gu: failed to snapshot gitconfig\n',
+    );
+    assert.deepEqual(gistUploads(), []);
+    assert.deepEqual(fs.readdirSync(scratchDir), []);
   });
 });


### PR DESCRIPTION
## Summary

- preserve cache and Gist content when an individual snapshot command fails
- continue processing independent snapshots, add concise failure context, and return nonzero after the run
- cover underlying stderr, silent failures, failed hydration, continuation, recovery, and multiple failures in the isolated `gu` harness

## Why

`gu` already avoided uploading stale cache content after a command failure, but its diagnostics, continuation behavior, cache hydration cleanup, and final exit status were not deterministic. This makes that contract explicit while keeping successful snapshot behavior unchanged.

## Validation

- `npm test` (61 passing)
- `bash -n bin/gu`
- `git diff --check`

Closes #99.
Part of #78.