### PR TITLE
[codex] Reject Git whitespace errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,9 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v6
 
+      - name: Check whitespace
+        run: git diff --check "$(git hash-object -t tree /dev/null)" HEAD
+
       - name: Set up Node.js
         uses: actions/setup-node@v6
         with:


### PR DESCRIPTION
## Summary

- check every tracked file for Git-recognized whitespace errors
- run the check immediately after checkout, before Node setup and dependency installation
- keep the existing install and test steps unchanged

Closes #106.

## Why

A plain `git diff --check` sees no changes in a clean Actions checkout. Diffing the current tree against Git's empty tree treats every tracked file as added, so the same history-independent check works for pull requests, pushes, and manual runs.

## Validation

- `git diff --check "$(git hash-object -t tree /dev/null)" HEAD`
- synthetic committed trailing-whitespace file exits nonzero
- `npm test` (81 passing)