### PR TITLE
[codex] Move ballin_config behind typed CLI shim

### DIFF
--- a/bin/ballin_config
+++ b/bin/ballin_config
@@ -1,6 +1,3 @@
 #!/usr/bin/env node
 
-const { configAction } = require('../config/index.ts');
-
-const [request, keys, value, ...other] = process.argv.slice(2);
-console.log(configAction(request, keys, value, other)); // eslint-disable-line no-console
+require('../config/cli.ts').runConfigCli();

--- a/config/cli.ts
+++ b/config/cli.ts
@@ -1,0 +1,17 @@
+const { configAction } = require('./index.ts');
+
+type ConfigCliArgs = string[];
+type WriteLine = (output: unknown) => void;
+
+const writeStdoutLine: WriteLine = (output) => {
+  console.log(output); // eslint-disable-line no-console
+};
+
+const runConfigCli = (args: ConfigCliArgs = process.argv.slice(2), writeLine: WriteLine = writeStdoutLine) => {
+  const [request, keys, value, ...other] = args;
+  writeLine(configAction(request, keys, value, other));
+};
+
+module.exports = {
+  runConfigCli,
+};

--- a/config/cli.ts
+++ b/config/cli.ts
@@ -1,15 +1,10 @@
 const { configAction } = require('./index.ts');
 
 type ConfigCliArgs = string[];
-type WriteLine = (output: unknown) => void;
 
-const writeStdoutLine: WriteLine = (output) => {
-  console.log(output); // eslint-disable-line no-console
-};
-
-const runConfigCli = (args: ConfigCliArgs = process.argv.slice(2), writeLine: WriteLine = writeStdoutLine) => {
+const runConfigCli = (args: ConfigCliArgs = process.argv.slice(2)) => {
   const [request, keys, value, ...other] = args;
-  writeLine(configAction(request, keys, value, other));
+  console.log(configAction(request, keys, value, other)); // eslint-disable-line no-console
 };
 
 module.exports = {

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -12,15 +12,13 @@ const jsRules = {
   'no-console': 'error',
 };
 const tsFiles = ['config/**/*.ts', 'test/**/*.ts'];
-const isBallinConfigBin = (filePath) => filePath.replaceAll('\\', '/').endsWith('/bin/ballin_config')
-  || filePath === 'bin/ballin_config';
 
 export default tseslint.config(
   {
     ignores: ['coverage/**'],
   },
   {
-    files: ['**/*.js', isBallinConfigBin],
+    files: ['**/*.js'],
     ...js.configs.recommended,
     languageOptions: {
       ecmaVersion: 'latest',

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "Useful scripts to save time",
   "scripts": {
-    "lint": "eslint . bin/ballin_config",
+    "lint": "eslint .",
     "typecheck": "tsc --noEmit",
     "test:unit": "mocha",
     "test": "npm run lint && npm run typecheck && npm run test:unit"


### PR DESCRIPTION
## Summary

- add `config/cli.ts` as the typed CLI entrypoint for `ballin_config`
- keep `bin/ballin_config` as a tiny extensionless shebang shim
- remove the `bin/ballin_config` lint script and ESLint flat-config special handling

## Why

Issue #132 tracks using `bin/ballin_config` as the first proof of concept for the stable `bin/*` shim architecture from #130. This keeps the user-facing command and installed symlink behavior stable while moving the executable logic into TypeScript-managed source.

## Validation

- `npm test`

Closes #132