### PR TITLE
[codex] Refactor gu snapshot internals

### DIFF
--- a/commands/gu.ts
+++ b/commands/gu.ts
@@ -480,6 +480,12 @@ const collectSnapshots = (homeDir: string): SnapshotCommand[] => {
 
 const runGuCli = (args = process.argv.slice(2)): void => {
   const homeDir = process.env.HOME ?? '';
+
+  if (args[0] === 'help') {
+    process.exitCode = runVisible('ballin');
+    return;
+  }
+
   const id = configValue('gu.id');
   const url = `${configValue('gu.url')}/${id}`;
 
@@ -505,8 +511,9 @@ const runGuCli = (args = process.argv.slice(2)): void => {
         process.stdout.write(`Error: 'read' needs a filename.\n\nOptions: ${fileSuggestions}\n`);
         process.exitCode = 1;
       }
-    } else if (args[0] === 'help') {
-      process.exitCode = runVisible('ballin');
+    } else {
+      writeStderrLine(`gu: unknown command '${args[0]}'`);
+      process.exitCode = 1;
     }
     return;
   }

--- a/commands/gu.ts
+++ b/commands/gu.ts
@@ -66,7 +66,6 @@ const fileSuggestions = `
   ballin_config
   bash_completions
   bash_profile.sh
-  Brewfile
   bashrc.sh
   brackets_disabled_extensions
   brackets_extensions

--- a/commands/gu.ts
+++ b/commands/gu.ts
@@ -247,6 +247,13 @@ const snapshotIsEmpty = (filePath: string): boolean => (
   fs.readFileSync(filePath, 'utf8') === emptySnapshotContent
 );
 
+const createSnapshotUploadFile = (sourceFile: string, fileName: string): string => {
+  const tempFile = makeTempFile('ballin-gu-upload-');
+  const uploadFile = path.join(path.dirname(tempFile), fileName);
+  fs.copyFileSync(sourceFile, uploadFile);
+  return uploadFile;
+};
+
 const classifySnapshotResult = (
   isNew: boolean,
   isChanged: boolean,
@@ -301,19 +308,22 @@ const updateSnapshot = (id: string, cacheDir: string, snapshot: SnapshotCommand)
       isChanged = !snapshotFilesMatch(inputFile, cacheFile);
     }
 
+    isEmpty = snapshotIsEmpty(inputFile);
+    resultState = classifySnapshotResult(isNew, isChanged, isEmpty);
+
     if (isChanged) {
+      const uploadFile = createSnapshotUploadFile(inputFile, snapshot.fileName);
+      try {
+        if (!uploadGistFile(id, uploadFile)) {
+          return false;
+        }
+      } finally {
+        removeTempFile(uploadFile);
+      }
       fs.copyFileSync(inputFile, cacheFile);
     }
-    isEmpty = snapshotIsEmpty(cacheFile);
-    resultState = classifySnapshotResult(isNew, isChanged, isEmpty);
   } finally {
     removeTempFile(inputFile);
-  }
-
-  if (resultState !== 'unchanged') {
-    if (!uploadGistFile(id, cacheFile)) {
-      return false;
-    }
   }
 
   writeSnapshotStatus(snapshot, resultState, isEmpty);

--- a/commands/gu.ts
+++ b/commands/gu.ts
@@ -43,6 +43,11 @@ type GuConfigResult = {
   exitStatus: number;
 };
 
+type CommandCheckResult = {
+  ok: boolean;
+  exitStatus: number;
+};
+
 type SnapshotCollector = {
   addFile: (sourceName: string, fileName: string) => void;
   addShellCommand: (
@@ -61,6 +66,7 @@ const fileSuggestions = `
   ballin_config
   bash_completions
   bash_profile.sh
+  Brewfile
   bashrc.sh
   brackets_disabled_extensions
   brackets_extensions
@@ -218,12 +224,18 @@ const uploadGistFile = (id: string, filePath: string): boolean => {
   return result.status === 0 && !result.error;
 };
 
-const verifyGistReadable = (id: string): boolean => {
+const verifyGistReadable = (id: string): CommandCheckResult => {
   const result = runGist(['-r', id], { stdio: ['ignore', 'ignore', 'inherit'] });
   if (result.error) {
-    reportSpawnError('gist', result.error);
+    return {
+      ok: false,
+      exitStatus: reportSpawnError('gist', result.error),
+    };
   }
-  return result.status === 0 && !result.error;
+  if (result.status !== 0) {
+    return { ok: false, exitStatus: 1 };
+  }
+  return { ok: true, exitStatus: 0 };
 };
 
 const readGistFileToStdout = (id: string, fileName: string): boolean => {
@@ -573,9 +585,10 @@ const runGuCli = (args = process.argv.slice(2)): void => {
     return;
   }
 
-  if (!verifyGistReadable(config.id)) {
+  const gistReadable = verifyGistReadable(config.id);
+  if (!gistReadable.ok) {
     writeStdoutLine("Error retrieving your gist, please run 'ballin_update'.");
-    process.exitCode = 1;
+    process.exitCode = gistReadable.exitStatus;
     return;
   }
 

--- a/commands/gu.ts
+++ b/commands/gu.ts
@@ -33,6 +33,16 @@ type SnapshotResultState = 'unchanged' | 'created' | 'removed' | 'updated';
 
 type SnapshotOptions = Pick<SnapshotCommand, 'env' | 'suppressStderrOnSuccess'>;
 
+type ConfigValueResult = {
+  value: string;
+  spawnStatus?: number;
+};
+
+type GuConfigResult = {
+  config: { id: string; url: string } | null;
+  exitStatus: number;
+};
+
 type SnapshotCollector = {
   addFile: (sourceName: string, fileName: string) => void;
   addShellCommand: (
@@ -78,27 +88,6 @@ const fileSuggestions = `
   zprofile.sh
   zshrc.sh`;
 
-const configValue = (key: string): string => (
-  readCommandOutput('ballin_config', ['get', key], { stdio: ['ignore', 'pipe', 'inherit'] })?.trim() ?? ''
-);
-
-const guConfig = (): { id: string; url: string } | null => {
-  const id = configValue('gu.id');
-  const url = configValue('gu.url');
-
-  if (id && url) {
-    return { id, url };
-  }
-
-  if (!id) {
-    writeStderrLine('gu: missing config value gu.id');
-  }
-  if (!url) {
-    writeStderrLine('gu: missing config value gu.url');
-  }
-  return null;
-};
-
 const runGist = (args: string[], options = {}): ReturnType<typeof runCommand> => (
   runCommand('gist', args, options)
 );
@@ -115,6 +104,44 @@ const reportSpawnError = (command: string, error: Error): number => {
   }
   writeStderrLine(error.message);
   return 1;
+};
+
+const configValue = (key: string): ConfigValueResult => {
+  const result = runCommand('ballin_config', ['get', key], {
+    stdio: ['ignore', 'pipe', 'inherit'],
+  });
+  if (result.error) {
+    return {
+      value: '',
+      spawnStatus: reportSpawnError('ballin_config', result.error),
+    };
+  }
+  if (result.status !== 0) {
+    return { value: '' };
+  }
+  return { value: result.stdout.trim() };
+};
+
+const guConfig = (): GuConfigResult => {
+  const idResult = configValue('gu.id');
+  const urlResult = configValue('gu.url');
+  const id = idResult.value;
+  const url = urlResult.value;
+
+  if (id && url) {
+    return { config: { id, url }, exitStatus: 0 };
+  }
+
+  if (!id) {
+    writeStderrLine('gu: missing config value gu.id');
+  }
+  if (!url) {
+    writeStderrLine('gu: missing config value gu.url');
+  }
+  return {
+    config: null,
+    exitStatus: idResult.spawnStatus ?? urlResult.spawnStatus ?? 1,
+  };
 };
 
 const shellStyleExitStatus = (result: ReturnType<typeof runCommand>): number => {
@@ -533,9 +560,9 @@ const runGuCli = (args = process.argv.slice(2)): void => {
     return;
   }
 
-  const config = guConfig();
+  const { config, exitStatus } = guConfig();
   if (!config) {
-    process.exitCode = 1;
+    process.exitCode = exitStatus;
     return;
   }
   const url = `${config.url}/${config.id}`;

--- a/commands/gu.ts
+++ b/commands/gu.ts
@@ -233,7 +233,7 @@ const verifyGistReadable = (id: string): CommandCheckResult => {
     };
   }
   if (result.status !== 0) {
-    return { ok: false, exitStatus: 1 };
+    return { ok: false, exitStatus: shellStyleExitStatus(result) };
   }
   return { ok: true, exitStatus: 0 };
 };

--- a/commands/gu.ts
+++ b/commands/gu.ts
@@ -124,7 +124,8 @@ const configValue = (key: string): ConfigValueResult => {
   if (result.status !== 0) {
     return { value: '' };
   }
-  return { value: result.stdout.trim() };
+  const value = result.stdout.trim();
+  return { value: value === 'null' ? '' : value };
 };
 
 const guConfig = (): GuConfigResult => {

--- a/commands/gu.ts
+++ b/commands/gu.ts
@@ -82,6 +82,23 @@ const configValue = (key: string): string => (
   readCommandOutput('ballin_config', ['get', key], { stdio: ['ignore', 'pipe', 'inherit'] })?.trim() ?? ''
 );
 
+const guConfig = (): { id: string; url: string } | null => {
+  const id = configValue('gu.id');
+  const url = configValue('gu.url');
+
+  if (id && url) {
+    return { id, url };
+  }
+
+  if (!id) {
+    writeStderrLine('gu: missing config value gu.id');
+  }
+  if (!url) {
+    writeStderrLine('gu: missing config value gu.url');
+  }
+  return null;
+};
+
 const runGist = (args: string[], options = {}): ReturnType<typeof runCommand> => (
   runCommand('gist', args, options)
 );
@@ -483,6 +500,11 @@ const runGuCli = (args = process.argv.slice(2)): void => {
   const command = args[0];
 
   if (command === 'help') {
+    if (args.length !== 1) {
+      writeStderrLine('gu help: expected no arguments');
+      process.exitCode = 1;
+      return;
+    }
     process.exitCode = runVisible('ballin');
     return;
   }
@@ -511,8 +533,12 @@ const runGuCli = (args = process.argv.slice(2)): void => {
     return;
   }
 
-  const id = configValue('gu.id');
-  const url = `${configValue('gu.url')}/${id}`;
+  const config = guConfig();
+  if (!config) {
+    process.exitCode = 1;
+    return;
+  }
+  const url = `${config.url}/${config.id}`;
 
   if (command === 'open') {
     writeStdoutLine(url);
@@ -520,14 +546,14 @@ const runGuCli = (args = process.argv.slice(2)): void => {
     return;
   }
 
-  if (!verifyGistReadable(id)) {
+  if (!verifyGistReadable(config.id)) {
     writeStdoutLine("Error retrieving your gist, please run 'ballin_update'.");
     process.exitCode = 1;
     return;
   }
 
   if (command === 'read') {
-    if (readGistFileToStdout(id, args[1])) {
+    if (readGistFileToStdout(config.id, args[1])) {
       return;
     } else {
       process.stdout.write(`\nOptions: ${fileSuggestions}\n`);
@@ -541,7 +567,7 @@ const runGuCli = (args = process.argv.slice(2)): void => {
 
   let failed = false;
   collectSnapshots(homeDir).forEach((snapshot) => {
-    if (!updateSnapshot(id, cacheDir, snapshot)) {
+    if (!updateSnapshot(config.id, cacheDir, snapshot)) {
       writeStderrLine(`gu: failed to snapshot ${snapshot.fileName}`);
       failed = true;
     }

--- a/commands/gu.ts
+++ b/commands/gu.ts
@@ -493,8 +493,20 @@ const runGuCli = (args = process.argv.slice(2)): void => {
     return;
   }
 
+  if (command === 'open' && args.length !== 1) {
+    writeStderrLine('gu open: expected no arguments');
+    process.exitCode = 1;
+    return;
+  }
+
   if (command === 'read' && !args[1]) {
     process.stdout.write(`Error: 'read' needs a filename.\n\nOptions: ${fileSuggestions}\n`);
+    process.exitCode = 1;
+    return;
+  }
+
+  if (command === 'read' && args.length !== 2) {
+    writeStderrLine('gu read: expected exactly one filename');
     process.exitCode = 1;
     return;
   }

--- a/commands/gu.ts
+++ b/commands/gu.ts
@@ -480,14 +480,33 @@ const collectSnapshots = (homeDir: string): SnapshotCommand[] => {
 
 const runGuCli = (args = process.argv.slice(2)): void => {
   const homeDir = process.env.HOME ?? '';
+  const command = args[0];
 
-  if (args[0] === 'help') {
+  if (command === 'help') {
     process.exitCode = runVisible('ballin');
+    return;
+  }
+
+  if (command && !['open', 'read'].includes(command)) {
+    writeStderrLine(`gu: unknown command '${command}'`);
+    process.exitCode = 1;
+    return;
+  }
+
+  if (command === 'read' && !args[1]) {
+    process.stdout.write(`Error: 'read' needs a filename.\n\nOptions: ${fileSuggestions}\n`);
+    process.exitCode = 1;
     return;
   }
 
   const id = configValue('gu.id');
   const url = `${configValue('gu.url')}/${id}`;
+
+  if (command === 'open') {
+    writeStdoutLine(url);
+    process.exitCode = runVisible('open', [url]);
+    return;
+  }
 
   if (!verifyGistReadable(id)) {
     writeStdoutLine("Error retrieving your gist, please run 'ballin_update'.");
@@ -495,24 +514,11 @@ const runGuCli = (args = process.argv.slice(2)): void => {
     return;
   }
 
-  if (args.length > 0) {
-    if (args[0] === 'open') {
-      writeStdoutLine(url);
-      process.exitCode = runVisible('open', [url]);
-    } else if (args[0] === 'read') {
-      if (args[1]) {
-        if (readGistFileToStdout(id, args[1])) {
-          return;
-        } else {
-          process.stdout.write(`\nOptions: ${fileSuggestions}\n`);
-          process.exitCode = 1;
-        }
-      } else {
-        process.stdout.write(`Error: 'read' needs a filename.\n\nOptions: ${fileSuggestions}\n`);
-        process.exitCode = 1;
-      }
+  if (command === 'read') {
+    if (readGistFileToStdout(id, args[1])) {
+      return;
     } else {
-      writeStderrLine(`gu: unknown command '${args[0]}'`);
+      process.stdout.write(`\nOptions: ${fileSuggestions}\n`);
       process.exitCode = 1;
     }
     return;

--- a/commands/gu.ts
+++ b/commands/gu.ts
@@ -24,6 +24,29 @@ type SnapshotCommand = {
   suppressStderrOnSuccess?: boolean;
 };
 
+type SnapshotCacheState = {
+  cacheFile: string;
+  isNew: boolean;
+};
+
+type SnapshotResultState = 'unchanged' | 'created' | 'removed' | 'updated';
+
+type SnapshotOptions = Pick<SnapshotCommand, 'env' | 'suppressStderrOnSuccess'>;
+
+type SnapshotCollector = {
+  addFile: (sourceName: string, fileName: string) => void;
+  addShellCommand: (
+    fileName: string,
+    command: string,
+    cwd?: string,
+    options?: SnapshotOptions,
+  ) => void;
+  addDirectoryListing: (fileName: string, directory: string) => void;
+  snapshots: SnapshotCommand[];
+};
+
+const emptySnapshotContent = 'empty\n';
+
 const fileSuggestions = `
   ballin_config
   bash_completions
@@ -124,6 +147,48 @@ const writeFileToStderr = (filePath: string): void => {
   }
 };
 
+const readGistFileToFile = (
+  id: string,
+  fileName: string,
+  outputFile: string,
+  stderr: 'inherit' | 'ignore',
+): boolean => {
+  const outputFd = fs.openSync(outputFile, 'w');
+  let result: ReturnType<typeof runCommand>;
+  try {
+    result = runGist(['-r', id, fileName], { stdio: ['ignore', outputFd, stderr] });
+  } finally {
+    fs.closeSync(outputFd);
+  }
+  if (result.error) {
+    reportSpawnError('gist', result.error);
+  }
+  return result.status === 0 && !result.error;
+};
+
+const uploadGistFile = (id: string, filePath: string): void => {
+  const result = runGist(['-u', id, filePath], { stdio: ['ignore', 'ignore', 'inherit'] });
+  if (result.error) {
+    reportSpawnError('gist', result.error);
+  }
+};
+
+const verifyGistReadable = (id: string): boolean => {
+  const result = runGist(['-r', id], { stdio: ['ignore', 'ignore', 'inherit'] });
+  if (result.error) {
+    reportSpawnError('gist', result.error);
+  }
+  return result.status === 0 && !result.error;
+};
+
+const readGistFileToStdout = (id: string, fileName: string): boolean => {
+  const result = runGist(['-r', id, fileName], { stdio: ['ignore', 'inherit', 'inherit'] });
+  if (result.error) {
+    reportSpawnError('gist', result.error);
+  }
+  return result.status === 0 && !result.error;
+};
+
 const captureSnapshotInput = (snapshot: SnapshotCommand, inputFile: string): boolean => {
   const outputFd = fs.openSync(inputFile, 'w');
   const stderrFile = makeTempFile('ballin-gu-stderr-');
@@ -152,32 +217,75 @@ const captureSnapshotInput = (snapshot: SnapshotCommand, inputFile: string): boo
 };
 
 const seedCacheFromGist = (id: string, fileName: string, cacheFile: string): boolean => {
-  const outputFd = fs.openSync(cacheFile, 'w');
-  let result: ReturnType<typeof runCommand>;
-  try {
-    result = runGist(['-r', id, fileName], { stdio: ['ignore', outputFd, 'inherit'] });
-  } finally {
-    fs.closeSync(outputFd);
-  }
-  if (result.error) {
-    reportSpawnError('gist', result.error);
-  }
-  if (result.status === 0 && !result.error) {
+  if (readGistFileToFile(id, fileName, cacheFile, 'inherit')) {
     return true;
   }
   fs.rmSync(cacheFile, { force: true });
   return false;
 };
 
-const updateSnapshot = (id: string, cacheDir: string, snapshot: SnapshotCommand): boolean => {
-  const cacheFile = path.join(cacheDir, snapshot.fileName);
-  let isNew = false;
-  let isChanged = true;
-  let isEmpty = false;
+const prepareSnapshotCache = (id: string, cacheDir: string, fileName: string): SnapshotCacheState => {
+  const cacheFile = path.join(cacheDir, fileName);
+  const isNew = !fileExists(cacheFile) && !seedCacheFromGist(id, fileName, cacheFile);
+  return { cacheFile, isNew };
+};
 
-  if (!fileExists(cacheFile)) {
-    isNew = !seedCacheFromGist(id, snapshot.fileName, cacheFile);
+const normalizeSnapshotInput = (inputFile: string): void => {
+  if (fs.statSync(inputFile).size === 0) {
+    fs.writeFileSync(inputFile, emptySnapshotContent);
+  } else {
+    ensureTrailingNewline(inputFile);
   }
+};
+
+const snapshotFilesMatch = (leftFile: string, rightFile: string): boolean => (
+  fs.readFileSync(leftFile).equals(fs.readFileSync(rightFile))
+);
+
+const snapshotIsEmpty = (filePath: string): boolean => (
+  fs.readFileSync(filePath, 'utf8') === emptySnapshotContent
+);
+
+const classifySnapshotResult = (
+  isNew: boolean,
+  isChanged: boolean,
+  isEmpty: boolean,
+): SnapshotResultState => {
+  if (!isChanged) {
+    return 'unchanged';
+  }
+  if (isNew) {
+    return 'created';
+  }
+  if (isEmpty) {
+    return 'removed';
+  }
+  return 'updated';
+};
+
+const writeSnapshotStatus = (
+  snapshot: SnapshotCommand,
+  resultState: SnapshotResultState,
+  isEmpty: boolean,
+): void => {
+  const fileWithoutExtension = snapshot.fileName.replace(/\.[^.]*$/, '');
+  if (resultState === 'unchanged') {
+    if (!isEmpty) {
+      writeStdoutLine(`✔ ${fileWithoutExtension}`);
+    }
+  } else if (resultState === 'created') {
+    writeStdoutLine(`💾 ${fileWithoutExtension}`);
+  } else if (resultState === 'removed') {
+    writeStdoutLine(`✖︎ ${fileWithoutExtension}`);
+  } else {
+    writeStdoutLine(`✚ ${fileWithoutExtension}`);
+  }
+};
+
+const updateSnapshot = (id: string, cacheDir: string, snapshot: SnapshotCommand): boolean => {
+  const { cacheFile, isNew } = prepareSnapshotCache(id, cacheDir, snapshot.fileName);
+  let resultState: SnapshotResultState = 'updated';
+  let isEmpty = false;
 
   const inputFile = makeTempFile('ballin-gu-input-');
   try {
@@ -185,43 +293,27 @@ const updateSnapshot = (id: string, cacheDir: string, snapshot: SnapshotCommand)
       return false;
     }
 
-    if (fs.statSync(inputFile).size === 0) {
-      fs.writeFileSync(inputFile, 'empty\n');
-    } else {
-      ensureTrailingNewline(inputFile);
-    }
+    normalizeSnapshotInput(inputFile);
 
+    let isChanged = true;
     if (!isNew && fileExists(cacheFile)) {
-      isChanged = !fs.readFileSync(inputFile).equals(fs.readFileSync(cacheFile));
+      isChanged = !snapshotFilesMatch(inputFile, cacheFile);
     }
 
     if (isChanged) {
       fs.copyFileSync(inputFile, cacheFile);
     }
-    isEmpty = fs.readFileSync(cacheFile, 'utf8') === 'empty\n';
+    isEmpty = snapshotIsEmpty(cacheFile);
+    resultState = classifySnapshotResult(isNew, isChanged, isEmpty);
   } finally {
     removeTempFile(inputFile);
   }
 
-  if (isChanged) {
-    const result = runGist(['-u', id, cacheFile], { stdio: ['ignore', 'ignore', 'inherit'] });
-    if (result.error) {
-      reportSpawnError('gist', result.error);
-    }
+  if (resultState !== 'unchanged') {
+    uploadGistFile(id, cacheFile);
   }
 
-  const fileWithoutExtension = snapshot.fileName.replace(/\.[^.]*$/, '');
-  if (!isChanged) {
-    if (!isEmpty) {
-      writeStdoutLine(`✔ ${fileWithoutExtension}`);
-    }
-  } else if (isNew) {
-    writeStdoutLine(`💾 ${fileWithoutExtension}`);
-  } else if (isEmpty) {
-    writeStdoutLine(`✖︎ ${fileWithoutExtension}`);
-  } else {
-    writeStdoutLine(`✚ ${fileWithoutExtension}`);
-  }
+  writeSnapshotStatus(snapshot, resultState, isEmpty);
 
   return true;
 };
@@ -244,19 +336,50 @@ const shellSnapshot = (
   cwd,
 });
 
-const collectSnapshots = (homeDir: string): SnapshotCommand[] => {
+const directoryListingSnapshot = (fileName: string, directory: string): SnapshotCommand => ({
+  fileName,
+  command: 'ls',
+  args: [directory],
+});
+
+const createSnapshotCollector = (homeDir: string): SnapshotCollector => {
   const snapshots: SnapshotCommand[] = [];
-  const addIfFile = (sourceName: string, fileName: string): void => {
+  const addFile = (sourceName: string, fileName: string): void => {
     if (fileExists(path.join(homeDir, sourceName))) {
       snapshots.push(catSnapshot(homeDir, fileName, sourceName));
     }
   };
+  const addShellCommand = (
+    fileName: string,
+    command: string,
+    cwd = homeDir,
+    options: SnapshotOptions = {},
+  ): void => {
+    snapshots.push({ ...shellSnapshot(fileName, command, cwd), ...options });
+  };
+  const addDirectoryListing = (fileName: string, directory: string): void => {
+    if (dirExists(directory)) {
+      snapshots.push(directoryListingSnapshot(fileName, directory));
+    }
+  };
 
-  addIfFile('.bash_profile', 'bash_profile.sh');
-  addIfFile('.bashrc', 'bashrc.sh');
-  addIfFile('.profile', 'profile.sh');
-  addIfFile('.zprofile', 'zprofile.sh');
-  addIfFile('.zshrc', 'zshrc.sh');
+  return {
+    addFile,
+    addShellCommand,
+    addDirectoryListing,
+    snapshots,
+  };
+};
+
+const collectSnapshots = (homeDir: string): SnapshotCommand[] => {
+  const collector = createSnapshotCollector(homeDir);
+  const { addFile, addShellCommand, addDirectoryListing, snapshots } = collector;
+
+  addFile('.bash_profile', 'bash_profile.sh');
+  addFile('.bashrc', 'bashrc.sh');
+  addFile('.profile', 'profile.sh');
+  addFile('.zprofile', 'zprofile.sh');
+  addFile('.zshrc', 'zshrc.sh');
 
   const brewAvailable = commandExists('brew');
   let bashCompletionDir = process.env.BALLIN_GU_BASH_COMPLETION_DIR ?? '';
@@ -273,11 +396,7 @@ const collectSnapshots = (homeDir: string): SnapshotCommand[] => {
     }
   }
   if (bashCompletionDir && dirExists(bashCompletionDir)) {
-    snapshots.push({
-      fileName: 'bash_completions',
-      command: 'ls',
-      args: [bashCompletionDir],
-    });
+    addDirectoryListing('bash_completions', bashCompletionDir);
   }
 
   if (brewAvailable) {
@@ -286,25 +405,24 @@ const collectSnapshots = (homeDir: string): SnapshotCommand[] => {
       HOMEBREW_NO_AUTO_UPDATE: '1',
       HOMEBREW_NO_ENV_HINTS: '1',
     };
-    snapshots.push({ ...shellSnapshot('brew_list', 'brew list --formula', homeDir), env: brewEnv });
-    snapshots.push({ ...shellSnapshot('brew_leaves', 'brew leaves', homeDir), env: brewEnv });
-    snapshots.push({ ...shellSnapshot('brew_cask', 'brew list --cask', homeDir), env: brewEnv });
-    snapshots.push({
-      ...shellSnapshot('brew_services', 'brew services list', homeDir),
+    addShellCommand('brew_list', 'brew list --formula', homeDir, { env: brewEnv });
+    addShellCommand('brew_leaves', 'brew leaves', homeDir, { env: brewEnv });
+    addShellCommand('brew_cask', 'brew list --cask', homeDir, { env: brewEnv });
+    addShellCommand('brew_services', 'brew services list', homeDir, {
       env: brewEnv,
       suppressStderrOnSuccess: true,
     });
-    snapshots.push({ ...shellSnapshot('Brewfile', 'brew bundle dump --file=-', homeDir), env: brewEnv });
+    addShellCommand('Brewfile', 'brew bundle dump --file=-', homeDir, { env: brewEnv });
   }
 
-  addIfFile('.gitignore_global', 'gitignore_global');
-  addIfFile('.gitconfig', 'gitconfig');
+  addFile('.gitignore_global', 'gitignore_global');
+  addFile('.gitconfig', 'gitconfig');
 
   if (commandExists('npm')) {
-    snapshots.push(shellSnapshot('npm_global', 'npm list -g --depth=0', homeDir));
+    addShellCommand('npm_global', 'npm list -g --depth=0');
   }
 
-  addIfFile('.nvmrc', 'nvmrc');
+  addFile('.nvmrc', 'nvmrc');
 
   [
     ['Code', 'code', 'vs'],
@@ -320,7 +438,7 @@ const collectSnapshots = (homeDir: string): SnapshotCommand[] => {
       }
     });
     if (commandExists(binaryName)) {
-      snapshots.push(shellSnapshot(`${prefix}_extensions`, `${binaryName} --list-extensions`, vscodeDir));
+      addShellCommand(`${prefix}_extensions`, `${binaryName} --list-extensions`, vscodeDir);
     }
   });
 
@@ -332,16 +450,16 @@ const collectSnapshots = (homeDir: string): SnapshotCommand[] => {
     if (fileExists(path.join(bracketsDir, 'keymap.json'))) {
       snapshots.push(catSnapshot(bracketsDir, 'brackets_keymap.json', 'keymap.json'));
     }
-    snapshots.push(shellSnapshot('brackets_extensions', 'ls -A extensions/user/', bracketsDir));
-    snapshots.push(shellSnapshot('brackets_disabled_extensions', 'ls -A extensions/disabled/', bracketsDir));
+    addShellCommand('brackets_extensions', 'ls -A extensions/user/', bracketsDir);
+    addShellCommand('brackets_disabled_extensions', 'ls -A extensions/disabled/', bracketsDir);
   }
 
-  addIfFile('.vimrc', 'vimrc');
-  addIfFile('.nanorc', 'nanorc');
-  addIfFile(path.join('.ballin-scripts', 'ballin.config.json'), 'ballin_config');
+  addFile('.vimrc', 'vimrc');
+  addFile('.nanorc', 'nanorc');
+  addFile(path.join('.ballin-scripts', 'ballin.config.json'), 'ballin_config');
 
   if (commandExists('mas')) {
-    snapshots.push(shellSnapshot('mas', 'mas list', homeDir));
+    addShellCommand('mas', 'mas list');
   }
 
   return snapshots;
@@ -352,11 +470,7 @@ const runGuCli = (args = process.argv.slice(2)): void => {
   const id = configValue('gu.id');
   const url = `${configValue('gu.url')}/${id}`;
 
-  const initialGistRead = runGist(['-r', id], { stdio: ['ignore', 'ignore', 'inherit'] });
-  if (initialGistRead.error) {
-    reportSpawnError('gist', initialGistRead.error);
-  }
-  if (initialGistRead.status !== 0 || initialGistRead.error) {
+  if (!verifyGistReadable(id)) {
     writeStdoutLine("Error retrieving your gist, please run 'ballin_update'.");
     return;
   }
@@ -367,11 +481,7 @@ const runGuCli = (args = process.argv.slice(2)): void => {
       process.exitCode = runVisible('open', [url]);
     } else if (args[0] === 'read') {
       if (args[1]) {
-        const result = runGist(['-r', id, args[1]], { stdio: ['ignore', 'inherit', 'inherit'] });
-        if (result.error) {
-          reportSpawnError('gist', result.error);
-        }
-        if (result.status === 0) {
+        if (readGistFileToStdout(id, args[1])) {
           return;
         } else {
           process.stdout.write(`\nOptions: ${fileSuggestions}\n`);

--- a/commands/gu.ts
+++ b/commands/gu.ts
@@ -166,11 +166,12 @@ const readGistFileToFile = (
   return result.status === 0 && !result.error;
 };
 
-const uploadGistFile = (id: string, filePath: string): void => {
+const uploadGistFile = (id: string, filePath: string): boolean => {
   const result = runGist(['-u', id, filePath], { stdio: ['ignore', 'ignore', 'inherit'] });
   if (result.error) {
     reportSpawnError('gist', result.error);
   }
+  return result.status === 0 && !result.error;
 };
 
 const verifyGistReadable = (id: string): boolean => {
@@ -310,7 +311,9 @@ const updateSnapshot = (id: string, cacheDir: string, snapshot: SnapshotCommand)
   }
 
   if (resultState !== 'unchanged') {
-    uploadGistFile(id, cacheFile);
+    if (!uploadGistFile(id, cacheFile)) {
+      return false;
+    }
   }
 
   writeSnapshotStatus(snapshot, resultState, isEmpty);
@@ -472,6 +475,7 @@ const runGuCli = (args = process.argv.slice(2)): void => {
 
   if (!verifyGistReadable(id)) {
     writeStdoutLine("Error retrieving your gist, please run 'ballin_update'.");
+    process.exitCode = 1;
     return;
   }
 
@@ -485,9 +489,11 @@ const runGuCli = (args = process.argv.slice(2)): void => {
           return;
         } else {
           process.stdout.write(`\nOptions: ${fileSuggestions}\n`);
+          process.exitCode = 1;
         }
       } else {
         process.stdout.write(`Error: 'read' needs a filename.\n\nOptions: ${fileSuggestions}\n`);
+        process.exitCode = 1;
       }
     } else if (args[0] === 'help') {
       process.exitCode = runVisible('ballin');

--- a/test/gu.test.ts
+++ b/test/gu.test.ts
@@ -144,6 +144,15 @@ exit 42
     fs.chmodSync(path.join(testBinDir, 'ballin_config'), 0o644);
   };
 
+  const removeGistCommand = () => {
+    fs.rmSync(path.join(testBinDir, 'gist'));
+  };
+
+  const makeGistCommandPermissionDenied = () => {
+    fs.writeFileSync(path.join(testBinDir, 'gist'), 'not executable\n', { mode: 0o644 });
+    fs.chmodSync(path.join(testBinDir, 'gist'), 0o644);
+  };
+
   const installFakeBallinCommand = () => {
     writeTestExecutable('ballin', `#!/usr/bin/env bash
 printf '%s\\n' "$*" >> "$FAKE_BALLIN_LOG"
@@ -476,6 +485,7 @@ kill -TERM "$$"
 
     assert.equal(result.status, 1);
     assert.include(result.stdout, '\nOptions: ');
+    assert.include(result.stdout, 'Brewfile');
     assert.include(result.stdout, 'ballin_config');
     assert.include(result.stdout, 'vsI_settings');
     assert.deepEqual(gistReads(), ['missing_file']);
@@ -506,6 +516,32 @@ kill -TERM "$$"
     assert.equal(result.status, 1);
     assert.equal(result.stdout, "Error retrieving your gist, please run 'ballin_update'.\n");
     assert.equal(result.stderr, 'simulated initial gist read failure\n');
+    assert.isFalse(fs.existsSync(guCacheDir));
+    assert.deepEqual(gistReads(), []);
+    assert.deepEqual(gistUploads(), []);
+  });
+
+  it('reports missing gist reads before snapshotting', () => {
+    removeGistCommand();
+
+    const result = runGu();
+
+    assert.equal(result.status, 127);
+    assert.equal(result.stdout, "Error retrieving your gist, please run 'ballin_update'.\n");
+    assert.equal(result.stderr, 'gist: command not found\n');
+    assert.isFalse(fs.existsSync(guCacheDir));
+    assert.deepEqual(gistReads(), []);
+    assert.deepEqual(gistUploads(), []);
+  });
+
+  it('reports permission-denied gist reads before snapshotting', () => {
+    makeGistCommandPermissionDenied();
+
+    const result = runGu();
+
+    assert.equal(result.status, 126);
+    assert.equal(result.stdout, "Error retrieving your gist, please run 'ballin_update'.\n");
+    assert.equal(result.stderr, 'gist: Permission denied\n');
     assert.isFalse(fs.existsSync(guCacheDir));
     assert.deepEqual(gistReads(), []);
     assert.deepEqual(gistUploads(), []);

--- a/test/gu.test.ts
+++ b/test/gu.test.ts
@@ -30,6 +30,7 @@ type RunGuOptions = {
   brewPrefixFail?: boolean;
   completionDir?: string;
   gistInitialReadFail?: boolean;
+  gistInitialReadSignal?: boolean;
   gistUploadFail?: boolean;
   commandPath?: string;
 };
@@ -89,6 +90,9 @@ if [ "$1" = '-r' ]; then
     if [ "$FAKE_GIST_INITIAL_READ_FAIL" = 'true' ]; then
       printf '%s\\n' 'simulated initial gist read failure' >&2
       exit 17
+    fi
+    if [ "$FAKE_GIST_INITIAL_READ_SIGNAL" = 'true' ]; then
+      kill -TERM "$$"
     fi
     exit 0
   elif [ "$#" -ne 3 ]; then
@@ -245,6 +249,7 @@ done
     brewPrefixFail = false,
     completionDir,
     gistInitialReadFail = false,
+    gistInitialReadSignal = false,
     gistUploadFail = false,
     commandPath = guPath,
   }: RunGuOptions = {}) => spawnSync(commandPath, args, {
@@ -261,6 +266,7 @@ done
       FAKE_GIST_READ_LOG: gistReadLogPath,
       FAKE_GIST_UPLOAD_LOG: gistUploadLogPath,
       FAKE_GIST_INITIAL_READ_FAIL: gistInitialReadFail ? 'true' : 'false',
+      FAKE_GIST_INITIAL_READ_SIGNAL: gistInitialReadSignal ? 'true' : 'false',
       FAKE_GIST_UPLOAD_FAIL: gistUploadFail ? 'true' : 'false',
       FAKE_BREW_LOG: brewLogPath,
       FAKE_OPEN_LOG: openLogPath,
@@ -510,12 +516,23 @@ kill -TERM "$$"
     assert.deepEqual(gistReads(), []);
   });
 
-  it('reports an initial Gist retrieval failure before snapshotting', () => {
+  it('uses the initial Gist retrieval failure status before snapshotting', () => {
     const result = runGu({ gistInitialReadFail: true });
 
-    assert.equal(result.status, 1);
+    assert.equal(result.status, 17);
     assert.equal(result.stdout, "Error retrieving your gist, please run 'ballin_update'.\n");
     assert.equal(result.stderr, 'simulated initial gist read failure\n');
+    assert.isFalse(fs.existsSync(guCacheDir));
+    assert.deepEqual(gistReads(), []);
+    assert.deepEqual(gistUploads(), []);
+  });
+
+  it('uses a shell-style signal exit status for initial Gist retrieval', () => {
+    const result = runGu({ gistInitialReadSignal: true });
+
+    assert.equal(result.status, 143);
+    assert.equal(result.stdout, "Error retrieving your gist, please run 'ballin_update'.\n");
+    assert.equal(result.stderr, '');
     assert.isFalse(fs.existsSync(guCacheDir));
     assert.deepEqual(gistReads(), []);
     assert.deepEqual(gistUploads(), []);

--- a/test/gu.test.ts
+++ b/test/gu.test.ts
@@ -354,6 +354,25 @@ kill -TERM "$$"
     assert.deepEqual(ballinCalls(), ['']);
   });
 
+  it('prints help without requiring a readable Gist', () => {
+    const result = runGu({ args: ['help'], gistInitialReadFail: true });
+
+    assertGuSucceeded(result);
+    assert.equal(result.stdout, 'fake ballin help\n');
+    assert.deepEqual(ballinCalls(), ['']);
+    assert.deepEqual(gistReads(), []);
+  });
+
+  it('fails unknown commands instead of ignoring them', () => {
+    const result = runGu({ args: ['typo'] });
+
+    assert.equal(result.status, 1);
+    assert.equal(result.stdout, '');
+    assert.equal(result.stderr, "gu: unknown command 'typo'\n");
+    assert.deepEqual(gistReads(), []);
+    assert.deepEqual(gistUploads(), []);
+  });
+
   it('reads a named Gist file', () => {
     seedFakeGistFile('vimrc', 'set number\n');
 

--- a/test/gu.test.ts
+++ b/test/gu.test.ts
@@ -801,9 +801,25 @@ printf '%s\\n' '123456 Example App'
     assert.equal(result.stderr, 'simulated gist upload failure\ngu: failed to snapshot zshrc.sh\n');
     assert.deepEqual(fs.readdirSync(scratchDir), []);
     assert.equal(result.stdout, '');
-    assert.equal(fs.readFileSync(cachedSnapshotPath(), 'utf8'), 'export COLOR=blue\n');
+    assert.equal(fs.readFileSync(cachedSnapshotPath(), 'utf8'), 'export COLOR=red\n');
     assert.equal(fs.readFileSync(fakeGistFilePath(), 'utf8'), 'export COLOR=red\n');
     assert.deepEqual(gistUploads(), []);
+  });
+
+  it('retries a changed snapshot after a failed Gist upload', () => {
+    writeSnapshot('export COLOR=blue\n');
+    seedGuCache('export COLOR=red\n');
+    seedFakeGist('export COLOR=red\n');
+
+    const failedResult = runGu({ gistUploadFail: true });
+    const retriedResult = runGu();
+
+    assert.equal(failedResult.status, 1);
+    assertGuSucceeded(retriedResult);
+    assert.equal(retriedResult.stdout, '✚ zshrc\n');
+    assert.equal(fs.readFileSync(cachedSnapshotPath(), 'utf8'), 'export COLOR=blue\n');
+    assert.equal(fs.readFileSync(fakeGistFilePath(), 'utf8'), 'export COLOR=blue\n');
+    assert.deepEqual(gistUploads(), [snapshotFileName]);
   });
 
   it('streams large snapshot output without the default spawn buffer limit', () => {

--- a/test/gu.test.ts
+++ b/test/gu.test.ts
@@ -135,6 +135,15 @@ exit 42
 `);
   };
 
+  const removeBallinConfigCommand = () => {
+    fs.rmSync(path.join(testBinDir, 'ballin_config'));
+  };
+
+  const makeBallinConfigCommandPermissionDenied = () => {
+    fs.writeFileSync(path.join(testBinDir, 'ballin_config'), 'not executable\n', { mode: 0o644 });
+    fs.chmodSync(path.join(testBinDir, 'ballin_config'), 0o644);
+  };
+
   const installFakeBallinCommand = () => {
     writeTestExecutable('ballin', `#!/usr/bin/env bash
 printf '%s\\n' "$*" >> "$FAKE_BALLIN_LOG"
@@ -513,6 +522,44 @@ kill -TERM "$$"
       result.stderr,
       'ballin_config failed for gu.id\n'
         + 'ballin_config failed for gu.url\n'
+        + 'gu: missing config value gu.id\n'
+        + 'gu: missing config value gu.url\n',
+    );
+    assert.isFalse(fs.existsSync(guCacheDir));
+    assert.deepEqual(gistReads(), []);
+    assert.deepEqual(gistUploads(), []);
+  });
+
+  it('reports missing ballin_config reads before snapshotting', () => {
+    removeBallinConfigCommand();
+
+    const result = runGu();
+
+    assert.equal(result.status, 127);
+    assert.equal(result.stdout, '');
+    assert.equal(
+      result.stderr,
+      'ballin_config: command not found\n'
+        + 'ballin_config: command not found\n'
+        + 'gu: missing config value gu.id\n'
+        + 'gu: missing config value gu.url\n',
+    );
+    assert.isFalse(fs.existsSync(guCacheDir));
+    assert.deepEqual(gistReads(), []);
+    assert.deepEqual(gistUploads(), []);
+  });
+
+  it('reports permission-denied ballin_config reads before snapshotting', () => {
+    makeBallinConfigCommandPermissionDenied();
+
+    const result = runGu();
+
+    assert.equal(result.status, 126);
+    assert.equal(result.stdout, '');
+    assert.equal(
+      result.stderr,
+      'ballin_config: Permission denied\n'
+        + 'ballin_config: Permission denied\n'
         + 'gu: missing config value gu.id\n'
         + 'gu: missing config value gu.url\n',
     );

--- a/test/gu.test.ts
+++ b/test/gu.test.ts
@@ -302,6 +302,15 @@ done
     assert.deepEqual(openCalls(), ['https://example.test/gists/test-gist-id']);
   });
 
+  it('opens the configured Gist URL without requiring a readable Gist', () => {
+    const result = runGu({ args: ['open'], gistInitialReadFail: true });
+
+    assertGuSucceeded(result);
+    assert.equal(result.stdout, 'https://example.test/gists/test-gist-id\n');
+    assert.deepEqual(openCalls(), ['https://example.test/gists/test-gist-id']);
+    assert.deepEqual(gistReads(), []);
+  });
+
   it('remains executable through the installed symlink model', () => {
     const linkPath = path.join(testBinDir, 'gu-link');
     fs.symlinkSync(guPath, linkPath);
@@ -373,6 +382,16 @@ kill -TERM "$$"
     assert.deepEqual(gistUploads(), []);
   });
 
+  it('fails unknown commands before checking Gist readability', () => {
+    const result = runGu({ args: ['typo'], gistInitialReadFail: true });
+
+    assert.equal(result.status, 1);
+    assert.equal(result.stdout, '');
+    assert.equal(result.stderr, "gu: unknown command 'typo'\n");
+    assert.deepEqual(gistReads(), []);
+    assert.deepEqual(gistUploads(), []);
+  });
+
   it('reads a named Gist file', () => {
     seedFakeGistFile('vimrc', 'set number\n');
 
@@ -412,6 +431,16 @@ kill -TERM "$$"
     assert.equal(result.status, 1);
     assert.include(result.stdout, "Error: 'read' needs a filename.");
     assert.include(result.stdout, '\nOptions: ');
+    assert.deepEqual(gistReads(), []);
+  });
+
+  it('reports a missing read filename before checking Gist readability', () => {
+    const result = runGu({ args: ['read'], gistInitialReadFail: true });
+
+    assert.equal(result.status, 1);
+    assert.include(result.stdout, "Error: 'read' needs a filename.");
+    assert.include(result.stdout, '\nOptions: ');
+    assert.equal(result.stderr, '');
     assert.deepEqual(gistReads(), []);
   });
 

--- a/test/gu.test.ts
+++ b/test/gu.test.ts
@@ -321,6 +321,24 @@ done
     assert.deepEqual(gistReads(), []);
   });
 
+  it('fails open when Gist config cannot be read', () => {
+    installFailingBallinConfigCommand();
+
+    const result = runGu({ args: ['open'] });
+
+    assert.equal(result.status, 1);
+    assert.equal(result.stdout, '');
+    assert.equal(
+      result.stderr,
+      'ballin_config failed for gu.id\n'
+        + 'ballin_config failed for gu.url\n'
+        + 'gu: missing config value gu.id\n'
+        + 'gu: missing config value gu.url\n',
+    );
+    assert.deepEqual(openCalls(), []);
+    assert.deepEqual(gistReads(), []);
+  });
+
   it('remains executable through the installed symlink model', () => {
     const linkPath = path.join(testBinDir, 'gu-link');
     fs.symlinkSync(guPath, linkPath);
@@ -379,6 +397,16 @@ kill -TERM "$$"
     assertGuSucceeded(result);
     assert.equal(result.stdout, 'fake ballin help\n');
     assert.deepEqual(ballinCalls(), ['']);
+    assert.deepEqual(gistReads(), []);
+  });
+
+  it('fails help when extra arguments are provided', () => {
+    const result = runGu({ args: ['help', 'extra'] });
+
+    assert.equal(result.status, 1);
+    assert.equal(result.stdout, '');
+    assert.equal(result.stderr, 'gu help: expected no arguments\n');
+    assert.deepEqual(ballinCalls(), []);
     assert.deepEqual(gistReads(), []);
   });
 
@@ -480,14 +508,16 @@ kill -TERM "$$"
     const result = runGu();
 
     assert.equal(result.status, 1);
-    assert.equal(result.stdout, "Error retrieving your gist, please run 'ballin_update'.\n");
+    assert.equal(result.stdout, '');
     assert.equal(
       result.stderr,
       'ballin_config failed for gu.id\n'
         + 'ballin_config failed for gu.url\n'
-        + 'Unexpected Gist ID\n',
+        + 'gu: missing config value gu.id\n'
+        + 'gu: missing config value gu.url\n',
     );
     assert.isFalse(fs.existsSync(guCacheDir));
+    assert.deepEqual(gistReads(), []);
     assert.deepEqual(gistUploads(), []);
   });
 

--- a/test/gu.test.ts
+++ b/test/gu.test.ts
@@ -380,7 +380,7 @@ kill -TERM "$$"
   it('prints options when a requested Gist file is missing', () => {
     const result = runGu({ args: ['read', 'missing_file'] });
 
-    assertGuSucceeded(result);
+    assert.equal(result.status, 1);
     assert.include(result.stdout, '\nOptions: ');
     assert.include(result.stdout, 'ballin_config');
     assert.include(result.stdout, 'vsI_settings');
@@ -390,7 +390,7 @@ kill -TERM "$$"
   it('prints options when read is missing a filename', () => {
     const result = runGu({ args: ['read'] });
 
-    assertGuSucceeded(result);
+    assert.equal(result.status, 1);
     assert.include(result.stdout, "Error: 'read' needs a filename.");
     assert.include(result.stdout, '\nOptions: ');
     assert.deepEqual(gistReads(), []);
@@ -399,7 +399,7 @@ kill -TERM "$$"
   it('reports an initial Gist retrieval failure before snapshotting', () => {
     const result = runGu({ gistInitialReadFail: true });
 
-    assert.equal(result.status, 0);
+    assert.equal(result.status, 1);
     assert.equal(result.stdout, "Error retrieving your gist, please run 'ballin_update'.\n");
     assert.equal(result.stderr, 'simulated initial gist read failure\n');
     assert.isFalse(fs.existsSync(guCacheDir));
@@ -412,7 +412,7 @@ kill -TERM "$$"
 
     const result = runGu();
 
-    assert.equal(result.status, 0);
+    assert.equal(result.status, 1);
     assert.equal(result.stdout, "Error retrieving your gist, please run 'ballin_update'.\n");
     assert.equal(
       result.stderr,
@@ -790,17 +790,17 @@ printf '%s\\n' '123456 Example App'
     assert.deepEqual(gistUploads(), [snapshotFileName]);
   });
 
-  it('keeps current shell behavior when a Gist upload fails', () => {
+  it('reports a failure when a Gist upload fails', () => {
     writeSnapshot('export COLOR=blue\n');
     seedGuCache('export COLOR=red\n');
     seedFakeGist('export COLOR=red\n');
 
     const result = runGu({ gistUploadFail: true });
 
-    assert.equal(result.status, 0);
-    assert.equal(result.stderr, 'simulated gist upload failure\n');
+    assert.equal(result.status, 1);
+    assert.equal(result.stderr, 'simulated gist upload failure\ngu: failed to snapshot zshrc.sh\n');
     assert.deepEqual(fs.readdirSync(scratchDir), []);
-    assert.equal(result.stdout, '✚ zshrc\n');
+    assert.equal(result.stdout, '');
     assert.equal(fs.readFileSync(cachedSnapshotPath(), 'utf8'), 'export COLOR=blue\n');
     assert.equal(fs.readFileSync(fakeGistFilePath(), 'utf8'), 'export COLOR=red\n');
     assert.deepEqual(gistUploads(), []);

--- a/test/gu.test.ts
+++ b/test/gu.test.ts
@@ -139,6 +139,22 @@ exit 42
 `);
   };
 
+  const installDefaultIdBallinConfigCommand = () => {
+    writeTestExecutable('ballin_config', `#!/usr/bin/env bash
+if [ "$1" != 'get' ]; then
+  printf '%s\\n' 'Unexpected ballin_config action' >&2
+  exit 2
+elif [ "$2" = 'gu.id' ]; then
+  printf '%s\\n' 'null'
+elif [ "$2" = 'gu.url' ]; then
+  printf '%s\\n' 'https://example.test/gists'
+else
+  printf '%s\\n' 'Unexpected ballin_config call' >&2
+  exit 2
+fi
+`);
+  };
+
   const removeBallinConfigCommand = () => {
     fs.rmSync(path.join(testBinDir, 'ballin_config'));
   };
@@ -359,6 +375,18 @@ done
         + 'gu: missing config value gu.id\n'
         + 'gu: missing config value gu.url\n',
     );
+    assert.deepEqual(openCalls(), []);
+    assert.deepEqual(gistReads(), []);
+  });
+
+  it('treats a default null Gist ID as missing when opening', () => {
+    installDefaultIdBallinConfigCommand();
+
+    const result = runGu({ args: ['open'] });
+
+    assert.equal(result.status, 1);
+    assert.equal(result.stdout, '');
+    assert.equal(result.stderr, 'gu: missing config value gu.id\n');
     assert.deepEqual(openCalls(), []);
     assert.deepEqual(gistReads(), []);
   });

--- a/test/gu.test.ts
+++ b/test/gu.test.ts
@@ -491,7 +491,6 @@ kill -TERM "$$"
 
     assert.equal(result.status, 1);
     assert.include(result.stdout, '\nOptions: ');
-    assert.include(result.stdout, 'Brewfile');
     assert.include(result.stdout, 'ballin_config');
     assert.include(result.stdout, 'vsI_settings');
     assert.deepEqual(gistReads(), ['missing_file']);

--- a/test/gu.test.ts
+++ b/test/gu.test.ts
@@ -311,6 +311,16 @@ done
     assert.deepEqual(gistReads(), []);
   });
 
+  it('fails open when extra arguments are provided', () => {
+    const result = runGu({ args: ['open', 'extra'] });
+
+    assert.equal(result.status, 1);
+    assert.equal(result.stdout, '');
+    assert.equal(result.stderr, 'gu open: expected no arguments\n');
+    assert.deepEqual(openCalls(), []);
+    assert.deepEqual(gistReads(), []);
+  });
+
   it('remains executable through the installed symlink model', () => {
     const linkPath = path.join(testBinDir, 'gu-link');
     fs.symlinkSync(guPath, linkPath);
@@ -400,6 +410,15 @@ kill -TERM "$$"
     assertGuSucceeded(result);
     assert.equal(result.stdout, 'set number\n');
     assert.deepEqual(gistReads(), ['vimrc']);
+  });
+
+  it('fails read when extra arguments are provided', () => {
+    const result = runGu({ args: ['read', 'vimrc', 'extra'] });
+
+    assert.equal(result.status, 1);
+    assert.equal(result.stdout, '');
+    assert.equal(result.stderr, 'gu read: expected exactly one filename\n');
+    assert.deepEqual(gistReads(), []);
   });
 
   it('streams large Gist files when reading a named file', () => {


### PR DESCRIPTION
## Summary

Refactors `commands/gu.ts` internals after the TypeScript shim migration, then tightens a few failure paths that no longer need to preserve shell parity.

- adds explicit snapshot cache/result state helpers for created, updated, removed, and unchanged snapshots
- centralizes Gist read/upload boundaries used by initial checks, `gu read`, cache hydration, and uploads
- separates snapshot definition helpers for file snapshots, shell-command snapshots, and directory listings
- makes failed initial Gist reads, failed `gu read` lookups, missing read filenames, failed uploads, and unknown subcommands exit nonzero
- validates help, unknown commands, missing `read` filenames, and extra `open`/`read` arguments before remote Gist checks
- requires non-empty `gu.id` and `gu.url` config before opening, reading, or snapshotting a Gist, including treating default `null` values as missing
- reports `ballin_config` and initial `gist` spawn failures while preserving shell-style statuses
- lets `gu help` and `gu open` run without requiring readable Gist state first
- avoids printing a successful snapshot status icon when the Gist upload failed
- keeps the local cache unchanged until an upload succeeds, so failed uploads are retried on the next run

## Validation

- `npm test` (175 passing)

Closes #151.