### PR TITLE
[codex] Convert remaining Mocha tests to TypeScript

### DIFF
--- a/test/ballin.test.ts
+++ b/test/ballin.test.ts
@@ -5,9 +5,10 @@ const os = require('os');
 const path = require('path');
 
 const ballinPath = path.join(__dirname, '..', 'bin', 'ballin');
+type StringSpawnResult = import('child_process').SpawnSyncReturns<string>;
 
 describe('ballin', () => {
-  const assertHelpOutput = (result) => {
+  const assertHelpOutput = (result: StringSpawnResult) => {
     assert.equal(result.status, 0);
     assert.include(result.stdout, 'A Collection of Ballin Scripts!');
     assert.include(result.stdout, 'ballin_update');

--- a/test/ballin_update.test.ts
+++ b/test/ballin_update.test.ts
@@ -5,27 +5,31 @@ const os = require('os');
 const path = require('path');
 
 const updatePath = path.join(__dirname, '..', 'bin', 'ballin_update');
+type SpawnUpdateOverrides = Omit<
+  import('child_process').SpawnSyncOptionsWithStringEncoding,
+  'encoding' | 'env'
+>;
 
 describe('ballin_update', () => {
-  let testDir;
-  let homeDir;
-  let repoDir;
-  let toolDir;
-  let commandLogPath;
-  let mergeCountPath;
+  let testDir: string;
+  let homeDir: string;
+  let repoDir: string;
+  let toolDir: string;
+  let commandLogPath: string;
+  let mergeCountPath: string;
 
-  const commandPath = (name) => process.env.PATH
+  const commandPath = (name: string) => (process.env.PATH ?? '')
     .split(path.delimiter)
     .map((directory) => path.join(directory, name))
     .find((candidate) => fs.existsSync(candidate));
 
-  const writeExecutable = (name, contents, directory = toolDir) => {
+  const writeExecutable = (name: string, contents: string, directory = toolDir) => {
     const executablePath = path.join(directory, name);
     fs.writeFileSync(executablePath, contents, { mode: 0o755 });
     return executablePath;
   };
 
-  const linkCommand = (name) => {
+  const linkCommand = (name: string) => {
     const sourcePath = commandPath(name);
     assert.exists(sourcePath, `${name} is required to run the ballin_update test harness`);
     fs.symlinkSync(sourcePath, path.join(toolDir, name));
@@ -82,7 +86,12 @@ exit "$FAKE_INSTALL_STATUS"
 `, repoDir);
   };
 
-  const runUpdate = (env = {}, commandPath = updatePath, spawnOptions = {}) => spawnSync(commandPath, [], {
+  const runUpdate = (
+    env: NodeJS.ProcessEnv = {},
+    commandPath = updatePath,
+    spawnOptions: SpawnUpdateOverrides = {},
+  ) => spawnSync(commandPath, [], {
+    ...spawnOptions,
     encoding: 'utf8',
     env: {
       HOME: homeDir,
@@ -98,7 +107,6 @@ exit "$FAKE_INSTALL_STATUS"
       FAKE_INSTALL_STATUS: '0',
       ...env,
     },
-    ...spawnOptions,
   });
 
   const commandLog = () => (

--- a/test/gu.test.ts
+++ b/test/gu.test.ts
@@ -19,22 +19,36 @@ const requiredCommands = [
   'tail',
   'node',
 ];
+type StringSpawnResult = import('child_process').SpawnSyncReturns<string>;
+
+type RunGuOptions = {
+  args?: string[];
+  failedPaths?: string[];
+  emitUnderlyingStderr?: boolean;
+  brewServicesFail?: boolean;
+  brewPrefix?: string;
+  brewPrefixFail?: boolean;
+  completionDir?: string;
+  gistInitialReadFail?: boolean;
+  gistUploadFail?: boolean;
+  commandPath?: string;
+};
 
 describe('gu', () => {
-  let testHomeDir;
-  let testBinDir;
-  let guCacheDir;
-  let fakeGistDir;
-  let gistReadLogPath;
-  let scratchDir;
-  let gistUploadLogPath;
-  let brewLogPath;
-  let openLogPath;
-  let ballinLogPath;
-  let realCatPath;
+  let testHomeDir: string;
+  let testBinDir: string;
+  let guCacheDir: string;
+  let fakeGistDir: string;
+  let gistReadLogPath: string;
+  let scratchDir: string;
+  let gistUploadLogPath: string;
+  let brewLogPath: string;
+  let openLogPath: string;
+  let ballinLogPath: string;
+  let realCatPath: string;
 
-  const linkRequiredCommand = (command) => {
-    const commandPath = process.env.PATH
+  const linkRequiredCommand = (command: string) => {
+    const commandPath = (process.env.PATH ?? '')
       .split(path.delimiter)
       .map((directory) => path.join(directory, command))
       .find((candidate) => fs.existsSync(candidate));
@@ -43,7 +57,7 @@ describe('gu', () => {
     fs.symlinkSync(commandPath, path.join(testBinDir, command));
   };
 
-  const writeTestExecutable = (name, contents) => {
+  const writeTestExecutable = (name: string, contents: string) => {
     fs.writeFileSync(path.join(testBinDir, name), contents, { mode: 0o755 });
   };
 
@@ -215,7 +229,7 @@ done
     gistInitialReadFail = false,
     gistUploadFail = false,
     commandPath = guPath,
-  } = {}) => spawnSync(commandPath, args, {
+  }: RunGuOptions = {}) => spawnSync(commandPath, args, {
     encoding: 'utf8',
     maxBuffer: 10 * 1024 * 1024,
     env: {
@@ -245,21 +259,21 @@ done
   const snapshotPath = () => path.join(testHomeDir, '.zshrc');
   const cachedSnapshotPath = () => path.join(guCacheDir, snapshotFileName);
   const fakeGistFilePath = () => path.join(fakeGistDir, snapshotFileName);
-  const writeSnapshot = (content) => fs.writeFileSync(snapshotPath(), content);
-  const seedGuCache = (content) => {
+  const writeSnapshot = (content: string) => fs.writeFileSync(snapshotPath(), content);
+  const seedGuCache = (content: string) => {
     fs.mkdirSync(guCacheDir, { recursive: true });
     fs.writeFileSync(cachedSnapshotPath(), content);
   };
-  const seedFakeGist = (content) => fs.writeFileSync(fakeGistFilePath(), content);
-  const seedFakeGistFile = (fileName, content) => {
+  const seedFakeGist = (content: string) => fs.writeFileSync(fakeGistFilePath(), content);
+  const seedFakeGistFile = (fileName: string, content: string) => {
     fs.writeFileSync(path.join(fakeGistDir, fileName), content);
   };
-  const assertGuSucceeded = (result) => {
+  const assertGuSucceeded = (result: StringSpawnResult) => {
     assert.equal(result.status, 0);
     assert.equal(result.stderr, '');
     assert.deepEqual(fs.readdirSync(scratchDir), []);
   };
-  const readLogLines = (logPath) => (
+  const readLogLines = (logPath: string) => (
     fs.existsSync(logPath) ? fs.readFileSync(logPath, 'utf8').trim().split('\n') : []
   );
   const gistReads = () => readLogLines(gistReadLogPath);
@@ -268,13 +282,13 @@ done
   const openCalls = () => readLogLines(openLogPath);
   const ballinCalls = () => readLogLines(ballinLogPath);
 
-  const writeBashCompletions = (brewPrefix, names) => {
+  const writeBashCompletions = (brewPrefix: string, names: string[]) => {
     const completionDirectory = path.join(brewPrefix, 'etc', 'bash_completion.d');
     fs.mkdirSync(completionDirectory, { recursive: true });
     names.forEach((name) => fs.writeFileSync(path.join(completionDirectory, name), ''));
   };
 
-  const writeAppSupportFile = (segments, content) => {
+  const writeAppSupportFile = (segments: string[], content: string) => {
     const filePath = path.join(testHomeDir, 'Library', 'Application Support', ...segments);
     fs.mkdirSync(path.dirname(filePath), { recursive: true });
     fs.writeFileSync(filePath, content);
@@ -530,11 +544,11 @@ printf '%s\\n' '123456 Example App'
     assert.deepEqual(gistUploads(), ['npm_global', 'mas']);
   });
 
-  [
+  ([
     ['Apple Silicon', path.join('opt', 'homebrew')],
     ['Intel', path.join('usr', 'local')],
     ['custom', path.join('srv', 'custombrew')],
-  ].forEach(([label, relativePrefix]) => {
+  ] as [string, string][]).forEach(([label, relativePrefix]) => {
     it(`discovers ${label}-style bash completions from the active Homebrew prefix`, () => {
       const brewPrefix = path.join(testHomeDir, relativePrefix);
       installFakeBrewCommand();
@@ -548,8 +562,8 @@ printf '%s\\n' '123456 Example App'
         fs.readFileSync(path.join(guCacheDir, 'bash_completions'), 'utf8'),
         'git\nnpm\n',
       );
-      assert.equal(brewCalls().filter((call) => call.endsWith('|--prefix')).length, 1);
-      assert.equal(gistUploads().filter((name) => name === 'bash_completions').length, 1);
+      assert.equal(brewCalls().filter((call: string) => call.endsWith('|--prefix')).length, 1);
+      assert.equal(gistUploads().filter((name: string) => name === 'bash_completions').length, 1);
     });
   });
 
@@ -577,7 +591,7 @@ printf '%s\\n' '123456 Example App'
       fs.readFileSync(path.join(guCacheDir, 'bash_completions'), 'utf8'),
       'active-tool\n',
     );
-    assert.equal(gistUploads().filter((name) => name === 'bash_completions').length, 1);
+    assert.equal(gistUploads().filter((name: string) => name === 'bash_completions').length, 1);
   });
 
   it('uses an explicit bash completion directory override when brew is unavailable', () => {
@@ -631,7 +645,7 @@ printf '%s\\n' '123456 Example App'
     assertGuSucceeded(result);
     assert.notInclude(result.stdout, 'bash_completions');
     assert.isFalse(fs.existsSync(path.join(guCacheDir, 'bash_completions')));
-    assert.equal(brewCalls().filter((call) => call.endsWith('|--prefix')).length, 1);
+    assert.equal(brewCalls().filter((call: string) => call.endsWith('|--prefix')).length, 1);
   });
 
   it('captures Homebrew inventory with flags while suppressing successful services stderr', () => {

--- a/test/install.test.ts
+++ b/test/install.test.ts
@@ -5,21 +5,25 @@ const os = require('os');
 const path = require('path');
 
 const installPath = path.join(__dirname, '..', 'install.sh');
+type RunInstallOptions = {
+  env?: NodeJS.ProcessEnv;
+  input?: string;
+};
 
 describe('install', () => {
-  let homeDir;
-  let binDir;
-  let repoDir;
-  let commandLogPath;
+  let homeDir: string;
+  let binDir: string;
+  let repoDir: string;
+  let commandLogPath: string;
 
-  const writeExecutable = (name, contents, directory = binDir) => {
+  const writeExecutable = (name: string, contents: string, directory = binDir) => {
     const executablePath = path.join(directory, name);
     fs.writeFileSync(executablePath, contents, { mode: 0o755 });
     return executablePath;
   };
 
-  const linkCommand = (name, directory = binDir) => {
-    const commandPath = process.env.PATH
+  const linkCommand = (name: string, directory = binDir) => {
+    const commandPath = (process.env.PATH ?? '')
       .split(path.delimiter)
       .map((commandDirectory) => path.join(commandDirectory, name))
       .find((candidate) => fs.existsSync(candidate));
@@ -55,7 +59,7 @@ esac
 `, path.join(repoDir, 'bin'));
   };
 
-  const runInstall = ({ env = {}, input } = {}) => spawnSync(installPath, [], {
+  const runInstall = ({ env = {}, input }: RunInstallOptions = {}) => spawnSync(installPath, [], {
     encoding: 'utf8',
     input,
     env: {

--- a/test/uninstall.test.ts
+++ b/test/uninstall.test.ts
@@ -6,32 +6,36 @@ const path = require('path');
 const { relocateSystemPath } = require('../commands/ballin_uninstall.ts');
 
 const uninstallPath = path.join(__dirname, '..', 'bin', 'ballin_uninstall');
+type RunUninstallOptions = {
+  brewPrefix?: string;
+  commandPath?: string;
+};
 
 describe('ballin_uninstall', () => {
-  let testDir;
-  let homeDir;
-  let repoDir;
-  let toolDir;
-  let systemRoot;
+  let testDir: string;
+  let homeDir: string;
+  let repoDir: string;
+  let toolDir: string;
+  let systemRoot: string;
 
-  const commandPath = (name) => process.env.PATH
+  const commandPath = (name: string) => (process.env.PATH ?? '')
     .split(path.delimiter)
     .map((directory) => path.join(directory, name))
     .find((candidate) => fs.existsSync(candidate));
 
-  const writeExecutable = (name, contents) => {
+  const writeExecutable = (name: string, contents: string) => {
     const executablePath = path.join(toolDir, name);
     fs.writeFileSync(executablePath, contents, { mode: 0o755 });
     return executablePath;
   };
 
-  const createCommand = (name) => {
+  const createCommand = (name: string) => {
     const filePath = path.join(repoDir, 'bin', name);
     fs.writeFileSync(filePath, `${name}\n`);
     return filePath;
   };
 
-  const runUninstall = ({ brewPrefix, commandPath: command = uninstallPath } = {}) => {
+  const runUninstall = ({ brewPrefix, commandPath: command = uninstallPath }: RunUninstallOptions = {}) => {
     if (brewPrefix) {
       writeExecutable('brew', `#!/usr/bin/env bash
 if [ "$1" = '--prefix' ]; then
@@ -143,10 +147,10 @@ exit 2
     }
   });
 
-  [
+  ([
     { name: 'Intel Homebrew', prefix: '/usr/local', relativeBin: ['usr', 'local', 'bin'] },
     { name: 'Apple Silicon Homebrew', prefix: '/opt/homebrew', relativeBin: ['opt', 'homebrew', 'bin'] },
-  ].forEach(({ name, prefix, relativeBin }) => {
+  ] as { name: string; prefix: string; relativeBin: string[] }[]).forEach(({ name, prefix, relativeBin }) => {
     it(`handles the ${name} location without checking it twice`, () => {
       const binDir = path.join(systemRoot, ...relativeBin);
       const ballin = createCommand('ballin');

--- a/test/up.test.ts
+++ b/test/up.test.ts
@@ -5,17 +5,25 @@ const os = require('os');
 const path = require('path');
 
 const upPath = path.join(__dirname, '..', 'bin', 'up');
+type InstallCommandStubOptions = {
+  output?: string;
+  status?: number;
+  directory?: string;
+};
 
 describe('up', () => {
-  let tempDir;
-  let binDir;
-  let logPath;
+  let tempDir: string;
+  let binDir: string;
+  let logPath: string;
 
-  const writeTestExecutable = (name, contents) => {
+  const writeTestExecutable = (name: string, contents: string) => {
     fs.writeFileSync(path.join(binDir, name), contents, { mode: 0o755 });
   };
 
-  const installCommandStub = (name, { output = '', status = 0, directory = binDir } = {}) => {
+  const installCommandStub = (
+    name: string,
+    { output = '', status = 0, directory = binDir }: InstallCommandStubOptions = {},
+  ) => {
     fs.writeFileSync(path.join(directory, name), `#!/usr/bin/env bash
 printf '%s|%s|%s\\n' "${name}" "$HOMEBREW_NO_ENV_HINTS,$HOMEBREW_NO_ASK" "$*" >> "$UP_TEST_LOG"
 ${output ? `printf '%s\\n' '${output}'` : ''}
@@ -47,7 +55,7 @@ esac
     fs.rmSync(tempDir, { recursive: true, force: true });
   });
 
-  const runUp = (env = {}) => spawnSync(upPath, [], {
+  const runUp = (env: NodeJS.ProcessEnv = {}) => spawnSync(upPath, [], {
     encoding: 'utf8',
     env: {
       HOME: tempDir,
@@ -59,7 +67,7 @@ esac
     },
   });
 
-  const installNvmStub = (nvmDir) => {
+  const installNvmStub = (nvmDir: string) => {
     fs.mkdirSync(nvmDir, { recursive: true });
     fs.writeFileSync(
       path.join(nvmDir, 'nvm.sh'),
@@ -70,7 +78,7 @@ esac
     );
   };
 
-  const installPathUpdatingNvmStub = (nvmDir, nvmBinDir) => {
+  const installPathUpdatingNvmStub = (nvmDir: string, nvmBinDir: string) => {
     fs.mkdirSync(nvmDir, { recursive: true });
     fs.writeFileSync(
       path.join(nvmDir, 'nvm.sh'),

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,7 +16,6 @@
   "include": [
     "commands/**/*.ts",
     "config/**/*.ts",
-    "test/config.test.ts",
-    "test/setup.ts"
+    "test/**/*.ts"
   ]
 }


### PR DESCRIPTION
## Summary

- Renamed the remaining JavaScript Mocha test files to TypeScript, including the top-level `ballin` harness test.
- Added strict TypeScript annotations for test helpers, temp path state, spawn results/options, and tuple-style fixture cases while preserving the existing CommonJS runtime style.
- Expanded `tsconfig.json` to include all `test/**/*.ts` files.

Closes #127

## Validation

- `npm run typecheck`
- `npm run lint`
- `npm run test:unit`
- `npm test`
- `git grep -Ilz '^#!.*bash' -- . | xargs -0 -r -n1 bash -n`

Note: I also ran a broader executable-file `bash -n` check first; it failed because the extensionless Node shims are executable Node scripts, not Bash scripts. The exact CI Bash shebang check listed above passes.