### PR TITLE
[codex] Restore config from adopted backup gist

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -162,6 +162,8 @@ done
             printf '\n%s\n' '👍 Storing your previous gist ID in your config:'
             RESTORE_CONFIG='.ballin.config.restore.tmp'
             PREVIOUS_CONFIG='.ballin.config.restore.previous.tmp'
+            ACTIVE_GIST_TOKEN_FILE="$("$ballin_config" get gu.token_file)"
+            ACTIVE_GIST_URL="$("$ballin_config" get gu.url)"
             cp 'ballin.config.json' "$PREVIOUS_CONFIG"
             if gist -r "$GIST_ID" ballin_config > "$RESTORE_CONFIG"; then
               cp "$RESTORE_CONFIG" 'ballin.config.json'
@@ -175,6 +177,8 @@ done
                 printf '\n🙌 %s\n' "$UPDATE_RESULT"
                 printf '\n👀 Optional capabilities: %s\n' "$optional_capabilities_url"
               fi
+              "$ballin_config" set gu.token_file "$ACTIVE_GIST_TOKEN_FILE"
+              "$ballin_config" set gu.url "$ACTIVE_GIST_URL"
             else
               printf '\n%s\n' 'ℹ️  No ballin_config snapshot was found in that gist; keeping the local config defaults.'
             fi

--- a/install.sh
+++ b/install.sh
@@ -160,9 +160,26 @@ done
           read -rep 'Enter your gist ID: ' GIST_ID
           if [ "$(gist -r "$GIST_ID")" == "$(printf '%b' "$GIST_DESCRIPTION")" ]; then
             printf '\n%s\n' '👍 Storing your previous gist ID in your config:'
+            RESTORE_CONFIG='.ballin.config.restore.tmp'
+            PREVIOUS_CONFIG='.ballin.config.restore.previous.tmp'
+            cp 'ballin.config.json' "$PREVIOUS_CONFIG"
+            if gist -r "$GIST_ID" ballin_config > "$RESTORE_CONFIG"; then
+              cp "$RESTORE_CONFIG" 'ballin.config.json'
+              if ! UPDATE_RESULT=$(node "$repo_dir/config/updateConfig.ts"); then
+                cp "$PREVIOUS_CONFIG" 'ballin.config.json'
+                rm -f "$RESTORE_CONFIG" "$PREVIOUS_CONFIG"
+                exit 1
+              fi
+              printf '\n%s\n' '♻️  Restored ballin.config.json from your backup gist.'
+              if [ -n "$UPDATE_RESULT" ]; then
+                printf '\n🙌 %s\n' "$UPDATE_RESULT"
+                printf '\n👀 Optional capabilities: %s\n' "$optional_capabilities_url"
+              fi
+            else
+              printf '\n%s\n' 'ℹ️  No ballin_config snapshot was found in that gist; keeping the local config defaults.'
+            fi
+            rm -f "$RESTORE_CONFIG" "$PREVIOUS_CONFIG"
             "$ballin_config" set gu.id "$GIST_ID"
-            printf '\n%s\n' 'ℹ️  Keeping your local ballin.config.json settings; only the backup gist ID was adopted.'
-            printf '%s\n' '    New defaults stay managed by installer updates, and future gu runs will back up local settings.'
             VALID_GIST_ID=0
           else
             printf "\n⚠️  INVALID: Expected \e[1mgist -r '%s'\e[0m to output:\n%s\n" "$GIST_ID" "$GIST_DESCRIPTION"

--- a/install.sh
+++ b/install.sh
@@ -162,8 +162,6 @@ done
             printf '\n%s\n' '👍 Storing your previous gist ID in your config:'
             RESTORE_CONFIG='.ballin.config.restore.tmp'
             PREVIOUS_CONFIG='.ballin.config.restore.previous.tmp'
-            ACTIVE_GIST_TOKEN_FILE="$("$ballin_config" get gu.token_file)"
-            ACTIVE_GIST_URL="$("$ballin_config" get gu.url)"
             cp 'ballin.config.json' "$PREVIOUS_CONFIG"
             if gist -r "$GIST_ID" ballin_config > "$RESTORE_CONFIG"; then
               cp "$RESTORE_CONFIG" 'ballin.config.json'
@@ -177,8 +175,6 @@ done
                 printf '\n🙌 %s\n' "$UPDATE_RESULT"
                 printf '\n👀 Optional capabilities: %s\n' "$optional_capabilities_url"
               fi
-              "$ballin_config" set gu.token_file "$ACTIVE_GIST_TOKEN_FILE"
-              "$ballin_config" set gu.url "$ACTIVE_GIST_URL"
             else
               printf '\n%s\n' 'ℹ️  No ballin_config snapshot was found in that gist; keeping the local config defaults.'
             fi

--- a/install.sh
+++ b/install.sh
@@ -161,6 +161,8 @@ done
           if [ "$(gist -r "$GIST_ID")" == "$(printf '%b' "$GIST_DESCRIPTION")" ]; then
             printf '\n%s\n' '👍 Storing your previous gist ID in your config:'
             "$ballin_config" set gu.id "$GIST_ID"
+            printf '\n%s\n' 'ℹ️  Keeping your local ballin.config.json settings; only the backup gist ID was adopted.'
+            printf '%s\n' '    New defaults stay managed by installer updates, and future gu runs will back up local settings.'
             VALID_GIST_ID=0
           else
             printf "\n⚠️  INVALID: Expected \e[1mgist -r '%s'\e[0m to output:\n%s\n" "$GIST_ID" "$GIST_DESCRIPTION"

--- a/install.sh
+++ b/install.sh
@@ -173,7 +173,7 @@ done
               printf '\n%s\n' '♻️  Restored ballin.config.json from your backup gist.'
               if [ -n "$UPDATE_RESULT" ]; then
                 printf '\n🙌 %s\n' "$UPDATE_RESULT"
-                printf '\n👀 Optional capabilities: %s\n' "$optional_capabilities_url"
+                printf '\n👀 Docs: %s\n' "$docs_url"
               fi
             else
               printf '\n%s\n' 'ℹ️  No ballin_config snapshot was found in that gist; keeping the local config defaults.'

--- a/install.sh
+++ b/install.sh
@@ -177,8 +177,16 @@ done
               fi
               restored_gist_token_path="$HOME/$("$ballin_config" get gu.token_file)"
               if [ "$restored_gist_token_path" != "$gist_token_path" ] && [ ! -f "$restored_gist_token_path" ]; then
-                cp "$gist_token_path" "$restored_gist_token_path"
-                chmod 600 "$restored_gist_token_path"
+                restored_gist_token_dir="${restored_gist_token_path%/*}"
+                if ! mkdir -p "$restored_gist_token_dir"; then
+                  exit 1
+                fi
+                if ! cp "$gist_token_path" "$restored_gist_token_path"; then
+                  exit 1
+                fi
+                if ! chmod 600 "$restored_gist_token_path"; then
+                  exit 1
+                fi
               fi
             else
               printf '\n%s\n' 'ℹ️  No ballin_config snapshot was found in that gist; keeping the local config defaults.'

--- a/install.sh
+++ b/install.sh
@@ -175,6 +175,11 @@ done
                 printf '\n🙌 %s\n' "$UPDATE_RESULT"
                 printf '\n👀 Docs: %s\n' "$docs_url"
               fi
+              restored_gist_token_path="$HOME/$("$ballin_config" get gu.token_file)"
+              if [ "$restored_gist_token_path" != "$gist_token_path" ] && [ ! -f "$restored_gist_token_path" ]; then
+                cp "$gist_token_path" "$restored_gist_token_path"
+                chmod 600 "$restored_gist_token_path"
+              fi
             else
               printf '\n%s\n' 'ℹ️  No ballin_config snapshot was found in that gist; keeping the local config defaults.'
             fi

--- a/test/install.test.ts
+++ b/test/install.test.ts
@@ -77,10 +77,8 @@ case "$1:$2" in
     ;;
   set:gu.id)
     printf '%s\\n' "$3" > "$gist_id_file"
+    printf '%s\\n' '{"up":{"cleanup":"false","ballin":"true","gu":"true","softwareupdate":"false","npm":"true","nvm":"true"},"gu":{"id":"returning-gist-id","token_file":".restored-gist","url":"https://old-gist.example.test"}}' > "$HOME/.ballin-scripts/ballin.config.json"
     printf '%s\\n' "\\"gu.id\\" set to: \\"$3\\""
-    ;;
-  set:gu.token_file|set:gu.url)
-    printf '%s\\n' "\\"$2\\" set to: \\"$3\\""
     ;;
 esac
 `, path.join(repoDir, 'bin'));
@@ -257,12 +255,13 @@ esac
     assert.include(result.stdout, 'Storing your previous gist ID in your config');
     assert.include(result.stdout, 'Restored ballin.config.json from your backup gist');
     assert.include(commandLog(), 'gist:-r returning-gist-id ballin_config');
-    assert.include(commandLog(), 'ballin_config:set gu.token_file .gist\n');
-    assert.include(commandLog(), 'ballin_config:set gu.url https://gist.example.test\n');
     assert.include(commandLog(), 'ballin_config:set gu.id returning-gist-id\n');
     const restoredConfig = JSON.parse(fs.readFileSync(path.join(repoDir, 'ballin.config.json'), 'utf8'));
     assert.equal(restoredConfig.up.cleanup, 'false');
     assert.equal(restoredConfig.up.gu, 'true');
+    assert.equal(restoredConfig.gu.id, 'returning-gist-id');
+    assert.equal(restoredConfig.gu.token_file, '.restored-gist');
+    assert.equal(restoredConfig.gu.url, 'https://old-gist.example.test');
   });
 
   it('stops before Gist and success output when config creation fails', () => {

--- a/test/install.test.ts
+++ b/test/install.test.ts
@@ -79,6 +79,9 @@ case "$1:$2" in
     printf '%s\\n' "$3" > "$gist_id_file"
     printf '%s\\n' "\\"gu.id\\" set to: \\"$3\\""
     ;;
+  set:gu.token_file|set:gu.url)
+    printf '%s\\n' "\\"$2\\" set to: \\"$3\\""
+    ;;
 esac
 `, path.join(repoDir, 'bin'));
   };
@@ -238,7 +241,7 @@ case "$1:$2" in
   -l:) exit 0 ;;
   -r:returning-gist-id)
     if [ "$3" = 'ballin_config' ]; then
-      printf '%s\\n' '{"up":{"cleanup":"false","ballin":"true","gu":"true","softwareupdate":"false","npm":"true","nvm":"true"},"gu":{"id":"previous-gist-id","token_file":".restored-gist","url":"https://gist.example.test"}}'
+      printf '%s\\n' '{"up":{"cleanup":"false","ballin":"true","gu":"true","softwareupdate":"false","npm":"true","nvm":"true"},"gu":{"id":"previous-gist-id","token_file":".restored-gist","url":"https://old-gist.example.test"}}'
       exit 0
     fi
     printf '%s\\n' '### Backup of your dev environment'
@@ -254,11 +257,12 @@ esac
     assert.include(result.stdout, 'Storing your previous gist ID in your config');
     assert.include(result.stdout, 'Restored ballin.config.json from your backup gist');
     assert.include(commandLog(), 'gist:-r returning-gist-id ballin_config');
+    assert.include(commandLog(), 'ballin_config:set gu.token_file .gist\n');
+    assert.include(commandLog(), 'ballin_config:set gu.url https://gist.example.test\n');
     assert.include(commandLog(), 'ballin_config:set gu.id returning-gist-id\n');
     const restoredConfig = JSON.parse(fs.readFileSync(path.join(repoDir, 'ballin.config.json'), 'utf8'));
     assert.equal(restoredConfig.up.cleanup, 'false');
     assert.equal(restoredConfig.up.gu, 'true');
-    assert.equal(restoredConfig.gu.token_file, '.restored-gist');
   });
 
   it('stops before Gist and success output when config creation fails', () => {

--- a/test/install.test.ts
+++ b/test/install.test.ts
@@ -70,7 +70,7 @@ case "$1:$2" in
       config_json=$(<"$HOME/.ballin-scripts/ballin.config.json")
     fi
     case "$config_json" in
-      *'.restored-gist'*) printf '%s\\n' '.restored-gist' ;;
+      *'.config/ballin/restored-gist'*) printf '%s\\n' '.config/ballin/restored-gist' ;;
       *) printf '%s\\n' '.gist' ;;
     esac
     ;;
@@ -249,7 +249,7 @@ case "$1:$2" in
   -l:) exit 0 ;;
   -r:returning-gist-id)
     if [ "$3" = 'ballin_config' ]; then
-      printf '%s\\n' '{"up":{"cleanup":"false","ballin":"true","gu":"true","softwareupdate":"false","npm":"true","nvm":"true"},"gu":{"id":"previous-gist-id","token_file":".restored-gist","url":"https://old-gist.example.test"}}'
+      printf '%s\\n' '{"up":{"cleanup":"false","ballin":"true","gu":"true","softwareupdate":"false","npm":"true","nvm":"true"},"gu":{"id":"previous-gist-id","token_file":".config/ballin/restored-gist","url":"https://old-gist.example.test"}}'
       exit 0
     fi
     printf '%s\\n' '### Backup of your dev environment'
@@ -270,9 +270,9 @@ esac
     assert.equal(restoredConfig.up.cleanup, 'false');
     assert.equal(restoredConfig.up.gu, 'true');
     assert.equal(restoredConfig.gu.id, 'returning-gist-id');
-    assert.equal(restoredConfig.gu.token_file, '.restored-gist');
+    assert.equal(restoredConfig.gu.token_file, '.config/ballin/restored-gist');
     assert.equal(restoredConfig.gu.url, 'https://old-gist.example.test');
-    assert.equal(fs.readFileSync(path.join(homeDir, '.restored-gist'), 'utf8'), 'token\n');
+    assert.equal(fs.readFileSync(path.join(homeDir, '.config', 'ballin', 'restored-gist'), 'utf8'), 'token\n');
   });
 
   it('stops before Gist and success output when config creation fails', () => {

--- a/test/install.test.ts
+++ b/test/install.test.ts
@@ -77,7 +77,8 @@ case "$1:$2" in
     ;;
   set:gu.id)
     printf '%s\\n' "$3" > "$gist_id_file"
-    printf '%s\\n' '{"up":{"cleanup":"false","ballin":"true","gu":"true","softwareupdate":"false","npm":"true","nvm":"true"},"gu":{"id":"returning-gist-id","token_file":".restored-gist","url":"https://old-gist.example.test"}}' > "$HOME/.ballin-scripts/ballin.config.json"
+    config_json=$(<"$HOME/.ballin-scripts/ballin.config.json")
+    printf '%s\\n' "\${config_json/\\\"id\\\":\\\"previous-gist-id\\\"/\\\"id\\\":\\\"$3\\\"}" > "$HOME/.ballin-scripts/ballin.config.json"
     printf '%s\\n' "\\"gu.id\\" set to: \\"$3\\""
     ;;
 esac

--- a/test/install.test.ts
+++ b/test/install.test.ts
@@ -59,6 +59,30 @@ esac
 `, path.join(repoDir, 'bin'));
   };
 
+  const installAdoptableConfigCommand = () => {
+    writeExecutable('ballin_config', `#!/usr/bin/env bash
+printf 'ballin_config:%s\\n' "$*" >> "$FAKE_COMMAND_LOG"
+gist_id_file="$HOME/.configured-gist-id"
+case "$1:$2" in
+  get:gu.token_file) printf '%s\\n' '.gist' ;;
+  get:gu.url) printf '%s\\n' 'https://gist.example.test' ;;
+  get:gu.id)
+    if [ -f "$gist_id_file" ]; then
+      while IFS= read -r gist_id; do
+        printf '%s\\n' "$gist_id"
+      done < "$gist_id_file"
+    else
+      printf '%s\\n' 'null'
+    fi
+    ;;
+  set:gu.id)
+    printf '%s\\n' "$3" > "$gist_id_file"
+    printf '%s\\n' "\\"gu.id\\" set to: \\"$3\\""
+    ;;
+esac
+`, path.join(repoDir, 'bin'));
+  };
+
   const runInstall = ({ env = {}, input }: RunInstallOptions = {}) => spawnSync(installPath, [], {
     encoding: 'utf8',
     input,
@@ -202,6 +226,40 @@ printf '%s\\n' gist >> "$FAKE_COMMAND_LOG"
     assert.include(result.stdout, updateOutput.trim());
     assert.equal(result.stdout.match(/👀 Optional capabilities:/g).length, 1);
     assert.include(result.stdout, 'docs/optional-capabilities.md');
+  });
+
+  it('adopts an existing backup gist without restoring remote config values', () => {
+    installBaseCommands();
+    installAdoptableConfigCommand();
+    fs.writeFileSync(path.join(homeDir, '.gist'), 'token\n');
+    writeExecutable('gist', `#!/usr/bin/env bash
+printf 'gist:%s\\n' "$*" >> "$FAKE_COMMAND_LOG"
+case "$1:$2" in
+  -l:) exit 0 ;;
+  -r:returning-gist-id)
+    if [ "$3" = 'ballin_config' ]; then
+      printf '%s\\n' 'remote config should not be restored' >&2
+      exit 3
+    fi
+    printf '%s\\n' '### Backup of your dev environment'
+    printf '%s\\n' 'Created by [ballin-scripts](https://github.com/JBallin/ballin-scripts)'
+    printf '\\n'
+    ;;
+esac
+`);
+
+    const result = runInstall({ input: 'y\nreturning-gist-id\n' });
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.include(result.stdout, 'Storing your previous gist ID in your config');
+    assert.include(result.stdout, 'Keeping your local ballin.config.json settings');
+    assert.include(result.stdout, 'only the backup gist ID was adopted');
+    assert.notInclude(commandLog(), 'gist:-r returning-gist-id ballin_config');
+    assert.include(commandLog(), 'ballin_config:set gu.id returning-gist-id\n');
+    assert.deepEqual(
+      JSON.parse(fs.readFileSync(path.join(repoDir, 'ballin.config.json'), 'utf8')),
+      JSON.parse(fs.readFileSync(path.join(repoDir, 'config', '.defaultConfig.json'), 'utf8')),
+    );
   });
 
   it('stops before Gist and success output when config creation fails', () => {

--- a/test/install.test.ts
+++ b/test/install.test.ts
@@ -228,7 +228,7 @@ printf '%s\\n' gist >> "$FAKE_COMMAND_LOG"
     assert.include(result.stdout, 'docs/optional-capabilities.md');
   });
 
-  it('adopts an existing backup gist without restoring remote config values', () => {
+  it('restores config values from an adopted backup gist', () => {
     installBaseCommands();
     installAdoptableConfigCommand();
     fs.writeFileSync(path.join(homeDir, '.gist'), 'token\n');
@@ -238,8 +238,8 @@ case "$1:$2" in
   -l:) exit 0 ;;
   -r:returning-gist-id)
     if [ "$3" = 'ballin_config' ]; then
-      printf '%s\\n' 'remote config should not be restored' >&2
-      exit 3
+      printf '%s\\n' '{"up":{"cleanup":"false","ballin":"true","gu":"true","softwareupdate":"false","npm":"true","nvm":"true"},"gu":{"id":"previous-gist-id","token_file":".restored-gist","url":"https://gist.example.test"}}'
+      exit 0
     fi
     printf '%s\\n' '### Backup of your dev environment'
     printf '%s\\n' 'Created by [ballin-scripts](https://github.com/JBallin/ballin-scripts)'
@@ -252,14 +252,13 @@ esac
 
     assert.equal(result.status, 0, result.stderr);
     assert.include(result.stdout, 'Storing your previous gist ID in your config');
-    assert.include(result.stdout, 'Keeping your local ballin.config.json settings');
-    assert.include(result.stdout, 'only the backup gist ID was adopted');
-    assert.notInclude(commandLog(), 'gist:-r returning-gist-id ballin_config');
+    assert.include(result.stdout, 'Restored ballin.config.json from your backup gist');
+    assert.include(commandLog(), 'gist:-r returning-gist-id ballin_config');
     assert.include(commandLog(), 'ballin_config:set gu.id returning-gist-id\n');
-    assert.deepEqual(
-      JSON.parse(fs.readFileSync(path.join(repoDir, 'ballin.config.json'), 'utf8')),
-      JSON.parse(fs.readFileSync(path.join(repoDir, 'config', '.defaultConfig.json'), 'utf8')),
-    );
+    const restoredConfig = JSON.parse(fs.readFileSync(path.join(repoDir, 'ballin.config.json'), 'utf8'));
+    assert.equal(restoredConfig.up.cleanup, 'false');
+    assert.equal(restoredConfig.up.gu, 'true');
+    assert.equal(restoredConfig.gu.token_file, '.restored-gist');
   });
 
   it('stops before Gist and success output when config creation fails', () => {

--- a/test/install.test.ts
+++ b/test/install.test.ts
@@ -64,7 +64,16 @@ esac
 printf 'ballin_config:%s\\n' "$*" >> "$FAKE_COMMAND_LOG"
 gist_id_file="$HOME/.configured-gist-id"
 case "$1:$2" in
-  get:gu.token_file) printf '%s\\n' '.gist' ;;
+  get:gu.token_file)
+    config_json=''
+    if [ -f "$HOME/.ballin-scripts/ballin.config.json" ]; then
+      config_json=$(<"$HOME/.ballin-scripts/ballin.config.json")
+    fi
+    case "$config_json" in
+      *'.restored-gist'*) printf '%s\\n' '.restored-gist' ;;
+      *) printf '%s\\n' '.gist' ;;
+    esac
+    ;;
   get:gu.url) printf '%s\\n' 'https://gist.example.test' ;;
   get:gu.id)
     if [ -f "$gist_id_file" ]; then
@@ -263,6 +272,7 @@ esac
     assert.equal(restoredConfig.gu.id, 'returning-gist-id');
     assert.equal(restoredConfig.gu.token_file, '.restored-gist');
     assert.equal(restoredConfig.gu.url, 'https://old-gist.example.test');
+    assert.equal(fs.readFileSync(path.join(homeDir, '.restored-gist'), 'utf8'), 'token\n');
   });
 
   it('stops before Gist and success output when config creation fails', () => {


### PR DESCRIPTION
## Summary
- restore ballin.config.json from an adopted backup Gist when the Gist contains a ballin_config snapshot
- treat restored config settings as authoritative for returning users, including gu.token_file and gu.url
- run the existing config default merger after restore so returning users pick up new settings
- stamp the adopted gu.id back into the restored config and keep local defaults when no snapshot exists
- copy the validated Gist token to a restored gu.token_file path when the backup config changes it, including nested paths
- add installer coverage for the returning-user restore path, final restored config values, and restored token-file setup
- merge latest main so installer guidance uses the current docs URL

Closes #141

## Validation
- npm test: 150 passing
- bash -n install.sh
- git diff --check
- shellcheck passed in CI after replacing the stale optional_capabilities_url reference