### PR TITLE
[codex] Move installer config setup behind typed entrypoint

### DIFF
--- a/commands/install_setup.ts
+++ b/commands/install_setup.ts
@@ -1,8 +1,52 @@
 const fs = require('fs');
 const path = require('path');
 const {
+  runCommand,
   writeStdoutLine,
 } = require('./commandHelpers.ts');
+
+const configure = (repoDir: string, docsUrl: string): boolean => {
+  const configPath = path.join(repoDir, 'ballin.config.json');
+  const defaultConfigPath = path.join(repoDir, 'config', '.defaultConfig.json');
+  const updateConfigPath = path.join(repoDir, 'config', 'updateConfig.ts');
+
+  if (!fs.existsSync(configPath)) {
+    try {
+      fs.copyFileSync(defaultConfigPath, configPath);
+    } catch {
+      return false;
+    }
+    writeStdoutLine("\n🧠 Created 'ballin.config.json' file in root using default settings");
+    return true;
+  }
+
+  const childEnv: NodeJS.ProcessEnv = {
+    ...process.env,
+    PWD: path.join(repoDir, 'config'),
+  };
+  delete childEnv.BALLIN_TEST_CONFIG_PATH;
+
+  const updateResult = runCommand(process.execPath, [updateConfigPath], {
+    cwd: path.join(repoDir, 'config'),
+    env: childEnv,
+  });
+
+  if (updateResult.stderr) {
+    process.stderr.write(updateResult.stderr);
+  }
+
+  if (updateResult.status !== 0 || updateResult.error) {
+    return false;
+  }
+
+  const updateOutput = updateResult.stdout.trimEnd();
+  if (updateOutput) {
+    writeStdoutLine(`\n🙌 ${updateOutput}`);
+    writeStdoutLine(`\n👀 Docs: ${docsUrl}`);
+  }
+
+  return true;
+};
 
 const symlinkBinaries = (repoDir: string, binDir: string): boolean => {
   const sourceBinDir = path.join(repoDir, 'bin');
@@ -32,15 +76,26 @@ const symlinkBinaries = (repoDir: string, binDir: string): boolean => {
 };
 
 const runInstallSetupCli = (): void => {
-  const [, , command, repoDir, binDir] = process.argv;
+  const [, , command, repoDir, option] = process.argv;
 
-  if (command !== 'symlink-binaries' || !repoDir || !binDir) {
-    writeStdoutLine('Usage: install_setup.ts symlink-binaries <repo-dir> <bin-dir>');
+  if (command === 'configure' && repoDir && option) {
+    process.exitCode = configure(repoDir, option) ? 0 : 1;
+    return;
+  }
+
+  if (command === 'symlink-binaries' && repoDir && option) {
+    process.exitCode = symlinkBinaries(repoDir, option) ? 0 : 1;
+    return;
+  }
+
+  if (!command || !repoDir || !option) {
+    writeStdoutLine('Usage: install_setup.ts <configure|symlink-binaries> <repo-dir> <docs-url|bin-dir>');
     process.exitCode = 1;
     return;
   }
 
-  process.exitCode = symlinkBinaries(repoDir, binDir) ? 0 : 1;
+  writeStdoutLine(`Unknown install setup command: ${command}`);
+  process.exitCode = 1;
 };
 
 if (require.main === module) {
@@ -48,6 +103,7 @@ if (require.main === module) {
 }
 
 module.exports = {
+  configure,
   runInstallSetupCli,
   symlinkBinaries,
 };

--- a/install.sh
+++ b/install.sh
@@ -71,11 +71,9 @@ if [ ! -f "$repo_dir/ballin.config.json" ]; then
 fi
 
 # Configuration must succeed before Gist credentials or command symlinks are touched.
-if [ -f "$repo_dir/commands/install_setup.ts" ]; then
-  if ! node "$repo_dir/commands/install_setup.ts" configure "$repo_dir" "$docs_url"; then
-    printf '\n⚠️  ERROR: Unable to create or update ballin.config.json\n'
-    exit 1
-  fi
+if [ -f "$repo_dir/commands/install_setup.ts" ] \
+  && node "$repo_dir/commands/install_setup.ts" configure "$repo_dir" "$docs_url"; then
+  :
 else
   if ! (
     cd "$repo_dir/config"

--- a/install.sh
+++ b/install.sh
@@ -71,28 +71,35 @@ if [ ! -f "$repo_dir/ballin.config.json" ]; then
 fi
 
 # Configuration must succeed before Gist credentials or command symlinks are touched.
-if ! (
-  cd "$repo_dir/config"
-  if [ ! -f '../ballin.config.json' ]; then
-    # create config
-    if ! cp '.defaultConfig.json' '../ballin.config.json'; then
-      exit 1
-    fi
-    printf '\n%s\n' "🧠 Created 'ballin.config.json' file in root using default settings"
-  else
-    # ballin_update reruns this installer after pulling changes; add any new
-    # default options to the existing config without overwriting user settings.
-    if ! UPDATE_RESULT=$(node "$repo_dir/config/updateConfig.ts"); then
-      exit 1
-    fi
-    if [ -n "$UPDATE_RESULT" ]; then
-      printf '\n🙌 %s\n' "$UPDATE_RESULT"
-      printf '\n👀 Docs: %s\n' "$docs_url"
-    fi
+if [ -f "$repo_dir/commands/install_setup.ts" ]; then
+  if ! node "$repo_dir/commands/install_setup.ts" configure "$repo_dir" "$docs_url"; then
+    printf '\n⚠️  ERROR: Unable to create or update ballin.config.json\n'
+    exit 1
   fi
-); then
-  printf '\n⚠️  ERROR: Unable to create or update ballin.config.json\n'
-  exit 1
+else
+  if ! (
+    cd "$repo_dir/config"
+    if [ ! -f '../ballin.config.json' ]; then
+      # create config
+      if ! cp '.defaultConfig.json' '../ballin.config.json'; then
+        exit 1
+      fi
+      printf '\n%s\n' "🧠 Created 'ballin.config.json' file in root using default settings"
+    else
+      # ballin_update reruns this installer after pulling changes; add any new
+      # default options to the existing config without overwriting user settings.
+      if ! UPDATE_RESULT=$(node "$repo_dir/config/updateConfig.ts"); then
+        exit 1
+      fi
+      if [ -n "$UPDATE_RESULT" ]; then
+        printf '\n🙌 %s\n' "$UPDATE_RESULT"
+        printf '\n👀 Docs: %s\n' "$docs_url"
+      fi
+    fi
+  ); then
+    printf '\n⚠️  ERROR: Unable to create or update ballin.config.json\n'
+    exit 1
+  fi
 fi
 
 

--- a/test/install.test.ts
+++ b/test/install.test.ts
@@ -227,6 +227,45 @@ printf '%s\\n' gist >> "$FAKE_COMMAND_LOG"
     assert.notInclude(commandLog(), 'node:install_setup');
   });
 
+  it('falls back to Bash config setup when the typed setup entrypoint does not support configure yet', () => {
+    installBaseCommands();
+    installConfigCommand();
+    writeExecutable('node', `#!/usr/bin/env bash
+if [ "$1" = '-p' ]; then
+  printf '%s\\n' "$FAKE_NODE_SUPPORTED"
+  exit 0
+fi
+if [ "$1" = "$HOME/.ballin-scripts/commands/install_setup.ts" ]; then
+  printf 'node:install_setup %s\\n' "$*" >> "$FAKE_COMMAND_LOG"
+  shift
+  if [ "$1" = 'symlink-binaries' ]; then
+    repo_dir="$2"
+    bin_dir="$3"
+    mkdir -p "$bin_dir"
+    for bin in "$repo_dir/bin/"*; do
+      ln -sfn "$bin" "$bin_dir/\${bin##*/}"
+    done
+    printf '\\n💪 symlinked binaries into %s\\n' "$bin_dir"
+    exit 0
+  fi
+  exit 1
+fi
+printf '%s' "$FAKE_UPDATE_OUTPUT"
+exit "$FAKE_NODE_STATUS"
+`);
+    fs.writeFileSync(path.join(homeDir, '.gist'), 'token\n');
+
+    const result = runInstall();
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.include(result.stdout, "Created 'ballin.config.json'");
+    assert.deepEqual(
+      JSON.parse(fs.readFileSync(path.join(repoDir, 'ballin.config.json'), 'utf8')),
+      JSON.parse(fs.readFileSync(path.join(repoDir, 'config', '.defaultConfig.json'), 'utf8')),
+    );
+    assert.include(commandLog(), 'node:install_setup');
+  });
+
   it('does not repeat unchanged setup guidance during an ordinary update', () => {
     installBaseCommands();
     installConfigCommand();

--- a/test/install.test.ts
+++ b/test/install.test.ts
@@ -42,6 +42,22 @@ fi
 if [ "$1" = "$HOME/.ballin-scripts/commands/install_setup.ts" ]; then
   printf 'node:install_setup %s\\n' "$*" >> "$FAKE_COMMAND_LOG"
   shift
+  if [ "$1" = 'configure' ]; then
+    repo_dir="$2"
+    docs_url="$3"
+    if [ ! -f "$repo_dir/ballin.config.json" ]; then
+      if ! cp "$repo_dir/config/.defaultConfig.json" "$repo_dir/ballin.config.json"; then
+        exit 1
+      fi
+      printf "\\n🧠 Created 'ballin.config.json' file in root using default settings\\n"
+      exit 0
+    fi
+    printf '%s' "$FAKE_UPDATE_OUTPUT"
+    if [ -n "$FAKE_UPDATE_OUTPUT" ]; then
+      printf '\\n👀 Docs: %s\\n' "$docs_url"
+    fi
+    exit "$FAKE_NODE_STATUS"
+  fi
   if [ "$1" != 'symlink-binaries' ]; then
     exit 2
   fi
@@ -193,6 +209,7 @@ printf '%s\\n' gist >> "$FAKE_COMMAND_LOG"
     );
     assert.isTrue(fs.lstatSync(path.join(binDir, 'ballin_config')).isSymbolicLink());
     assert.include(commandLog(), 'node:install_setup');
+    assert.include(commandLog(), 'symlink-binaries');
     assert.include(commandLog(), 'gist:-l\n');
   });
 
@@ -240,6 +257,7 @@ printf '%s\\n' gist >> "$FAKE_COMMAND_LOG"
     assert.include(result.stdout, updateOutput.trim());
     assert.equal(result.stdout.match(/👀 Docs:/g).length, 1);
     assert.include(result.stdout, 'docs/README.md');
+    assert.include(commandLog(), 'configure');
   });
 
   it('stops before Gist and success output when config creation fails', () => {

--- a/test/install_setup.test.ts
+++ b/test/install_setup.test.ts
@@ -4,16 +4,19 @@ const fs = require('fs');
 const os = require('os');
 const path = require('path');
 const {
+  configure,
   symlinkBinaries,
 } = require('../commands/install_setup.ts');
 
 const installSetupPath = path.join(__dirname, '..', 'commands', 'install_setup.ts');
+const repoRoot = path.join(__dirname, '..');
 
 describe('install setup', () => {
   let testDir: string;
   let repoDir: string;
   let sourceBinDir: string;
   let binDir: string;
+  const docsUrl = 'https://example.test/docs';
 
   const withoutStdout = (action: () => boolean): boolean => {
     const originalWrite = process.stdout.write;
@@ -23,6 +26,16 @@ describe('install setup', () => {
     } finally {
       process.stdout.write = originalWrite;
     }
+  };
+
+  const installConfigSources = () => {
+    fs.mkdirSync(path.join(repoDir, 'config'), { recursive: true });
+    ['.defaultConfig.json', 'index.ts', 'updateConfig.ts'].forEach((fileName) => {
+      fs.copyFileSync(
+        path.join(repoRoot, 'config', fileName),
+        path.join(repoDir, 'config', fileName),
+      );
+    });
   };
 
   beforeEach(() => {
@@ -48,6 +61,48 @@ describe('install setup', () => {
     assert.isTrue(fs.lstatSync(path.join(binDir, 'gu')).isSymbolicLink());
     assert.equal(fs.readlinkSync(path.join(binDir, 'ballin')), path.join(sourceBinDir, 'ballin'));
     assert.equal(fs.readlinkSync(path.join(binDir, 'gu')), path.join(sourceBinDir, 'gu'));
+  });
+
+  it('creates the default config through setup code', () => {
+    installConfigSources();
+
+    const result = withoutStdout(() => configure(repoDir, docsUrl));
+
+    assert.isTrue(result);
+    assert.deepEqual(
+      JSON.parse(fs.readFileSync(path.join(repoDir, 'ballin.config.json'), 'utf8')),
+      JSON.parse(fs.readFileSync(path.join(repoDir, 'config', '.defaultConfig.json'), 'utf8')),
+    );
+  });
+
+  it('runs config creation through the setup CLI', () => {
+    installConfigSources();
+
+    const result = spawnSync(process.execPath, [
+      installSetupPath,
+      'configure',
+      repoDir,
+      docsUrl,
+    ], {
+      encoding: 'utf8',
+    });
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.include(result.stdout, "Created 'ballin.config.json'");
+    assert.isTrue(fs.existsSync(path.join(repoDir, 'ballin.config.json')));
+  });
+
+  it('updates an existing config through setup code', () => {
+    installConfigSources();
+    fs.writeFileSync(path.join(repoDir, 'ballin.config.json'), '{}\n');
+
+    const result = withoutStdout(() => configure(repoDir, docsUrl));
+
+    assert.isTrue(result);
+    assert.include(
+      fs.readFileSync(path.join(repoDir, 'ballin.config.json'), 'utf8'),
+      '"up"',
+    );
   });
 
   it('runs the symlink step through the setup CLI', () => {


### PR DESCRIPTION
## Summary

- add a typed install setup command for config creation and migration
- make install.sh delegate config setup when the typed entrypoint exists
- preserve the existing Bash config setup fallback for stale existing checkouts
- cover config creation, migration, CLI invocation, and installer delegation in isolated tests

## Scope

This is the next focused slice of #158 after #162. It intentionally leaves Gist/auth setup in install.sh.

## Validation

- npm run test:unit -- --grep "install"
- npm test
- bash -n install.sh

Refs #158