### PR TITLE
[codex] Add AI contributor guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,15 +3,15 @@
 ## Repo map
 
 `ballin-scripts` is a small personal automation toolkit. Most user-facing behavior
-lives in Bash scripts under `bin/` and in `install.sh`. The Node.js layer in
+lives in Bash scripts under `bin/` and in `install.sh`. The Node.js code in
 `config/` manages `ballin.config.json`, and the Mocha tests in `test/` exercise
-the shell scripts and config helpers.
+the shell scripts and configuration helpers.
 
 ## Local commands
 
 - Use the Node.js version from `.nvmrc`.
 - Install dependencies with `npm ci`.
-- Run `npm test` after code, config, script, or test changes.
+- Run `npm test` after changes to code, config, scripts, or tests.
 - CI also runs this empty-tree whitespace check; use it locally when investigating
   whitespace failures:
 
@@ -28,7 +28,7 @@ the shell scripts and config helpers.
   `softwareupdate`, symlink, or other network-affecting operations must use
   temporary directories, fixture files, complete child-process environments, and
   command stubs instead of the real user environment.
-- Follow the existing `spawnSync` harness style and hooks like
+- Follow the existing `spawnSync` harness style, using hooks like
   `BALLIN_TEST_CONFIG_PATH`, `BALLIN_UNINSTALL_TEST_SYSTEM_ROOT`, and command-log
   stubs before adding new test escape hatches.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,9 +25,9 @@ the shell scripts and config helpers.
   `softwareupdate`, symlink, or other network-affecting operations against the
   real user environment.
 - Tests for install, uninstall, `up`, `gu`, Homebrew, Gist, GitHub, npm-global,
-  `softwareupdate`, symlink, or network-affecting behavior must use temporary
-  directories, fixture files, complete child-process environments, and command
-  stubs instead of the real user environment.
+  `softwareupdate`, symlink, or other network-affecting operations must use
+  temporary directories, fixture files, complete child-process environments, and
+  command stubs instead of the real user environment.
 - Follow the existing `spawnSync` harness style and hooks like
   `BALLIN_TEST_CONFIG_PATH`, `BALLIN_UNINSTALL_TEST_SYSTEM_ROOT`, and command-log
   stubs before adding new test escape hatches.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@ the shell scripts and config helpers.
 
 - Use the Node.js version from `.nvmrc`.
 - Install dependencies with `npm ci`.
-- Run `npm test` for code, config, script, or test changes.
+- Run `npm test` after code, config, script, or test changes.
 - CI also runs this empty-tree whitespace check; use it locally when investigating
   whitespace failures:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,13 +26,13 @@ the shell scripts and configuration helpers.
   `BALLIN_TEST_CONFIG_PATH`, `BALLIN_UNINSTALL_TEST_SYSTEM_ROOT`, and command-log
   stubs before adding new test escape hatches.
 
-## Shell and config changes
+## Shell, config, and docs
 
 - For shell changes, preserve CLI output and side effects unless the issue asks
   for behavior changes; watch quoting, globbing, paths with spaces, and
   executable modes on `bin/*` and `install.sh`.
 - Keep `config/.defaultConfig.json`, `config/updateConfig.js`, and config tests
   in sync when adding or changing settings.
-- Document new or changed user-facing configuration options in
-  `docs/optional-capabilities.md`, including settings that affect `up`, `gu`,
-  install, or update commands.
+- Update `docs/optional-capabilities.md` when optional setup, integrations,
+  dependencies, or user-facing settings change, especially for `up`, `gu`,
+  install, or update behavior.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,5 +33,5 @@ the shell scripts and configuration helpers.
   executable modes on `bin/*` and `install.sh`.
 - Keep `config/.defaultConfig.json`, `config/updateConfig.js`, and config tests
   in sync when adding or changing settings.
-- Update `docs/optional-capabilities.md` when optional setup, integrations,
-  dependencies, or documented settings change.
+- `docs/optional-capabilities.md` covers Node.js setup, optional integrations,
+  and `up` settings; update it when those user-facing choices change.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,9 +10,12 @@ the shell scripts and config helpers.
 ## Development workflow
 
 - Use the Node.js version from `.nvmrc`.
-- Install dependencies with `npm ci`.
-- Run the full local check with `npm test`; this runs ESLint and Mocha.
-- Before opening a PR, also run the whitespace check used by CI:
+- Install dependencies with `npm ci` for a clean, lockfile-based install. Use
+  `npm install` only when intentionally updating dependencies.
+- If using a git worktree, treat it like a fresh checkout; there is no
+  repo-specific worktree setup beyond installing dependencies in that checkout.
+- Run checks based on the change: `npm test` for code, config, script, or test
+  changes; the CI whitespace check is enough for docs-only changes.
 
   ```sh
   git diff --check "$(git hash-object -t tree /dev/null)" HEAD
@@ -37,12 +40,13 @@ the shell scripts and config helpers.
 - Preserve existing user-facing behavior unless the issue explicitly asks for a
   behavior change.
 - Be careful with quoting, globbing, and paths that may contain spaces.
-- Preserve executable bits on files under `bin/` and on `install.sh`.
+- Keep files under `bin/` and `install.sh` executable.
 - Prefer explicit checks and clear failure messages for operations that touch
   user config, symlinks, package managers, network-backed tools, or system update
   commands.
-- When adding behavior that can affect the user's environment, add or update
-  tests that prove it stays confined to the test harness.
+- For install, uninstall, update, Gist, symlink, package-manager, or system
+  update behavior, add or update tests that use temporary paths and stubs rather
+  than the real user environment.
 
 ## Config guidance
 
@@ -55,8 +59,6 @@ the shell scripts and config helpers.
 
 - Inspect the worktree before editing and preserve unrelated user changes.
 - Keep commits focused on the issue being addressed.
-- Do not encode personal Codex/session workflow preferences here; keep this file
-  limited to durable repository guidance.
 
 ## PR notes
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,20 +1,19 @@
 # AGENTS.md
 
-## Repository context
+## Repo map
 
 `ballin-scripts` is a small personal automation toolkit. Most user-facing behavior
 lives in Bash scripts under `bin/` and in `install.sh`. The Node.js layer in
 `config/` manages `ballin.config.json`, and the Mocha tests in `test/` exercise
 the shell scripts and config helpers.
 
-## Development workflow
+## Local commands
 
 - Use the Node.js version from `.nvmrc`.
 - Install dependencies with `npm ci`.
-- Git worktrees need no special setup beyond installing dependencies in the
-  worktree checkout.
-- Run checks based on the change: `npm test` for code, config, script, or test
-  changes; the CI whitespace check is enough for docs-only changes.
+- Run `npm test` for code, config, script, or test changes.
+- CI also runs this empty-tree whitespace check; use it locally when investigating
+  whitespace failures:
 
   ```sh
   git diff --check "$(git hash-object -t tree /dev/null)" HEAD
@@ -22,31 +21,20 @@ the shell scripts and config helpers.
 
 ## Testing and safety
 
-- Keep tests isolated from the real developer machine. Use temporary directories,
-  fixture files, and command stubs instead of real Homebrew, Gist, GitHub, npm,
-  macOS update, install, uninstall, or network behavior.
-- Follow the existing `spawnSync` test style: pass complete child-process
-  environments when that prevents real credentials, tools, config, or shell
-  state from leaking in.
-- Use the existing test escape hatches, such as `BALLIN_TEST_CONFIG_PATH`,
-  `BALLIN_UNINSTALL_TEST_SYSTEM_ROOT`, and command-log stubs, before adding new
-  ones.
+- Tests for install, uninstall, `up`, `gu`, Homebrew, Gist, GitHub, npm,
+  `softwareupdate`, symlinks, or network behavior must use temporary directories,
+  fixture files, and command stubs instead of the real user environment.
+- Follow the existing `spawnSync` harness style: pass complete child-process
+  environments and use hooks like `BALLIN_TEST_CONFIG_PATH`,
+  `BALLIN_UNINSTALL_TEST_SYSTEM_ROOT`, and command-log stubs before adding new
+  test escape hatches.
 
-## Shell script guidance
+## Shell and config changes
 
 - Preserve existing user-facing behavior unless the issue explicitly asks for a
   behavior change.
 - Be careful with quoting, globbing, and paths that may contain spaces.
 - Keep files under `bin/` and `install.sh` executable.
-- Prefer explicit checks and clear failure messages for operations that touch
-  user config, symlinks, package managers, network-backed tools, or system update
-  commands.
-- For install, uninstall, update, Gist, symlink, package-manager, or system
-  update behavior, add or update tests that use temporary paths and stubs rather
-  than the real user environment.
-
-## Config guidance
-
 - Keep `config/.defaultConfig.json`, `config/updateConfig.js`, and config tests
   in sync when adding or changing settings.
 - Document user-facing optional behavior in `docs/optional-capabilities.md` when

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,5 +34,4 @@ the shell scripts and configuration helpers.
 - Keep `config/.defaultConfig.json`, `config/updateConfig.js`, and config tests
   in sync when adding or changing settings.
 - Update `docs/optional-capabilities.md` when optional setup, integrations,
-  dependencies, or user-facing settings change, especially for `up`, `gu`,
-  install, or update behavior.
+  dependencies, or user-facing `up` settings change.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,6 +44,13 @@ the shell scripts and config helpers.
 - When adding behavior that can affect the user's environment, add or update
   tests that prove it stays confined to the test harness.
 
+## Config guidance
+
+- Keep `config/.defaultConfig.json`, `config/updateConfig.js`, and config tests
+  in sync when adding or changing settings.
+- Document user-facing optional behavior in `docs/optional-capabilities.md` when
+  a setting changes how `up`, `gu`, install, or update commands behave.
+
 ## Git hygiene
 
 - Inspect the worktree before editing and preserve unrelated user changes.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,8 +22,8 @@ the shell scripts and config helpers.
 ## Testing and safety
 
 - Do not run install, uninstall, `up`, `gu`, Homebrew, Gist, GitHub, npm-global,
-  `softwareupdate`, symlink, or network-affecting behavior against the real user
-  environment.
+  `softwareupdate`, symlink, or other network-affecting operations against the
+  real user environment.
 - Tests for install, uninstall, `up`, `gu`, Homebrew, Gist, GitHub, npm-global,
   `softwareupdate`, symlink, or network-affecting behavior must use temporary
   directories, fixture files, complete child-process environments, and command

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,13 +21,15 @@ the shell scripts and config helpers.
 
 ## Testing and safety
 
-- Tests for install, uninstall, `up`, `gu`, Homebrew, Gist, GitHub, npm,
-  `softwareupdate`, symlinks, or network behavior must use temporary directories,
-  fixture files, and command stubs instead of the real user environment.
-- Follow the existing `spawnSync` harness style: pass complete child-process
-  environments and use hooks like `BALLIN_TEST_CONFIG_PATH`,
-  `BALLIN_UNINSTALL_TEST_SYSTEM_ROOT`, and command-log stubs before adding new
-  test escape hatches.
+- Do not run install, uninstall, `up`, `gu`, Homebrew, Gist, GitHub, npm-global,
+  `softwareupdate`, symlink, or network-affecting behavior against the real user
+  environment unless the issue explicitly asks for it.
+- Tests for those paths must use temporary directories, fixture files, complete
+  child-process environments, and command stubs instead of the real user
+  environment.
+- Follow the existing `spawnSync` harness style and hooks like
+  `BALLIN_TEST_CONFIG_PATH`, `BALLIN_UNINSTALL_TEST_SYSTEM_ROOT`, and command-log
+  stubs before adding new test escape hatches.
 
 ## Shell and config changes
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,12 +12,6 @@ the shell scripts and configuration helpers.
 - Use the Node.js version from `.nvmrc`.
 - Install dependencies with `npm ci`.
 - Run `npm test` after changes to code, config, scripts, or tests.
-- CI also runs this empty-tree whitespace check; use it locally when investigating
-  whitespace failures:
-
-  ```sh
-  git diff --check "$(git hash-object -t tree /dev/null)" HEAD
-  ```
 
 ## Testing and safety
 
@@ -39,5 +33,6 @@ the shell scripts and configuration helpers.
   executable modes on `bin/*` and `install.sh`.
 - Keep `config/.defaultConfig.json`, `config/updateConfig.js`, and config tests
   in sync when adding or changing settings.
-- Document user-facing optional behavior in `docs/optional-capabilities.md` when
-  a setting changes how `up`, `gu`, install, or update commands behave.
+- Document new or changed user-facing configuration options in
+  `docs/optional-capabilities.md`, including settings that affect `up`, `gu`,
+  install, or update commands.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,10 +23,11 @@ the shell scripts and config helpers.
 
 - Do not run install, uninstall, `up`, `gu`, Homebrew, Gist, GitHub, npm-global,
   `softwareupdate`, symlink, or network-affecting behavior against the real user
-  environment unless the issue explicitly asks for it.
-- Tests for those paths must use temporary directories, fixture files, complete
-  child-process environments, and command stubs instead of the real user
   environment.
+- Tests for install, uninstall, `up`, `gu`, Homebrew, Gist, GitHub, npm-global,
+  `softwareupdate`, symlink, or network-affecting behavior must use temporary
+  directories, fixture files, complete child-process environments, and command
+  stubs instead of the real user environment.
 - Follow the existing `spawnSync` harness style and hooks like
   `BALLIN_TEST_CONFIG_PATH`, `BALLIN_UNINSTALL_TEST_SYSTEM_ROOT`, and command-log
   stubs before adding new test escape hatches.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,10 +10,9 @@ the shell scripts and config helpers.
 ## Development workflow
 
 - Use the Node.js version from `.nvmrc`.
-- Install dependencies with `npm ci` for a clean, lockfile-based install. Use
-  `npm install` only when intentionally updating dependencies.
-- If using a git worktree, treat it like a fresh checkout; there is no
-  repo-specific worktree setup beyond installing dependencies in that checkout.
+- Install dependencies with `npm ci`.
+- Git worktrees need no special setup beyond installing dependencies in the
+  worktree checkout.
 - Run checks based on the change: `npm test` for code, config, script, or test
   changes; the CI whitespace check is enough for docs-only changes.
 
@@ -32,8 +31,6 @@ the shell scripts and config helpers.
 - Use the existing test escape hatches, such as `BALLIN_TEST_CONFIG_PATH`,
   `BALLIN_UNINSTALL_TEST_SYSTEM_ROOT`, and command-log stubs, before adding new
   ones.
-- Keep tests deterministic and avoid depending on the developer machine's actual
-  installed tools, global packages, Homebrew state, Gists, or dotfiles.
 
 ## Shell script guidance
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,4 +34,4 @@ the shell scripts and configuration helpers.
 - Keep `config/.defaultConfig.json`, `config/updateConfig.js`, and config tests
   in sync when adding or changing settings.
 - Update `docs/optional-capabilities.md` when optional setup, integrations,
-  dependencies, or user-facing `up` settings change.
+  dependencies, or documented settings change.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,55 @@
+# AGENTS.md
+
+## Repository Context
+
+`ballin-scripts` is a small personal automation toolkit. Most user-facing behavior
+lives in Bash scripts under `bin/` and in `install.sh`. The Node.js layer in
+`config/` manages `ballin.config.json`, and the Mocha tests in `test/` exercise
+the shell scripts and config helpers.
+
+## Development Workflow
+
+- Use the Node.js version from `.nvmrc`.
+- Install dependencies with `npm ci`.
+- Run the full local check with `npm test`; this runs ESLint and Mocha.
+- Before opening a PR, also run the whitespace check used by CI:
+
+  ```sh
+  git diff --check "$(git hash-object -t tree /dev/null)" HEAD
+  ```
+
+## Testing And Safety
+
+- Keep tests isolated from the real developer machine. Use temporary directories,
+  fixture files, and command stubs instead of real Homebrew, Gist, GitHub, npm,
+  macOS update, install, or uninstall behavior.
+- Pass complete child-process environments in tests when that prevents real
+  credentials, tools, config, or shell state from leaking in.
+- Use the existing test escape hatches, such as `BALLIN_TEST_CONFIG_PATH`,
+  `BALLIN_UNINSTALL_TEST_SYSTEM_ROOT`, and command-log stubs, before adding new
+  ones.
+- Keep tests deterministic and avoid depending on the developer machine's actual
+  installed tools, global packages, Homebrew state, Gists, or dotfiles.
+
+## Shell Script Guidance
+
+- Preserve existing user-facing behavior unless the issue explicitly asks for a
+  behavior change.
+- Be careful with quoting, globbing, and paths that may contain spaces.
+- Prefer explicit checks and clear failure messages for operations that touch
+  user config, symlinks, package managers, network-backed tools, or system update
+  commands.
+- When adding behavior that can affect the user's environment, add or update
+  tests that prove it stays confined to the test harness.
+
+## Git Hygiene
+
+- Inspect the worktree before editing and preserve unrelated user changes.
+- Keep commits focused on the issue being addressed.
+- Do not encode personal Codex/session workflow preferences here; keep this file
+  limited to durable repository guidance.
+
+## PR Notes
+
+When opening a PR, include the issue being addressed, a concise summary of
+behavior changes, and the local checks that were run.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,13 +1,13 @@
 # AGENTS.md
 
-## Repository Context
+## Repository context
 
 `ballin-scripts` is a small personal automation toolkit. Most user-facing behavior
 lives in Bash scripts under `bin/` and in `install.sh`. The Node.js layer in
 `config/` manages `ballin.config.json`, and the Mocha tests in `test/` exercise
 the shell scripts and config helpers.
 
-## Development Workflow
+## Development workflow
 
 - Use the Node.js version from `.nvmrc`.
 - Install dependencies with `npm ci`.
@@ -18,38 +18,40 @@ the shell scripts and config helpers.
   git diff --check "$(git hash-object -t tree /dev/null)" HEAD
   ```
 
-## Testing And Safety
+## Testing and safety
 
 - Keep tests isolated from the real developer machine. Use temporary directories,
   fixture files, and command stubs instead of real Homebrew, Gist, GitHub, npm,
-  macOS update, install, or uninstall behavior.
-- Pass complete child-process environments in tests when that prevents real
-  credentials, tools, config, or shell state from leaking in.
+  macOS update, install, uninstall, or network behavior.
+- Follow the existing `spawnSync` test style: pass complete child-process
+  environments when that prevents real credentials, tools, config, or shell
+  state from leaking in.
 - Use the existing test escape hatches, such as `BALLIN_TEST_CONFIG_PATH`,
   `BALLIN_UNINSTALL_TEST_SYSTEM_ROOT`, and command-log stubs, before adding new
   ones.
 - Keep tests deterministic and avoid depending on the developer machine's actual
   installed tools, global packages, Homebrew state, Gists, or dotfiles.
 
-## Shell Script Guidance
+## Shell script guidance
 
 - Preserve existing user-facing behavior unless the issue explicitly asks for a
   behavior change.
 - Be careful with quoting, globbing, and paths that may contain spaces.
+- Preserve executable bits on files under `bin/` and on `install.sh`.
 - Prefer explicit checks and clear failure messages for operations that touch
   user config, symlinks, package managers, network-backed tools, or system update
   commands.
 - When adding behavior that can affect the user's environment, add or update
   tests that prove it stays confined to the test harness.
 
-## Git Hygiene
+## Git hygiene
 
 - Inspect the worktree before editing and preserve unrelated user changes.
 - Keep commits focused on the issue being addressed.
 - Do not encode personal Codex/session workflow preferences here; keep this file
   limited to durable repository guidance.
 
-## PR Notes
+## PR notes
 
 When opening a PR, include the issue being addressed, a concise summary of
 behavior changes, and the local checks that were run.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,21 +31,10 @@ the shell scripts and config helpers.
 
 ## Shell and config changes
 
-- Preserve existing user-facing behavior unless the issue explicitly asks for a
-  behavior change.
-- Be careful with quoting, globbing, and paths that may contain spaces.
-- Keep files under `bin/` and `install.sh` executable.
+- For shell changes, preserve CLI output and side effects unless the issue asks
+  for behavior changes; watch quoting, globbing, paths with spaces, and
+  executable modes on `bin/*` and `install.sh`.
 - Keep `config/.defaultConfig.json`, `config/updateConfig.js`, and config tests
   in sync when adding or changing settings.
 - Document user-facing optional behavior in `docs/optional-capabilities.md` when
   a setting changes how `up`, `gu`, install, or update commands behave.
-
-## Git hygiene
-
-- Inspect the worktree before editing and preserve unrelated user changes.
-- Keep commits focused on the issue being addressed.
-
-## PR notes
-
-When opening a PR, include the issue being addressed, a concise summary of
-behavior changes, and the local checks that were run.


### PR DESCRIPTION
## Summary

- Adds a root-level `AGENTS.md` for repo-specific AI contributor guidance.
- Documents the project layout, local checks, isolated test expectations, and shell-script safety notes.
- Keeps Git guidance lightweight and avoids encoding personal Codex/session workflow rules as repo policy.

Closes #112.

## Checks

- `git diff --check "$(git hash-object -t tree /dev/null)" HEAD`
- `npm test`