### PR TITLE
[codex] Use glob for extensionless ESLint target

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -12,15 +12,13 @@ const jsRules = {
   'no-console': 'error',
 };
 const tsFiles = ['config/**/*.ts', 'test/**/*.ts'];
-const isBallinConfigBin = (filePath) => filePath.replaceAll('\\', '/').endsWith('/bin/ballin_config')
-  || filePath === 'bin/ballin_config';
 
 export default tseslint.config(
   {
     ignores: ['coverage/**'],
   },
   {
-    files: ['**/*.js', isBallinConfigBin],
+    files: ['**/*.js', 'bin/ballin_config'],
     ...js.configs.recommended,
     languageOptions: {
       ecmaVersion: 'latest',


### PR DESCRIPTION
## Summary

Addresses the review feedback from #129 by replacing the flat-config predicate matcher for `bin/ballin_config` with an exact glob pattern.

## Changes

- Removes the `isBallinConfigBin` predicate function
- Uses `files: ['**/*.js', 'bin/ballin_config']` for the CommonJS JS config block
- Keeps the extensionless Node executable linted without matching the Bash scripts in `bin/*`

## Validation

- `npx eslint --print-config bin/ballin_config` confirms the file still receives CommonJS JS rules
- `npm test` (`112 passing`)