### PR TITLE
[codex] Expand up and Homebrew integration regression coverage

### DIFF
--- a/test/gu.test.js
+++ b/test/gu.test.js
@@ -26,6 +26,7 @@ describe('gu', () => {
   let gistReadLogPath;
   let scratchDir;
   let gistUploadLogPath;
+  let brewLogPath;
   let realCatPath;
 
   const linkRequiredCommand = (command) => {
@@ -95,6 +96,24 @@ fi
 `);
   };
 
+  const installFakeBrewCommand = () => {
+    writeTestExecutable('brew', `#!/usr/bin/env bash
+printf '%s|%s|%s\\n' "$HOMEBREW_NO_AUTO_UPDATE" "$HOMEBREW_NO_ENV_HINTS" "$*" >> "$FAKE_BREW_LOG"
+case "$*" in
+  'list --formula') printf '%s\\n' 'formula-one' ;;
+  'leaves') printf '%s\\n' 'leaf-one' ;;
+  'list --cask') printf '%s\\n' 'cask-one' ;;
+  'services list')
+    printf '%s\\n' 'service-one started'
+    printf '%s\\n' 'simulated services warning' >&2
+    if [ "$FAKE_BREW_SERVICES_FAIL" = 'true' ]; then exit 31; fi
+    ;;
+  'bundle dump --file=-') printf '%s\\n' 'brew "formula-one"' ;;
+  *) printf '%s\\n' 'Unexpected brew call' >&2; exit 2 ;;
+esac
+`);
+  };
+
   const installControllableCatCommand = () => {
     const catPath = fs.realpathSync(path.join(testBinDir, 'cat'));
     fs.unlinkSync(path.join(testBinDir, 'cat'));
@@ -121,6 +140,7 @@ done
     gistReadLogPath = path.join(testHomeDir, 'fake-gist-reads.log');
     scratchDir = path.join(testHomeDir, 'tmp');
     gistUploadLogPath = path.join(testHomeDir, 'fake-gist-uploads.log');
+    brewLogPath = path.join(testHomeDir, 'fake-brew.log');
 
     [
       testBinDir,
@@ -140,7 +160,11 @@ done
   });
 
   // Pass a complete child environment so real tools and credentials are not inherited.
-  const runGu = ({ failedPaths = [], emitUnderlyingStderr = false } = {}) => spawnSync(guPath, [], {
+  const runGu = ({
+    failedPaths = [],
+    emitUnderlyingStderr = false,
+    brewServicesFail = false,
+  } = {}) => spawnSync(guPath, [], {
     encoding: 'utf8',
     env: {
       HOME: testHomeDir,
@@ -150,6 +174,8 @@ done
       FAKE_GIST_STORAGE_DIR: fakeGistDir,
       FAKE_GIST_READ_LOG: gistReadLogPath,
       FAKE_GIST_UPLOAD_LOG: gistUploadLogPath,
+      FAKE_BREW_LOG: brewLogPath,
+      FAKE_BREW_SERVICES_FAIL: brewServicesFail ? 'true' : 'false',
       FAKE_CAT_FAILURE_PATHS: failedPaths.join(':'),
       FAKE_CAT_EMIT_STDERR: emitUnderlyingStderr ? 'true' : 'false',
       REAL_CAT: realCatPath,
@@ -175,6 +201,58 @@ done
   );
   const gistReads = () => readLogLines(gistReadLogPath);
   const gistUploads = () => readLogLines(gistUploadLogPath);
+  const brewCalls = () => readLogLines(brewLogPath);
+
+  it('captures Homebrew inventory with flags while suppressing successful services stderr', () => {
+    installFakeBrewCommand();
+
+    const result = runGu();
+
+    assertGuSucceeded(result);
+    assert.deepEqual(result.stdout.trim().split('\n'), [
+      '💾 brew_list',
+      '💾 brew_leaves',
+      '💾 brew_cask',
+      '💾 brew_services',
+      '💾 Brewfile',
+    ]);
+    assert.deepEqual(brewCalls(), [
+      '1|1|list --formula',
+      '1|1|leaves',
+      '1|1|list --cask',
+      '1|1|services list',
+      '1|1|bundle dump --file=-',
+    ]);
+    assert.equal(
+      fs.readFileSync(path.join(guCacheDir, 'brew_services'), 'utf8'),
+      'service-one started\n',
+    );
+    assert.deepEqual(gistUploads(), [
+      'brew_list',
+      'brew_leaves',
+      'brew_cask',
+      'brew_services',
+      'Brewfile',
+    ]);
+  });
+
+  it('surfaces failed brew services stderr and preserves other inventory snapshots', () => {
+    installFakeBrewCommand();
+
+    const result = runGu({ brewServicesFail: true });
+
+    assert.equal(result.status, 1);
+    assert.include(result.stderr, 'simulated services warning\n');
+    assert.include(result.stderr, 'gu: failed to snapshot brew_services\n');
+    assert.isFalse(fs.existsSync(path.join(guCacheDir, 'brew_services')));
+    assert.deepEqual(gistUploads(), [
+      'brew_list',
+      'brew_leaves',
+      'brew_cask',
+      'Brewfile',
+    ]);
+    assert.deepEqual(fs.readdirSync(scratchDir), []);
+  });
 
   it('creates and uploads the first snapshot when cache and Gist are missing', () => {
     writeSnapshot('alias hello="world"\n');

--- a/test/up.test.js
+++ b/test/up.test.js
@@ -11,22 +11,35 @@ describe('up', () => {
   let binDir;
   let logPath;
 
+  const writeTestExecutable = (name, contents) => {
+    fs.writeFileSync(path.join(binDir, name), contents, { mode: 0o755 });
+  };
+
+  const installCommandStub = (name, { output = '', status = 0 } = {}) => {
+    writeTestExecutable(name, `#!/usr/bin/env bash
+printf '%s|%s|%s\\n' "${name}" "$HOMEBREW_NO_ENV_HINTS,$HOMEBREW_NO_ASK" "$*" >> "$UP_TEST_LOG"
+${output ? `printf '%s\\n' '${output}'` : ''}
+exit ${status}
+`);
+  };
+
   beforeEach(() => {
     tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ballin-up-'));
     binDir = path.join(tempDir, 'bin');
-    logPath = path.join(tempDir, 'nvm.log');
+    logPath = path.join(tempDir, 'commands.log');
     fs.mkdirSync(binDir);
-    fs.writeFileSync(
-      path.join(binDir, 'ballin_config'),
-      `#!/usr/bin/env bash
-if [ "$2" = 'up.nvm' ]; then
-  printf '%s\\n' "\${TEST_UP_NVM:-false}"
-else
-  printf '%s\\n' 'false'
-fi
-`,
-      { mode: 0o755 },
-    );
+    fs.symlinkSync('/bin/bash', path.join(binDir, 'bash'));
+    writeTestExecutable('ballin_config', `#!/usr/bin/env bash
+case "$2" in
+  up.cleanup) printf '%s\\n' "\${TEST_UP_CLEANUP:-false}" ;;
+  up.nvm) printf '%s\\n' "\${TEST_UP_NVM:-false}" ;;
+  up.npm) printf '%s\\n' "\${TEST_UP_NPM:-false}" ;;
+  up.softwareupdate) printf '%s\\n' "\${TEST_UP_SOFTWAREUPDATE:-false}" ;;
+  up.ballin) printf '%s\\n' "\${TEST_UP_BALLIN:-false}" ;;
+  up.gu) printf '%s\\n' "\${TEST_UP_GU:-false}" ;;
+  *) printf '%s\\n' 'false' ;;
+esac
+`);
   });
 
   afterEach(() => {
@@ -37,8 +50,9 @@ fi
     encoding: 'utf8',
     env: {
       HOME: tempDir,
-      PATH: `${binDir}:/usr/bin:/bin`,
+      PATH: binDir,
       NVM_TEST_LOG: logPath,
+      UP_TEST_LOG: logPath,
       TEST_UP_NVM: 'true',
       ...env,
     },
@@ -54,6 +68,98 @@ fi
 `,
     );
   };
+
+  const commandLog = () => (
+    fs.existsSync(logPath) ? fs.readFileSync(logPath, 'utf8').trim().split('\n') : []
+  );
+
+  it('sets Homebrew flags, preserves output, cleans conditionally, and runs doctor', () => {
+    installCommandStub('brew', { output: 'visible Homebrew output' });
+
+    const result = runUp({ TEST_UP_NVM: 'false', TEST_UP_CLEANUP: 'true' });
+
+    assert.equal(result.status, 0);
+    assert.include(result.stdout, 'visible Homebrew output');
+    assert.include(result.stdout, 'Cleaning up Homebrew packages');
+    assert.include(result.stdout, 'Checking Homebrew installation');
+    assert.deepEqual(commandLog(), [
+      'brew|1,1|upgrade',
+      'brew|1,1|cleanup',
+      'brew|1,1|doctor',
+    ]);
+  });
+
+  it('skips cleanup when disabled while preserving upgrade and doctor output', () => {
+    installCommandStub('brew', { output: 'brew command output' });
+
+    const result = runUp({ TEST_UP_NVM: 'false' });
+
+    assert.equal(result.status, 0);
+    assert.notInclude(result.stdout, 'Cleaning up Homebrew packages');
+    assert.deepEqual(commandLog(), [
+      'brew|1,1|upgrade',
+      'brew|1,1|doctor',
+    ]);
+    assert.equal(result.stdout.match(/brew command output/g).length, 2);
+  });
+
+  it('runs enabled npm, macOS update, ballin update, and gu integrations', () => {
+    ['npm', 'softwareupdate', 'ballin_update', 'gu'].forEach((command) => {
+      installCommandStub(command);
+    });
+
+    const result = runUp({
+      TEST_UP_NVM: 'false',
+      TEST_UP_NPM: 'true',
+      TEST_UP_SOFTWAREUPDATE: 'true',
+      TEST_UP_BALLIN: 'true',
+      TEST_UP_GU: 'true',
+    });
+
+    assert.equal(result.status, 0);
+    assert.deepEqual(commandLog(), [
+      'npm|,|update -g',
+      'softwareupdate|,|-ia',
+      'ballin_update|,|',
+      'gu|,|',
+    ]);
+  });
+
+  it('does not run disabled optional integrations even when commands exist', () => {
+    ['npm', 'softwareupdate', 'ballin_update', 'gu'].forEach((command) => {
+      installCommandStub(command);
+    });
+
+    const result = runUp({ TEST_UP_NVM: 'false' });
+
+    assert.equal(result.status, 0);
+    assert.deepEqual(commandLog(), []);
+    assert.notInclude(result.stdout, 'Updating global npm packages');
+    assert.notInclude(result.stdout, 'Installing macOS updates');
+    assert.notInclude(result.stdout, 'Updating ballin-scripts');
+    assert.notInclude(result.stdout, 'Backing up development environment');
+  });
+
+  it('keeps later integrations isolated when an optional command fails', () => {
+    installCommandStub('npm', { output: 'simulated npm failure', status: 23 });
+    installCommandStub('ballin_update');
+    installCommandStub('gu');
+
+    const result = runUp({
+      TEST_UP_NVM: 'false',
+      TEST_UP_NPM: 'true',
+      TEST_UP_BALLIN: 'true',
+      TEST_UP_GU: 'true',
+    });
+
+    assert.equal(result.status, 0);
+    assert.include(result.stdout, 'simulated npm failure');
+    assert.deepEqual(commandLog(), [
+      'npm|,|update -g',
+      'ballin_update|,|',
+      'gu|,|',
+    ]);
+  });
 
   it('loads nvm from NVM_DIR and updates Node.js LTS', () => {
     const nvmDir = path.join(tempDir, 'custom-nvm');


### PR DESCRIPTION
## Summary

- expand the isolated `up` harness to cover Homebrew flags, visible upgrade/doctor output, and cleanup gating
- cover enabled and disabled npm, macOS update, ballin update, and `gu` integrations, including continuation after an optional-command failure
- reuse the isolated `gu` cache/Gist harness for Homebrew inventory flags and `brew services list` stderr behavior

## Why

Homebrew environment flags and stderr handling are subtle shell contracts that have regressed before. These tests preserve the existing behavior while ensuring no test can reach real package managers, system updates, credentials, Gists, or user scripts.

## Impact

Test-only change. Production behavior is unchanged.

## Validation

- `npm test` — 68 passing
- targeted `up` and `gu` suites — 26 passing in two independent repeat runs
- `git diff --check`

Closes #98
Part of #78