### PR TITLE
[codex] Expand installer regression coverage

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -31,6 +31,7 @@ if [[ ":$PATH:" != *":$bin_dir:"* ]]; then
   l3='and open a new terminal window and run this installation again.'
   printf '\n⚠️  ERROR: %s\n%s\n%s\n' "$l1" "$l2" "$l3"
   unset l1 l2 l3
+  exit 1
 # Check that Node.js is available before running configuration commands
 elif [ ! -x "$(command -v node)" ]; then
   printf '\n⚠️  ERROR: Node.js is required.\n'
@@ -46,6 +47,7 @@ elif [ ! -x "$(command -v gist)" ] && [ ! -x "$(command -v brew)" ]; then
   l3='and run this installation again.'
   printf '\n⚠️  ERROR: %s\n%s\n%s\n' "$l1" "$l2" "$l3"
   unset l1 l2 l3
+  exit 1
 else
 
 
@@ -55,22 +57,30 @@ if [ ! -f "$repo_dir/ballin.config.json" ]; then
   config_existed=false
 fi
 
-(
+# Configuration must succeed before Gist credentials or command symlinks are touched.
+if ! (
   cd "$repo_dir/config"
   if [ ! -f '../ballin.config.json' ]; then
     # create config
-    cp '.defaultConfig.json' '../ballin.config.json'
+    if ! cp '.defaultConfig.json' '../ballin.config.json'; then
+      exit 1
+    fi
     printf '\n%s\n' "🧠 Created 'ballin.config.json' file in root using default settings"
   else
     # ballin_update reruns this installer after pulling changes; add any new
     # default options to the existing config without overwriting user settings.
-    UPDATE_RESULT=$(node "$repo_dir/config/updateConfig.js")
+    if ! UPDATE_RESULT=$(node "$repo_dir/config/updateConfig.js"); then
+      exit 1
+    fi
     if [ -n "$UPDATE_RESULT" ]; then
       printf '\n🙌 %s\n' "$UPDATE_RESULT"
       printf '\nOptional capabilities: %s\n' "$optional_capabilities_url"
     fi
   fi
-)
+); then
+  printf '\n⚠️  ERROR: Unable to create or update ballin.config.json\n'
+  exit 1
+fi
 
 
 #################################### GIST ####################################

--- a/test/install.test.js
+++ b/test/install.test.js
@@ -10,14 +10,76 @@ describe('install', () => {
   let homeDir;
   let binDir;
   let repoDir;
+  let commandLogPath;
+
+  const writeExecutable = (name, contents, directory = binDir) => {
+    const executablePath = path.join(directory, name);
+    fs.writeFileSync(executablePath, contents, { mode: 0o755 });
+    return executablePath;
+  };
+
+  const linkCommand = (name, directory = binDir) => {
+    const commandPath = process.env.PATH
+      .split(path.delimiter)
+      .map((commandDirectory) => path.join(commandDirectory, name))
+      .find((candidate) => fs.existsSync(candidate));
+
+    assert.exists(commandPath, `${name} is required to run the install test harness`);
+    fs.symlinkSync(commandPath, path.join(directory, name));
+  };
+
+  const installBaseCommands = () => {
+    ['chmod', 'cp', 'ln', 'mkdir', 'rm'].forEach((command) => linkCommand(command));
+    writeExecutable('node', `#!/usr/bin/env bash
+printf '%s' "$FAKE_UPDATE_OUTPUT"
+exit "$FAKE_NODE_STATUS"
+`);
+    writeExecutable('gist', `#!/usr/bin/env bash
+printf 'gist:%s\\n' "$*" >> "$FAKE_COMMAND_LOG"
+exit 0
+`);
+  };
+
+  const installConfigCommand = () => {
+    writeExecutable('ballin_config', `#!/usr/bin/env bash
+printf 'ballin_config:%s\\n' "$*" >> "$FAKE_COMMAND_LOG"
+case "$1:$2" in
+  get:gu.token_file) printf '%s\\n' '.gist' ;;
+  get:gu.url) printf '%s\\n' 'https://gist.example.test' ;;
+  get:gu.id) printf '%s\\n' 'existing-gist-id' ;;
+esac
+`, path.join(repoDir, 'bin'));
+  };
+
+  const runInstall = ({ env = {}, input } = {}) => spawnSync(installPath, [], {
+    encoding: 'utf8',
+    input,
+    env: {
+      HOME: homeDir,
+      PATH: binDir,
+      FAKE_COMMAND_LOG: commandLogPath,
+      FAKE_NODE_STATUS: '0',
+      ...env,
+    },
+  });
+
+  const commandLog = () => (fs.existsSync(commandLogPath)
+    ? fs.readFileSync(commandLogPath, 'utf8')
+    : '');
 
   beforeEach(() => {
     homeDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ballin-install-'));
     binDir = path.join(homeDir, '.local', 'bin');
     repoDir = path.join(homeDir, '.ballin-scripts');
     fs.mkdirSync(binDir, { recursive: true });
-    fs.mkdirSync(repoDir);
-    fs.symlinkSync('/bin/bash', path.join(binDir, 'bash'));
+    fs.mkdirSync(path.join(repoDir, 'bin'), { recursive: true });
+    fs.mkdirSync(path.join(repoDir, 'config'));
+    fs.copyFileSync(
+      path.join(__dirname, '..', 'config', '.defaultConfig.json'),
+      path.join(repoDir, 'config', '.defaultConfig.json'),
+    );
+    commandLogPath = path.join(homeDir, 'commands.log');
+    linkCommand('bash');
   });
 
   afterEach(() => {
@@ -25,13 +87,7 @@ describe('install', () => {
   });
 
   it('stops with guidance when Node.js is unavailable', () => {
-    const result = spawnSync(installPath, [], {
-      encoding: 'utf8',
-      env: {
-        HOME: homeDir,
-        PATH: binDir,
-      },
-    });
+    const result = runInstall();
 
     assert.equal(result.status, 1);
     assert.include(result.stdout, 'Node.js is required');
@@ -40,5 +96,161 @@ describe('install', () => {
     assert.include(result.stdout, 'brew install node');
     assert.include(result.stdout, 'run this installer again');
     assert.isFalse(fs.existsSync(path.join(repoDir, 'ballin.config.json')));
+  });
+
+  it('stops before configuration and Gist work when the command directory is missing from PATH', () => {
+    const pathDir = path.join(homeDir, 'test-path');
+    fs.mkdirSync(pathDir);
+    ['bash'].forEach((command) => linkCommand(command, pathDir));
+    writeExecutable('node', '#!/usr/bin/env bash\nexit 0\n', pathDir);
+    writeExecutable('gist', `#!/usr/bin/env bash
+printf '%s\\n' gist >> "$FAKE_COMMAND_LOG"
+`, pathDir);
+
+    const result = runInstall({ env: { PATH: pathDir } });
+
+    assert.equal(result.status, 1);
+    assert.include(result.stdout, `${binDir} doesn't seem to be in your path.`);
+    assert.include(result.stdout, `export PATH="${binDir}:$PATH"`);
+    assert.isFalse(fs.existsSync(path.join(repoDir, 'ballin.config.json')));
+    assert.equal(commandLog(), '');
+  });
+
+  it('checks the Gist prerequisite before configuration work', () => {
+    installBaseCommands();
+    fs.unlinkSync(path.join(binDir, 'gist'));
+
+    const result = runInstall();
+
+    assert.equal(result.status, 1);
+    assert.include(result.stdout, "Can't find Homebrew, which is needed to download 'gist'.");
+    assert.isFalse(fs.existsSync(path.join(repoDir, 'ballin.config.json')));
+    assert.equal(commandLog(), '');
+  });
+
+  it('performs an isolated initial setup and shows optional capabilities once', () => {
+    installBaseCommands();
+    installConfigCommand();
+    fs.writeFileSync(path.join(homeDir, '.gist'), 'token\n');
+
+    const result = runInstall();
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.include(result.stdout, "Created 'ballin.config.json'");
+    assert.equal(result.stdout.match(/Optional capabilities:/g).length, 1);
+    assert.include(result.stdout, `symlinked binaries into ${binDir}`);
+    assert.include(result.stdout, '😎 ballin!');
+    assert.deepEqual(
+      JSON.parse(fs.readFileSync(path.join(repoDir, 'ballin.config.json'), 'utf8')),
+      JSON.parse(fs.readFileSync(path.join(repoDir, 'config', '.defaultConfig.json'), 'utf8')),
+    );
+    assert.isTrue(fs.lstatSync(path.join(binDir, 'ballin_config')).isSymbolicLink());
+    assert.include(commandLog(), 'gist:-l\n');
+  });
+
+  it('does not repeat unchanged setup guidance during an ordinary update', () => {
+    installBaseCommands();
+    installConfigCommand();
+    fs.copyFileSync(
+      path.join(repoDir, 'config', '.defaultConfig.json'),
+      path.join(repoDir, 'ballin.config.json'),
+    );
+    fs.writeFileSync(path.join(homeDir, '.gist'), 'token\n');
+
+    const result = runInstall();
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.notInclude(result.stdout, 'Optional capabilities:');
+    assert.notInclude(result.stdout, "Created 'ballin.config.json'");
+    assert.include(result.stdout, '😎 ballin!');
+  });
+
+  it('reports newly added configuration and links to the guide', () => {
+    installBaseCommands();
+    installConfigCommand();
+    fs.writeFileSync(path.join(repoDir, 'ballin.config.json'), '{}\n');
+    fs.writeFileSync(path.join(homeDir, '.gist'), 'token\n');
+
+    const updateOutput = 'New configuration options have been added!\nup.nvm: false\n';
+    const result = runInstall({ env: { FAKE_UPDATE_OUTPUT: updateOutput } });
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.include(result.stdout, updateOutput.trim());
+    assert.equal(result.stdout.match(/Optional capabilities:/g).length, 1);
+    assert.include(result.stdout, 'docs/optional-capabilities.md');
+  });
+
+  it('stops before Gist and success output when config creation fails', () => {
+    installBaseCommands();
+    installConfigCommand();
+    fs.unlinkSync(path.join(binDir, 'cp'));
+    writeExecutable('cp', '#!/usr/bin/env bash\nexit 9\n');
+
+    const result = runInstall();
+
+    assert.equal(result.status, 1);
+    assert.include(result.stdout, 'Unable to create or update ballin.config.json');
+    assert.notInclude(commandLog(), 'ballin_config:');
+    assert.notInclude(commandLog(), 'gist:');
+    assert.notInclude(result.stdout, 'symlinked binaries');
+    assert.notInclude(result.stdout, '😎 ballin!');
+  });
+
+  it('stops before Gist and success output when config migration fails', () => {
+    installBaseCommands();
+    installConfigCommand();
+    fs.writeFileSync(path.join(repoDir, 'ballin.config.json'), '{}\n');
+
+    const result = runInstall({ env: { FAKE_NODE_STATUS: '7' } });
+
+    assert.equal(result.status, 1);
+    assert.include(result.stdout, 'Unable to create or update ballin.config.json');
+    assert.notInclude(commandLog(), 'ballin_config:');
+    assert.notInclude(commandLog(), 'gist:');
+    assert.notInclude(result.stdout, 'symlinked binaries');
+    assert.notInclude(result.stdout, '😎 ballin!');
+  });
+
+  it('uses the Homebrew prefix as the command directory when brew is present', () => {
+    installBaseCommands();
+    installConfigCommand();
+    fs.writeFileSync(path.join(homeDir, '.gist'), 'token\n');
+    writeExecutable('brew', `#!/usr/bin/env bash
+if [ "$1" = '--prefix' ]; then
+  printf '%s\\n' "$HOME/.local"
+  exit 0
+fi
+exit 2
+`);
+
+    const result = runInstall();
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.include(result.stdout, `symlinked binaries into ${binDir}`);
+  });
+
+  it('installs a missing Gist dependency through the Homebrew stub', () => {
+    installBaseCommands();
+    installConfigCommand();
+    fs.unlinkSync(path.join(binDir, 'gist'));
+    fs.writeFileSync(path.join(homeDir, '.gist'), 'token\n');
+    writeExecutable('brew', `#!/usr/bin/env bash
+if [ "$1" = '--prefix' ]; then
+  printf '%s\\n' "$HOME/.local"
+elif [ "$1:$2" = 'install:gist' ]; then
+  printf '%s\\n' '#!/usr/bin/env bash' 'printf "gist:%s\\\\n" "$*" >> "$FAKE_COMMAND_LOG"' > "$HOME/.local/bin/gist"
+  chmod +x "$HOME/.local/bin/gist"
+  printf '%s\\n' 'brew:install gist' >> "$FAKE_COMMAND_LOG"
+else
+  exit 2
+fi
+`);
+
+    const result = runInstall();
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.include(result.stdout, 'brew installing gist');
+    assert.include(commandLog(), 'brew:install gist\n');
+    assert.include(commandLog(), 'gist:-l\n');
   });
 });


### PR DESCRIPTION
## Summary

- expand the isolated installer harness across initial install, ordinary update, configuration migration, PATH prerequisite, Homebrew, and Gist dependency paths
- make missing PATH and Gist prerequisites return a failure status
- stop immediately when default-config creation or config migration fails, before Gist credentials, symlinks, or success output are touched
- document the configuration failure boundary in `install.sh`

## Why

The installer previously printed fatal prerequisite errors without returning a failure status, and configuration copy/migration failures could be masked by later successful shell statements. That allowed execution to continue into credential and installation work and could produce misleading success output.

## Impact

Successful initial installs and updates retain their existing behavior and guidance. Fatal prerequisite and configuration failures now stop predictably, while all external commands in the regression tests are isolated behind temporary directories and deterministic stubs.

## Validation

- `npx mocha test/install.test.js` — 10 passing
- `npm test` — 77 passing
- `bash -n install.sh`
- `git diff --check`

Closes #95.
Part of #78.