### PR TITLE
[codex] Remove tracked TODO comments

### DIFF
--- a/bin/gu
+++ b/bin/gu
@@ -1,18 +1,7 @@
 #!/usr/bin/env bash
 
-# TODO:
-  # function that takes a filename and reads the gist using 'gist -r'
-    # function to display names of the files?
-  # INIT:
-    # log in to gist
-    # create gist and save id in config
-  # give error if id/sn null or if gist -r $id gives error?
-    # need to make sure that the gist with that $id actually exists...tell them to run init?
-    # or maybe just run it for them now?
-
 id=$(ballin_config get gu.id)
 url="$(ballin_config get gu.url)/$id"
-# TODO: generate file_suggestions based on API response from GitHub gist instead of hard-coding all of them
 file_suggestions='
   ballin_config
   bash_completions
@@ -43,8 +32,6 @@ file_suggestions='
   vsI_settings
   zprofile.sh
   zshrc.sh'
-
-### TODO handle error when $id fails github API (check response code) (either nonexistant, deleted gist, skipped init etc)
 
 # make sure given at least one argument
 if ! gist -r "$id" > /dev/null; then
@@ -79,7 +66,6 @@ else
     if [ ! -d .gu-cache ]; then mkdir .gu-cache; fi
   )
 
-  # TODO: consider refactor to pass command arrays as $input instead of a string for safer execution.
   u() {
     local file_name=$1
     local cache_file="$HOME/.ballin-scripts/.gu-cache/$file_name"
@@ -240,12 +226,6 @@ else
     if [ -x "$(command -v npm)" ]; then
       u 'npm_global' 'npm list -g --depth=0'
     fi
-
-    # YARN
-    # TODO: remove last line (Done) which varies based on time
-    # if [ -x "$(command -v npm)" ]; then
-    #   u 'yarn_global' "yarn global list --depth=0 | sed '$d'"
-    # fi
 
     # NVM
     if [ -f .nvmrc ]; then

--- a/bin/up
+++ b/bin/up
@@ -40,19 +40,6 @@ if [ -x "$(command -v npm)" ] && [ "$(ballin_config get up.npm)" = 'true' ]; the
   npm update -g
 fi
 
-# TODO: fix pip/pip3
-### PIP
-# update pip
-# if [ -x "$(command -v pip)" ]; then
-#   pip install -U pip
-# fi
-
-### PIP3
-# update pip3
-# if [ -x "$(command -v pip3)" ]; then
-#   pip3 install -U pip
-# fi
-
 ### Mac App Store
 if [ -x "$(command -v mas)" ]; then
   progress 'Updating App Store apps'

--- a/install.sh
+++ b/install.sh
@@ -157,7 +157,6 @@ done
             printf '\n%s\n' '👍 Storing your previous gist ID in your config:'
             "$ballin_config" set gu.id "$GIST_ID"
             VALID_GIST_ID=0
-            # TODO: overwrite ballin.config.json config file from ballin.config.json in gist (if it exists) and echo that to user (both action and the stored config?). what if there were updates to the default though? maybe just copy the default and then overwrite any values that exist in the previous ballin.config.json
           else
             printf "\n⚠️  INVALID: Expected \e[1mgist -r '%s'\e[0m to output:\n%s\n" "$GIST_ID" "$GIST_DESCRIPTION"
           fi


### PR DESCRIPTION
## Summary

- remove the seven inline TODO comments audited in #122
- remove dead commented Yarn and pip/pip3 blocks whose follow-up decisions now live in GitHub issues
- preserve the exact original TODO text in the covering issues before removing it from the repo

## Follow-up Coverage

- #63 covers the initial `gu` Gist/setup TODO block and invalid/inaccessible Gist handling
- #138 covers the `gu` command-array migration risk
- #140 covers dynamic `gu read` suggestions
- #141 covers adopted-backup config restore policy
- #142 covers the `up` pip/pip3 support decision
- #143 covers the obsolete Yarn snapshot cleanup/replacement decision

Closes #122

## Validation

- `npm test`
