### PR TITLE
[codex] Validate Bash syntax in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,11 @@ jobs:
       - name: Check whitespace
         run: git diff --check "$(git hash-object -t tree /dev/null)" HEAD
 
+      - name: Check Bash syntax
+        run: |
+          git grep -Ilz '^#!.*bash' -- . \
+            | xargs -0 -r bash -n
+
       - name: Set up Node.js
         uses: actions/setup-node@v6
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Check Bash syntax
         run: |
           git grep -Ilz '^#!.*bash' -- . \
-            | xargs -0 -r bash -n
+            | xargs -0 -r -n1 bash -n
 
       - name: Set up Node.js
         uses: actions/setup-node@v6


### PR DESCRIPTION
## Summary

- Add a CI step that discovers tracked Bash-shebang files with `git grep`.
- Run every discovered Bash script through `bash -n` before Node setup and dependency installation.

Closes #108.

## Validation

- `git grep -Ilz '^#!.*bash' -- . | xargs -0 -r bash -n`
- Temporary syntax error in `bin/ballin` exited nonzero with `bash -n`
- `npm test`