### PR TITLE
[codex] Add typed installer setup entrypoint

### DIFF
--- a/commands/install_setup.ts
+++ b/commands/install_setup.ts
@@ -1,0 +1,53 @@
+const fs = require('fs');
+const path = require('path');
+const {
+  writeStdoutLine,
+} = require('./commandHelpers.ts');
+
+const symlinkBinaries = (repoDir: string, binDir: string): boolean => {
+  const sourceBinDir = path.join(repoDir, 'bin');
+
+  try {
+    fs.mkdirSync(binDir, { recursive: true });
+  } catch {
+    writeStdoutLine(`\n⚠️  ERROR: Unable to create ${binDir}`);
+    return false;
+  }
+
+  try {
+    for (const binName of fs.readdirSync(sourceBinDir)) {
+      const sourcePath = path.join(sourceBinDir, binName);
+      const targetPath = path.join(binDir, binName);
+
+      fs.rmSync(targetPath, { force: true });
+      fs.symlinkSync(sourcePath, targetPath);
+    }
+  } catch {
+    writeStdoutLine(`\n⚠️  ERROR: Unable to symlink binaries into ${binDir}`);
+    return false;
+  }
+
+  writeStdoutLine(`\n💪 symlinked binaries into ${binDir}`);
+  return true;
+};
+
+const runInstallSetupCli = (): void => {
+  const [, , command, repoDir, binDir] = process.argv;
+
+  if (command !== 'symlink-binaries' || !repoDir || !binDir) {
+    writeStdoutLine('Usage: install_setup.ts symlink-binaries <repo-dir> <bin-dir>');
+    process.exitCode = 1;
+    return;
+  }
+
+  process.exitCode = symlinkBinaries(repoDir, binDir) ? 0 : 1;
+};
+
+if (require.main === module) {
+  runInstallSetupCli();
+}
+
+module.exports = {
+  runInstallSetupCli,
+  symlinkBinaries,
+};

--- a/install.sh
+++ b/install.sh
@@ -195,8 +195,23 @@ done
   fi
 
   ############################## SYMLINK BINARIES ##############################
-  if ! node "$repo_dir/commands/install_setup.ts" symlink-binaries "$repo_dir" "$bin_dir"; then
-    exit 1
+  if [ -f "$repo_dir/commands/install_setup.ts" ]; then
+    if ! node "$repo_dir/commands/install_setup.ts" symlink-binaries "$repo_dir" "$bin_dir"; then
+      exit 1
+    fi
+  else
+    if ! mkdir -p "$bin_dir"; then
+      printf '\n⚠️  ERROR: Unable to create %s\n' "$bin_dir"
+      exit 1
+    fi
+
+    for bin in "$repo_dir/bin/"*; do
+      if ! ln -sfn "$bin" "$bin_dir/${bin##*/}"; then
+        printf '\n⚠️  ERROR: Unable to symlink binaries into %s\n' "$bin_dir"
+        exit 1
+      fi
+    done
+    printf '\n💪 symlinked binaries into %s\n' "$bin_dir"
   fi
 
   if [ "$config_existed" = false ] && [ -f "$repo_dir/ballin.config.json" ]; then

--- a/install.sh
+++ b/install.sh
@@ -195,18 +195,9 @@ done
   fi
 
   ############################## SYMLINK BINARIES ##############################
-  if ! mkdir -p "$bin_dir"; then
-    printf '\n⚠️  ERROR: Unable to create %s\n' "$bin_dir"
+  if ! node "$repo_dir/commands/install_setup.ts" symlink-binaries "$repo_dir" "$bin_dir"; then
     exit 1
   fi
-
-  for bin in "$repo_dir/bin/"*; do
-    if ! ln -sfn "$bin" "$bin_dir/${bin##*/}"; then
-      printf '\n⚠️  ERROR: Unable to symlink binaries into %s\n' "$bin_dir"
-      exit 1
-    fi
-  done
-  printf '\n💪 symlinked binaries into %s\n' "$bin_dir"
 
   if [ "$config_existed" = false ] && [ -f "$repo_dir/ballin.config.json" ]; then
     printf '\n👀 Optional capabilities: %s\n' "$optional_capabilities_url"

--- a/test/install.test.ts
+++ b/test/install.test.ts
@@ -39,6 +39,26 @@ if [ "$1" = '-p' ]; then
   printf '%s\\n' "$FAKE_NODE_SUPPORTED"
   exit 0
 fi
+if [ "$1" = "$HOME/.ballin-scripts/commands/install_setup.ts" ]; then
+  shift
+  if [ "$1" != 'symlink-binaries' ]; then
+    exit 2
+  fi
+  repo_dir="$2"
+  bin_dir="$3"
+  if ! mkdir -p "$bin_dir"; then
+    printf '\\n⚠️  ERROR: Unable to create %s\\n' "$bin_dir"
+    exit 1
+  fi
+  for bin in "$repo_dir/bin/"*; do
+    if ! ln -sfn "$bin" "$bin_dir/\${bin##*/}"; then
+      printf '\\n⚠️  ERROR: Unable to symlink binaries into %s\\n' "$bin_dir"
+      exit 1
+    fi
+  done
+  printf '\\n💪 symlinked binaries into %s\\n' "$bin_dir"
+  exit 0
+fi
 printf '%s' "$FAKE_UPDATE_OUTPUT"
 exit "$FAKE_NODE_STATUS"
 `);
@@ -82,6 +102,7 @@ esac
     repoDir = path.join(homeDir, '.ballin-scripts');
     fs.mkdirSync(binDir, { recursive: true });
     fs.mkdirSync(path.join(repoDir, 'bin'), { recursive: true });
+    fs.mkdirSync(path.join(repoDir, 'commands'));
     fs.mkdirSync(path.join(repoDir, 'config'));
     fs.copyFileSync(
       path.join(__dirname, '..', 'config', '.defaultConfig.json'),

--- a/test/install.test.ts
+++ b/test/install.test.ts
@@ -40,6 +40,7 @@ if [ "$1" = '-p' ]; then
   exit 0
 fi
 if [ "$1" = "$HOME/.ballin-scripts/commands/install_setup.ts" ]; then
+  printf 'node:install_setup %s\\n' "$*" >> "$FAKE_COMMAND_LOG"
   shift
   if [ "$1" != 'symlink-binaries' ]; then
     exit 2
@@ -103,6 +104,7 @@ esac
     fs.mkdirSync(binDir, { recursive: true });
     fs.mkdirSync(path.join(repoDir, 'bin'), { recursive: true });
     fs.mkdirSync(path.join(repoDir, 'commands'));
+    fs.writeFileSync(path.join(repoDir, 'commands', 'install_setup.ts'), '');
     fs.mkdirSync(path.join(repoDir, 'config'));
     fs.copyFileSync(
       path.join(__dirname, '..', 'config', '.defaultConfig.json'),
@@ -190,7 +192,22 @@ printf '%s\\n' gist >> "$FAKE_COMMAND_LOG"
       JSON.parse(fs.readFileSync(path.join(repoDir, 'config', '.defaultConfig.json'), 'utf8')),
     );
     assert.isTrue(fs.lstatSync(path.join(binDir, 'ballin_config')).isSymbolicLink());
+    assert.include(commandLog(), 'node:install_setup');
     assert.include(commandLog(), 'gist:-l\n');
+  });
+
+  it('falls back to Bash symlinking when the typed setup entrypoint is missing from an existing checkout', () => {
+    installBaseCommands();
+    installConfigCommand();
+    fs.unlinkSync(path.join(repoDir, 'commands', 'install_setup.ts'));
+    fs.writeFileSync(path.join(homeDir, '.gist'), 'token\n');
+
+    const result = runInstall();
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.include(result.stdout, `symlinked binaries into ${binDir}`);
+    assert.isTrue(fs.lstatSync(path.join(binDir, 'ballin_config')).isSymbolicLink());
+    assert.notInclude(commandLog(), 'node:install_setup');
   });
 
   it('does not repeat unchanged setup guidance during an ordinary update', () => {

--- a/test/install_setup.test.ts
+++ b/test/install_setup.test.ts
@@ -1,0 +1,87 @@
+const { assert } = require('chai');
+const { spawnSync } = require('child_process');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const {
+  symlinkBinaries,
+} = require('../commands/install_setup.ts');
+
+const installSetupPath = path.join(__dirname, '..', 'commands', 'install_setup.ts');
+
+describe('install setup', () => {
+  let testDir: string;
+  let repoDir: string;
+  let sourceBinDir: string;
+  let binDir: string;
+
+  const withoutStdout = (action: () => boolean): boolean => {
+    const originalWrite = process.stdout.write;
+    process.stdout.write = (() => true) as typeof process.stdout.write;
+    try {
+      return action();
+    } finally {
+      process.stdout.write = originalWrite;
+    }
+  };
+
+  beforeEach(() => {
+    testDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ballin-install-setup-'));
+    repoDir = path.join(testDir, 'repo');
+    sourceBinDir = path.join(repoDir, 'bin');
+    binDir = path.join(testDir, 'home', '.local', 'bin');
+
+    fs.mkdirSync(sourceBinDir, { recursive: true });
+    fs.writeFileSync(path.join(sourceBinDir, 'ballin'), '#!/usr/bin/env node\n');
+    fs.writeFileSync(path.join(sourceBinDir, 'gu'), '#!/usr/bin/env node\n');
+  });
+
+  afterEach(() => {
+    fs.rmSync(testDir, { recursive: true, force: true });
+  });
+
+  it('creates the command directory and symlinks repository binaries', () => {
+    const result = withoutStdout(() => symlinkBinaries(repoDir, binDir));
+
+    assert.isTrue(result);
+    assert.isTrue(fs.lstatSync(path.join(binDir, 'ballin')).isSymbolicLink());
+    assert.isTrue(fs.lstatSync(path.join(binDir, 'gu')).isSymbolicLink());
+    assert.equal(fs.readlinkSync(path.join(binDir, 'ballin')), path.join(sourceBinDir, 'ballin'));
+    assert.equal(fs.readlinkSync(path.join(binDir, 'gu')), path.join(sourceBinDir, 'gu'));
+  });
+
+  it('runs the symlink step through the setup CLI', () => {
+    const result = spawnSync(process.execPath, [
+      installSetupPath,
+      'symlink-binaries',
+      repoDir,
+      binDir,
+    ], {
+      encoding: 'utf8',
+    });
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.include(result.stdout, `symlinked binaries into ${binDir}`);
+    assert.isTrue(fs.lstatSync(path.join(binDir, 'ballin')).isSymbolicLink());
+    assert.equal(fs.readlinkSync(path.join(binDir, 'ballin')), path.join(sourceBinDir, 'ballin'));
+  });
+
+  it('replaces existing command symlinks', () => {
+    fs.mkdirSync(binDir, { recursive: true });
+    fs.symlinkSync(path.join(testDir, 'old-ballin'), path.join(binDir, 'ballin'));
+
+    const result = withoutStdout(() => symlinkBinaries(repoDir, binDir));
+
+    assert.isTrue(result);
+    assert.equal(fs.readlinkSync(path.join(binDir, 'ballin')), path.join(sourceBinDir, 'ballin'));
+  });
+
+  it('fails when a command target cannot be replaced', () => {
+    fs.mkdirSync(path.join(binDir, 'ballin'), { recursive: true });
+
+    const result = withoutStdout(() => symlinkBinaries(repoDir, binDir));
+
+    assert.isFalse(result);
+    assert.isTrue(fs.statSync(path.join(binDir, 'ballin')).isDirectory());
+  });
+});


### PR DESCRIPTION
## Summary

- add a typed post-Node installer setup entrypoint in commands/install_setup.ts
- move install.sh symlink creation behind that setup entrypoint while preserving the public Bash bootstrap path
- add isolated coverage for direct setup behavior, CLI invocation, and the install harness delegation

## Scope

This is the first small slice of #158. It intentionally leaves config migration and Gist/auth setup in install.sh for now.

## Validation

- npm test
- bash -n install.sh

Refs #158