### PR TITLE
[codex] Add ShellCheck CI gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,16 @@ jobs:
           git grep -Ilz '^#!.*bash' -- . \
             | xargs -0 -r -n1 bash -n
 
+      - name: Install ShellCheck
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes shellcheck
+
+      - name: Run ShellCheck
+        run: |
+          git grep -Ilz '^#!.*bash' -- . \
+            | xargs -0 -r shellcheck
+
       - name: Set up Node.js
         uses: actions/setup-node@v6
         with:

--- a/install.sh
+++ b/install.sh
@@ -7,14 +7,19 @@ optional_capabilities_url='https://github.com/JBallin/ballin-scripts/blob/main/d
 required_node_version='24.12'
 
 ################################## CLONE REPO ##################################
-(
+if ! (
   cd "$HOME" || exit
   # only clone if folder doesn't already exist
   if [ ! -d '.ballin-scripts' ]; then
     echo ''
-    git clone https://github.com/JBallin/ballin-scripts.git .ballin-scripts
+    if ! git clone https://github.com/JBallin/ballin-scripts.git .ballin-scripts; then
+      exit 1
+    fi
   fi
-)
+); then
+  printf '\n⚠️  ERROR: Unable to prepare %s\n' "$repo_dir"
+  exit 1
+fi
 
 
 ############################## CHECK INITIAL SETUP #############################
@@ -137,7 +142,7 @@ while [ ! -f "$gist_token_path" ]; do
   chmod 600 "$gist_token_path"
 done
 
-  (
+  if ! (
     l1='### Backup of your dev environment'
     l2='Created by [ballin-scripts](https://github.com/JBallin/ballin-scripts)'
     GIST_DESCRIPTION="$l1\n$l2\n"
@@ -184,7 +189,10 @@ done
       unset GIST_URL GIST_ID l1 l2 GIST_DESCRIPTION
       rm '.MyConfig.md'
     fi
-  )
+  ); then
+    printf '\n⚠️  ERROR: Unable to configure Gist backup\n'
+    exit 1
+  fi
 
   ############################## SYMLINK BINARIES ##############################
   if ! mkdir -p "$bin_dir"; then

--- a/install.sh
+++ b/install.sh
@@ -8,7 +8,7 @@ required_node_version='24.12'
 
 ################################## CLONE REPO ##################################
 (
-  cd "$HOME"
+  cd "$HOME" || exit
   # only clone if folder doesn't already exist
   if [ ! -d '.ballin-scripts' ]; then
     echo ''
@@ -113,7 +113,7 @@ fi
 # Prompt user for GitHub URL and token until a valid token file is created
 while [ ! -f "$gist_token_path" ]; do
   printf '\n%s\n' "🙏 Please enter your Gist base URL (for example, 'https://gist.github.com' for personal accounts or 'https://gist.[your GitHub Enterprise domain]' for enterprise accounts):"
-  read -p 'URL: ' URL
+  read -rp 'URL: ' URL
   # Save entered URL to configuration
   "$ballin_config" set gu.url "$URL"
   gist_config_url="$("$ballin_config" get gu.url)"
@@ -128,7 +128,7 @@ while [ ! -f "$gist_token_path" ]; do
   printf '\n%s' "1. Go to github.com/settings/tokens/new (or the equivalent page on your GitHub Enterprise instance)"
   printf '\n%s' "2. Generate a new token with the 'gist' scope"
   printf '\n%s\n' '3. Copy the token and paste it here'
-  read -sp 'Token: ' TOKEN
+  read -rsp 'Token: ' TOKEN
   # Save entered token to file
   printf '%s\n' "$TOKEN" > "$gist_token_path"
   unset TOKEN
@@ -143,17 +143,17 @@ done
     GIST_DESCRIPTION="$l1\n$l2\n"
 
     ### CHECK IF USER ALREADY HAS GIST ID
-    cd "$repo_dir"
+    cd "$repo_dir" || exit
     if [ "$("$ballin_config" get gu.id)" = 'null' ]; then
       echo ''
-      read -p '🤔 Do you already have a ballin-scripts backup gist? [y/N] ' YN
+      read -rp '🤔 Do you already have a ballin-scripts backup gist? [y/N] ' YN
       if [[ $YN == 'y' || $YN == 'Y' ]]; then
         unset YN
         VALID_GIST_ID=1
         printf '\n%s\n' 'Welcome Back!'
         while [ "$VALID_GIST_ID" == 1 ]; do
-          read -ep 'Enter your gist ID: ' GIST_ID
-          if [ "$(gist -r "$GIST_ID")" == "$(printf "$GIST_DESCRIPTION")" ]; then
+          read -rep 'Enter your gist ID: ' GIST_ID
+          if [ "$(gist -r "$GIST_ID")" == "$(printf '%b' "$GIST_DESCRIPTION")" ]; then
             printf '\n%s\n' '👍 Storing your previous gist ID in your config:'
             "$ballin_config" set gu.id "$GIST_ID"
             VALID_GIST_ID=0
@@ -167,7 +167,7 @@ done
 
     ### GENERATE + STORE GIST ID
     if [ "$("$ballin_config" get gu.id)" = 'null' ]; then
-      printf "$GIST_DESCRIPTION" > '.MyConfig.md'
+      printf '%b' "$GIST_DESCRIPTION" > '.MyConfig.md'
 
       GIST_URL=$(gist -p '.MyConfig.md')
       printf "\n💥 Created a private gist titled '.MyConfig' at the following URL:\n%s\n" "$GIST_URL"


### PR DESCRIPTION
Closes #109.

## Summary

- Adds a CI ShellCheck gate after the existing `bash -n` syntax check.
- Keeps ShellCheck scoped to tracked Bash scripts via the same `git grep` discovery pattern as the syntax check.
- Fixes the current ShellCheck findings in `install.sh`: guarded `cd`, `read -r`, and safe `printf '%b'` usage for the intentionally escaped Gist description.
- Hardens the installer setup/Gist subshell boundaries so failed directory setup stops the installer instead of being treated as a lint-only cleanup.

## Validation

- `npx --yes shellcheck install.sh`
- `git grep -Ilz '^#!.*bash' -- . | xargs -0 -r -n1 bash -n`
- `npm run test:unit -- --grep install`
- `npm test`