### PR TITLE
[codex] Clarify contributor guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,42 @@ the shell scripts and configuration helpers.
   `BALLIN_TEST_CONFIG_PATH`, `BALLIN_UNINSTALL_TEST_SYSTEM_ROOT`, and command-log
   stubs before adding new test escape hatches.
 
+## Command implementation layout
+
+- User-facing commands keep their stable, extensionless names under `bin/`.
+  When a command needs Node.js implementation code, keep the `bin/*` file as a
+  small shim and put the typed implementation next to the feature it owns. The
+  first proof of concept is `bin/ballin_config`, which loads `config/cli.ts`
+  beside the config helpers it orchestrates.
+- Use the feature-local pattern first (`config/`, a future command-specific
+  folder, or another existing domain folder) instead of adding a top-level
+  `commands/` or `src/commands/` directory. Introduce a shared command directory
+  only after several migrated commands need common structure that feature-local
+  folders cannot provide cleanly.
+- Node-backed command modules should export a runner such as
+  `runConfigCli(args)`. The runner should accept parsed arguments, default to
+  `process.argv.slice(2)` only at the CLI boundary, and return or print through
+  a narrow boundary that is easy to exercise from tests.
+- Keep file IO, environment reads, and child-process calls in helper functions
+  that can be pointed at fixtures or command stubs, using the existing test
+  hooks before adding new ones.
+- Shims should stay intentionally small:
+
+  ```js
+  #!/usr/bin/env node
+
+  require('../feature/cli.ts').runFeatureCli();
+  ```
+
+  This CommonJS `require()` style is intentional while the project relies on
+  Node.js 24 native TypeScript type stripping.
+- When migrating or adding a command, keep the installed command name and
+  executable mode stable in `bin/`, expose implementation functions that tests
+  can import directly, and cover user-facing shims with shebang and
+  installed-symlink execution tests.
+- See issue #132 for the `ballin_config` proof of concept and issue #130 for
+  the parent shim architecture tracker.
+
 ## Shell, config, and docs
 
 - For shell changes, preserve CLI output and side effects unless the issue asks

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,9 @@ the shell scripts and configuration helpers.
 
 - Use the Node.js version from `.nvmrc`.
 - Install dependencies with `npm ci`.
-- Run `npm test` after changes to code, config, scripts, or tests.
+- Run `npm test` after changes to code, config, scripts, or tests. For docs-only
+  changes, prefer `git diff --check` unless the docs change setup, commands, or
+  other user-facing behavior expectations.
 - TypeScript is checked with `tsc --noEmit` as part of `npm test`; production
   commands must remain runnable directly by Node without generated JavaScript,
   `dist/`, `ts-node`, `tsx`, Babel, or a bundler.
@@ -34,9 +36,9 @@ the shell scripts and configuration helpers.
 - For shell changes, preserve CLI output and side effects unless the issue asks
   for behavior changes; watch quoting, globbing, paths with spaces, and
   executable modes on `bin/*` and `install.sh`.
-- Keep extensionless `bin/*` commands and Node-backed entrypoints stable unless
-  a change intentionally updates their public behavior. Cover user-facing
-  command shims with shebang and installed-symlink execution tests.
+- Keep extensionless `bin/*` commands stable unless a change intentionally
+  updates their public behavior. Preserve executable modes and existing
+  shebang/symlink coverage for user-facing commands.
 - Keep `config/.defaultConfig.json`, `config/updateConfig.ts`, and config tests
   in sync when adding or changing settings.
 - `docs/optional-capabilities.md` covers Node.js setup, optional integrations,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,9 +35,8 @@ the shell scripts and configuration helpers.
   for behavior changes; watch quoting, globbing, paths with spaces, and
   executable modes on `bin/*` and `install.sh`.
 - Keep extensionless `bin/*` commands and Node-backed entrypoints stable unless
-  a change intentionally updates their public behavior. If a command delegates
-  to Node.js code, keep the `bin/*` file as a small shim and cover user-facing
-  shims with shebang and installed-symlink execution tests.
+  a change intentionally updates their public behavior. Cover user-facing
+  command shims with shebang and installed-symlink execution tests.
 - Keep `config/.defaultConfig.json`, `config/updateConfig.ts`, and config tests
   in sync when adding or changing settings.
 - `docs/optional-capabilities.md` covers Node.js setup, optional integrations,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,9 +34,11 @@ the shell scripts and configuration helpers.
 - For shell changes, preserve CLI output and side effects unless the issue asks
   for behavior changes; watch quoting, globbing, paths with spaces, and
   executable modes on `bin/*` and `install.sh`.
-- Keep extensionless `bin/*` commands stable unless a change intentionally
-  updates their public behavior. Preserve executable modes and existing
-  shebang/symlink coverage for user-facing commands.
+- Keep extensionless `bin/*` commands and Node-backed command entrypoints
+  stable unless a change intentionally updates their public behavior.
+  TypeScript source under `config/` is executed directly by Node. Preserve
+  executable modes and existing shebang/symlink coverage for user-facing
+  commands.
 - Keep `config/.defaultConfig.json`, `config/updateConfig.ts`, and config tests
   in sync when adding or changing settings.
 - `docs/optional-capabilities.md` covers Node.js setup, optional integrations,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,8 +11,7 @@ the shell scripts and configuration helpers.
 
 - Use the Node.js version from `.nvmrc`.
 - Install dependencies with `npm ci`.
-- Run `npm test` after changes to code, config, scripts, or tests. For docs-only
-  changes, use `git diff --check`.
+- Run `npm test` after changes to code, config, scripts, or tests.
 - TypeScript is checked with `tsc --noEmit` as part of `npm test`; production
   commands must remain runnable directly by Node without generated JavaScript,
   `dist/`, `ts-node`, `tsx`, Babel, or a bundler.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,9 +34,10 @@ the shell scripts and configuration helpers.
 - For shell changes, preserve CLI output and side effects unless the issue asks
   for behavior changes; watch quoting, globbing, paths with spaces, and
   executable modes on `bin/*` and `install.sh`.
-- Keep extensionless `bin/*` commands stable. If a command delegates to Node.js
-  code, keep the `bin/*` file as a tiny shim and cover user-facing shims with
-  shebang and installed-symlink execution tests.
+- Keep extensionless `bin/*` commands and Node-backed entrypoints stable unless
+  a change intentionally updates their public behavior. If a command delegates
+  to Node.js code, keep the `bin/*` file as a small shim and cover user-facing
+  shims with shebang and installed-symlink execution tests.
 - Keep `config/.defaultConfig.json`, `config/updateConfig.ts`, and config tests
   in sync when adding or changing settings.
 - `docs/optional-capabilities.md` covers Node.js setup, optional integrations,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,45 +29,14 @@ the shell scripts and configuration helpers.
   `BALLIN_TEST_CONFIG_PATH`, `BALLIN_UNINSTALL_TEST_SYSTEM_ROOT`, and command-log
   stubs before adding new test escape hatches.
 
-## Command shims and typed code
-
-- Keep user-facing command names stable and extensionless under `bin/`. Treat
-  those files as the installed command surface, even when their implementation
-  moves elsewhere.
-- When a `bin/*` command delegates to Node.js code, prefer a tiny shim that
-  loads a typed module from the feature area that owns the behavior. The current
-  proof of concept is `bin/ballin_config` delegating to `config/cli.ts`.
-- Keep typed command modules directly executable by Node.js 24 native
-  type-stripping. Do not introduce production build output or runtime loaders
-  such as `dist/`, `ts-node`, `tsx`, Babel, or a bundler.
-- Export a small runner such as `runConfigCli(args)` from Node-backed command
-  modules. Default to `process.argv.slice(2)` only at the CLI boundary so tests
-  can call the runner or lower-level helpers with explicit inputs.
-- Keep process IO, environment reads, file IO, and child-process calls behind
-  narrow helpers that tests can point at fixtures, isolated environments, or
-  command stubs. Reuse existing test hooks before adding new escape hatches.
-- Cover user-facing Node shims with both direct shebang execution and
-  installed-symlink execution tests.
-- Use feature-local implementation files first (`config/`, a future
-  command-specific folder, or another existing domain folder). If a migration
-  seems to need a shared top-level command directory, capture that decision in
-  the shim architecture tracker before adding the directory.
-- Shim shape for Node-backed commands:
-
-  ```js
-  #!/usr/bin/env node
-
-  require('../feature/cli.ts').runFeatureCli();
-  ```
-
-- Issue #130 tracks the broader shim architecture. Issue #132 is the
-  `ballin_config` proof of concept.
-
 ## Shell, config, and docs
 
 - For shell changes, preserve CLI output and side effects unless the issue asks
   for behavior changes; watch quoting, globbing, paths with spaces, and
   executable modes on `bin/*` and `install.sh`.
+- Keep extensionless `bin/*` commands stable. If a command delegates to Node.js
+  code, keep the `bin/*` file as a tiny shim and cover user-facing shims with
+  shebang and installed-symlink execution tests.
 - Keep `config/.defaultConfig.json`, `config/updateConfig.ts`, and config tests
   in sync when adding or changing settings.
 - `docs/optional-capabilities.md` covers Node.js setup, optional integrations,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,8 +12,7 @@ the shell scripts and configuration helpers.
 - Use the Node.js version from `.nvmrc`.
 - Install dependencies with `npm ci`.
 - Run `npm test` after changes to code, config, scripts, or tests. For docs-only
-  changes, prefer `git diff --check` unless the docs change setup, commands, or
-  other user-facing behavior expectations.
+  changes, use `git diff --check`.
 - TypeScript is checked with `tsc --noEmit` as part of `npm test`; production
   commands must remain runnable directly by Node without generated JavaScript,
   `dist/`, `ts-node`, `tsx`, Babel, or a bundler.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,26 +29,30 @@ the shell scripts and configuration helpers.
   `BALLIN_TEST_CONFIG_PATH`, `BALLIN_UNINSTALL_TEST_SYSTEM_ROOT`, and command-log
   stubs before adding new test escape hatches.
 
-## Command implementation layout
+## Command shims and typed code
 
-- User-facing commands keep their stable, extensionless names under `bin/`.
-  When a command needs Node.js implementation code, keep the `bin/*` file as a
-  small shim and put the typed implementation next to the feature it owns. The
-  first proof of concept is `bin/ballin_config`, which loads `config/cli.ts`
-  beside the config helpers it orchestrates.
-- Use the feature-local pattern first (`config/`, a future command-specific
-  folder, or another existing domain folder) instead of adding a top-level
-  `commands/` or `src/commands/` directory. Introduce a shared command directory
-  only after several migrated commands need common structure that feature-local
-  folders cannot provide cleanly.
-- Node-backed command modules should export a runner such as
-  `runConfigCli(args)`. The runner should accept parsed arguments, default to
-  `process.argv.slice(2)` only at the CLI boundary, and return or print through
-  a narrow boundary that is easy to exercise from tests.
-- Keep file IO, environment reads, and child-process calls in helper functions
-  that can be pointed at fixtures or command stubs, using the existing test
-  hooks before adding new ones.
-- Shims should stay intentionally small:
+- Keep user-facing command names stable and extensionless under `bin/`. Treat
+  those files as the installed command surface, even when their implementation
+  moves elsewhere.
+- When a `bin/*` command delegates to Node.js code, prefer a tiny shim that
+  loads a typed module from the feature area that owns the behavior. The current
+  proof of concept is `bin/ballin_config` delegating to `config/cli.ts`.
+- Keep typed command modules directly executable by Node.js 24 native
+  type-stripping. Do not introduce production build output or runtime loaders
+  such as `dist/`, `ts-node`, `tsx`, Babel, or a bundler.
+- Export a small runner such as `runConfigCli(args)` from Node-backed command
+  modules. Default to `process.argv.slice(2)` only at the CLI boundary so tests
+  can call the runner or lower-level helpers with explicit inputs.
+- Keep process IO, environment reads, file IO, and child-process calls behind
+  narrow helpers that tests can point at fixtures, isolated environments, or
+  command stubs. Reuse existing test hooks before adding new escape hatches.
+- Cover user-facing Node shims with both direct shebang execution and
+  installed-symlink execution tests.
+- Use feature-local implementation files first (`config/`, a future
+  command-specific folder, or another existing domain folder). If a migration
+  seems to need a shared top-level command directory, capture that decision in
+  the shim architecture tracker before adding the directory.
+- Shim shape for Node-backed commands:
 
   ```js
   #!/usr/bin/env node
@@ -56,23 +60,14 @@ the shell scripts and configuration helpers.
   require('../feature/cli.ts').runFeatureCli();
   ```
 
-  This CommonJS `require()` style is intentional while the project relies on
-  Node.js 24 native TypeScript type stripping.
-- When migrating or adding a command, keep the installed command name and
-  executable mode stable in `bin/`, expose implementation functions that tests
-  can import directly, and cover user-facing shims with shebang and
-  installed-symlink execution tests.
-- See issue #132 for the `ballin_config` proof of concept and issue #130 for
-  the parent shim architecture tracker.
+- Issue #130 tracks the broader shim architecture. Issue #132 is the
+  `ballin_config` proof of concept.
 
 ## Shell, config, and docs
 
 - For shell changes, preserve CLI output and side effects unless the issue asks
   for behavior changes; watch quoting, globbing, paths with spaces, and
   executable modes on `bin/*` and `install.sh`.
-- Keep extensionless `bin/*` commands and Node-backed command entrypoints
-  stable unless a change intentionally updates their public behavior.
-  TypeScript source under `config/` is executed directly by Node.
 - Keep `config/.defaultConfig.json`, `config/updateConfig.ts`, and config tests
   in sync when adding or changing settings.
 - `docs/optional-capabilities.md` covers Node.js setup, optional integrations,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,7 @@ $ npm test
 $ git push fork $BRANCH_NAME
 ```
 
-For repo-specific development context and automation guidance, see
+For extra repo context, testing notes, and automation guardrails, see
 [AGENTS.md](AGENTS.md).
 
 ## Suggestions Welcome

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,7 @@ $ npm test
 $ git push fork $BRANCH_NAME
 ```
 
-For extra repo context, testing notes, and automation guardrails, see
+For extra repo context that is useful when changing scripts or automation, see
 [AGENTS.md](AGENTS.md).
 
 ## Suggestions Welcome

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,8 +19,7 @@ $ npm test
 $ git push fork $BRANCH_NAME
 ```
 
-For extra repo context that is useful when changing scripts or automation, see
-[AGENTS.md](AGENTS.md).
+For more repo context, see [AGENTS.md](AGENTS.md).
 
 ## Suggestions Welcome
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,53 +19,7 @@ $ npm test
 $ git push fork $BRANCH_NAME
 ```
 
-## Command Layout
-
-User-facing commands should keep their stable, extensionless names under `bin/`.
-When a command needs Node.js implementation code, keep the `bin/*` file as a
-small shim and put the typed implementation next to the feature it owns. For
-example, `bin/ballin_config` loads `config/cli.ts`, which lives beside the
-config helpers it orchestrates.
-
-Use that feature-local pattern first (`config/`, a future command-specific
-folder, or another existing domain folder) instead of adding a top-level
-`commands/` or `src/commands/` directory. Introduce a shared command directory
-only after several migrated commands need common structure that feature-local
-folders cannot provide cleanly.
-
-Node-backed command modules should export a runner such as `runConfigCli(args)`.
-The runner should accept parsed arguments, default to `process.argv.slice(2)`
-only at the CLI boundary, and return or print through a narrow boundary that is
-easy to exercise from tests. Keep file IO, environment reads, and child-process
-calls in helper functions that can be pointed at fixtures or command stubs, using
-the existing test hooks before adding new ones.
-
-Shims should stay intentionally small:
-
-```js
-#!/usr/bin/env node
-
-require('../feature/cli.ts').runFeatureCli();
-```
-
-This CommonJS `require()` style is intentional while the project relies on
-Node.js 24 native TypeScript type stripping. Do not add generated JavaScript,
-`dist/`, `ts-node`, `tsx`, Babel, or a bundler for production commands.
-
-When migrating or adding a command:
-
-- keep the installed command name and executable mode stable in `bin/`;
-- expose implementation functions that tests can import directly;
-- cover the shim with shebang and installed-symlink execution tests when the
-  command is user-facing;
-- use temporary directories, isolated environments, and command stubs for tests
-  that touch install, uninstall, Homebrew, GitHub, Gist, npm-global, symlink, or
-  other network-affecting behavior;
-- update user-facing docs when configuration, dependencies, or optional
-  integrations change.
-
-The first proof of concept for this convention is the `ballin_config` migration
-from [issue #132](https://github.com/JBallin/ballin-scripts/issues/132).
+Command implementation conventions live in [AGENTS.md](AGENTS.md).
 
 ## Suggestions Welcome
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,6 +19,54 @@ $ npm test
 $ git push fork $BRANCH_NAME
 ```
 
+## Command Layout
+
+User-facing commands should keep their stable, extensionless names under `bin/`.
+When a command needs Node.js implementation code, keep the `bin/*` file as a
+small shim and put the typed implementation next to the feature it owns. For
+example, `bin/ballin_config` loads `config/cli.ts`, which lives beside the
+config helpers it orchestrates.
+
+Use that feature-local pattern first (`config/`, a future command-specific
+folder, or another existing domain folder) instead of adding a top-level
+`commands/` or `src/commands/` directory. Introduce a shared command directory
+only after several migrated commands need common structure that feature-local
+folders cannot provide cleanly.
+
+Node-backed command modules should export a runner such as `runConfigCli(args)`.
+The runner should accept parsed arguments, default to `process.argv.slice(2)`
+only at the CLI boundary, and return or print through a narrow boundary that is
+easy to exercise from tests. Keep file IO, environment reads, and child-process
+calls in helper functions that can be pointed at fixtures or command stubs, using
+the existing test hooks before adding new ones.
+
+Shims should stay intentionally small:
+
+```js
+#!/usr/bin/env node
+
+require('../feature/cli.ts').runFeatureCli();
+```
+
+This CommonJS `require()` style is intentional while the project relies on
+Node.js 24 native TypeScript type stripping. Do not add generated JavaScript,
+`dist/`, `ts-node`, `tsx`, Babel, or a bundler for production commands.
+
+When migrating or adding a command:
+
+- keep the installed command name and executable mode stable in `bin/`;
+- expose implementation functions that tests can import directly;
+- cover the shim with shebang and installed-symlink execution tests when the
+  command is user-facing;
+- use temporary directories, isolated environments, and command stubs for tests
+  that touch install, uninstall, Homebrew, GitHub, Gist, npm-global, symlink, or
+  other network-affecting behavior;
+- update user-facing docs when configuration, dependencies, or optional
+  integrations change.
+
+The first proof of concept for this convention is the `ballin_config` migration
+from [issue #132](https://github.com/JBallin/ballin-scripts/issues/132).
+
 ## Suggestions Welcome
 
 Please open issues (or PR's) with any suggestions for additions to `gu`/`up` or anything else.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,8 @@ $ npm test
 $ git push fork $BRANCH_NAME
 ```
 
-Command implementation conventions live in [AGENTS.md](AGENTS.md).
+For repo-specific development context and automation guidance, see
+[AGENTS.md](AGENTS.md).
 
 ## Suggestions Welcome
 


### PR DESCRIPTION
## Summary

- add a concise `CONTRIBUTING.md` pointer to `AGENTS.md` for extra repo context
- keep `AGENTS.md` guidance focused on preserving stable command entrypoints, direct Node execution for config TypeScript, executable modes, and existing user-facing command execution coverage

## Validation

- Not run; docs-only changes.