### PR TITLE
[codex] Clean up shared command helpers

### DIFF
--- a/commands/ballin_uninstall.ts
+++ b/commands/ballin_uninstall.ts
@@ -2,6 +2,7 @@ const fs = require('fs');
 const path = require('path');
 const {
   commandExists,
+  isDirectory,
   readCommandOutput,
   writeStdoutLine,
 } = require('./commandHelpers.ts');
@@ -63,7 +64,7 @@ const runBallinUninstallCli = (): void => {
   }
 
   const repoBinDir = path.join(repoDir, 'bin');
-  if (fs.existsSync(repoBinDir)) {
+  if (isDirectory(repoBinDir)) {
     fs.readdirSync(repoBinDir).forEach((binName: string) => {
       const targetPath = path.join(repoBinDir, binName);
       binDirs.forEach((binDir) => {

--- a/commands/ballin_uninstall.ts
+++ b/commands/ballin_uninstall.ts
@@ -2,7 +2,6 @@ const fs = require('fs');
 const path = require('path');
 const {
   commandExists,
-  isDirectory,
   readCommandOutput,
   writeStdoutLine,
 } = require('./commandHelpers.ts');
@@ -64,7 +63,7 @@ const runBallinUninstallCli = (): void => {
   }
 
   const repoBinDir = path.join(repoDir, 'bin');
-  if (isDirectory(repoBinDir)) {
+  if (fs.existsSync(repoBinDir)) {
     fs.readdirSync(repoBinDir).forEach((binName: string) => {
       const targetPath = path.join(repoBinDir, binName);
       binDirs.forEach((binDir) => {

--- a/commands/ballin_update.ts
+++ b/commands/ballin_update.ts
@@ -1,6 +1,6 @@
-const fs = require('fs');
 const path = require('path');
 const {
+  isDirectory,
   runCommand,
   writeStdoutLine,
 } = require('./commandHelpers.ts');
@@ -33,14 +33,6 @@ const runFetch = (cwd: string): number | null => (
 const isMergeInProgress = (cwd: string): boolean => (
   runGitQuiet(['rev-parse', '-q', '--verify', 'MERGE_HEAD'], cwd) === 0
 );
-
-const isDirectory = (candidate: string): boolean => {
-  try {
-    return fs.statSync(candidate).isDirectory();
-  } catch {
-    return false;
-  }
-};
 
 const stashChanges = (repoDir: string, recoveryContext: string): boolean => {
   if (isMergeInProgress(repoDir) && runGitQuiet(['merge', '--abort'], repoDir) !== 0) {

--- a/commands/ballin_update.ts
+++ b/commands/ballin_update.ts
@@ -6,29 +6,34 @@ const {
   writeStdoutLine,
 } = require('./commandHelpers.ts');
 
-const runGitQuiet = (args: string[], cwd: string): number | null => (
+import type { StdioOptions } from 'child_process';
+
+const commandEnv = (cwd: string): NodeJS.ProcessEnv => ({
+  ...process.env,
+  PWD: cwd,
+});
+
+const runGit = (args: string[], cwd: string, stdio: StdioOptions): number | null => (
   runCommand('git', args, {
     cwd,
-    env: {
-      ...process.env,
-      PWD: cwd,
-    },
-    stdio: 'ignore',
+    env: commandEnv(cwd),
+    stdio,
   }).status
+);
+
+const runGitQuiet = (args: string[], cwd: string): number | null => (
+  runGit(args, cwd, 'ignore')
 );
 
 const updateBranch = 'main';
 const updateRemoteRef = `origin/${updateBranch}`;
 
 const runFetch = (cwd: string): number | null => (
-  runCommand('git', ['fetch', 'origin', `+${updateBranch}:refs/remotes/origin/${updateBranch}`], {
+  runGit(
+    ['fetch', 'origin', `+${updateBranch}:refs/remotes/origin/${updateBranch}`],
     cwd,
-    env: {
-      ...process.env,
-      PWD: cwd,
-    },
-    stdio: ['inherit', 'ignore', 'inherit'],
-  }).status
+    ['inherit', 'ignore', 'inherit'],
+  )
 );
 
 const isMergeInProgress = (cwd: string): boolean => (
@@ -114,10 +119,7 @@ const runBallinUpdateCli = (): void => {
   writeStdoutLine();
   process.exitCode = runVisibleCommand('./install.sh', [], {
     cwd: repoDir,
-    env: {
-      ...process.env,
-      PWD: repoDir,
-    },
+    env: commandEnv(repoDir),
   });
 };
 

--- a/commands/ballin_update.ts
+++ b/commands/ballin_update.ts
@@ -2,6 +2,7 @@ const path = require('path');
 const {
   isDirectory,
   runCommand,
+  runVisibleCommand,
   writeStdoutLine,
 } = require('./commandHelpers.ts');
 
@@ -111,15 +112,13 @@ const runBallinUpdateCli = (): void => {
   }
 
   writeStdoutLine();
-  const installResult = runCommand('./install.sh', [], {
+  process.exitCode = runVisibleCommand('./install.sh', [], {
     cwd: repoDir,
     env: {
       ...process.env,
       PWD: repoDir,
     },
-    stdio: 'inherit',
   });
-  process.exitCode = installResult.status ?? 1;
 };
 
 module.exports = {

--- a/commands/commandHelpers.ts
+++ b/commands/commandHelpers.ts
@@ -15,6 +15,9 @@ type SpawnResult = {
 
 type SpawnOptions = Omit<SpawnSyncOptionsWithStringEncoding, 'encoding' | 'shell'>;
 
+const commandPermissionDeniedStatus = 126;
+const commandNotFoundStatus = 127;
+
 const runCommand = (
   command: string,
   args: string[] = [],
@@ -28,6 +31,14 @@ const isExecutable = (candidate: string): boolean => {
   try {
     fs.accessSync(candidate, fs.constants.X_OK);
     return fs.statSync(candidate).isFile();
+  } catch {
+    return false;
+  }
+};
+
+const isDirectory = (candidate: string): boolean => {
+  try {
+    return fs.statSync(candidate).isDirectory();
   } catch {
     return false;
   }
@@ -69,6 +80,30 @@ const progress = (text: string): void => {
   process.stdout.write(`\n==> ${text}\n`);
 };
 
+const reportSpawnError = (command: string, error: Error): number => {
+  const errorCode = (error as { code?: string }).code;
+  if (errorCode === 'EACCES') {
+    writeStderrLine(`${command}: Permission denied`);
+    return commandPermissionDeniedStatus;
+  }
+  if (errorCode === 'ENOENT') {
+    writeStderrLine(`${command}: command not found`);
+    return commandNotFoundStatus;
+  }
+  writeStderrLine(error.message);
+  return 1;
+};
+
+const spawnResultStatus = (result: SpawnResult): number => {
+  if (result.signal) {
+    const signalNumber = os.constants.signals[result.signal];
+    if (typeof signalNumber === 'number') {
+      return 128 + signalNumber;
+    }
+  }
+  return result.status ?? 1;
+};
+
 const ensureDir = (directory: string): void => {
   fs.mkdirSync(directory, { recursive: true });
 };
@@ -85,11 +120,14 @@ const removeTempFile = (filePath: string): void => {
 module.exports = {
   commandExists,
   ensureDir,
+  isDirectory,
   makeTempFile,
   progress,
   readCommandOutput,
+  reportSpawnError,
   removeTempFile,
   runCommand,
+  spawnResultStatus,
   writeStderrLine,
   writeStdoutLine,
 };

--- a/commands/commandHelpers.ts
+++ b/commands/commandHelpers.ts
@@ -104,6 +104,18 @@ const spawnResultStatus = (result: SpawnResult): number => {
   return result.status ?? 1;
 };
 
+const runVisibleCommand = (
+  command: string,
+  args: string[] = [],
+  options: SpawnOptions = {},
+): number => {
+  const result = runCommand(command, args, { ...options, stdio: 'inherit' });
+  if (result.error) {
+    return reportSpawnError(command, result.error);
+  }
+  return spawnResultStatus(result);
+};
+
 const ensureDir = (directory: string): void => {
   fs.mkdirSync(directory, { recursive: true });
 };
@@ -127,6 +139,7 @@ module.exports = {
   reportSpawnError,
   removeTempFile,
   runCommand,
+  runVisibleCommand,
   spawnResultStatus,
   writeStderrLine,
   writeStdoutLine,

--- a/commands/up.ts
+++ b/commands/up.ts
@@ -1,31 +1,15 @@
-const os = require('os');
 const fs = require('fs');
 const path = require('path');
 const {
   commandExists,
   makeTempFile,
   progress,
+  reportSpawnError,
   removeTempFile,
   runCommand,
+  spawnResultStatus,
   writeStderrLine,
 } = require('./commandHelpers.ts');
-
-const commandPermissionDeniedStatus = 126;
-const commandNotFoundStatus = 127;
-
-const reportSpawnError = (command: string, error: Error): number => {
-  const errorCode = (error as { code?: string }).code;
-  if (errorCode === 'EACCES') {
-    writeStderrLine(`${command}: Permission denied`);
-    return commandPermissionDeniedStatus;
-  }
-  if (errorCode === 'ENOENT') {
-    writeStderrLine(`${command}: command not found`);
-    return commandNotFoundStatus;
-  }
-  writeStderrLine(error.message);
-  return 1;
-};
 
 const configValue = (key: string, env = process.env): string => {
   const result = runCommand('ballin_config', ['get', key], {
@@ -47,13 +31,7 @@ const runVisible = (command: string, args: string[] = [], env = process.env): nu
   if (result.error) {
     return reportSpawnError(command, result.error);
   }
-  if (result.signal) {
-    const signalNumber = os.constants.signals[result.signal];
-    if (typeof signalNumber === 'number') {
-      return 128 + signalNumber;
-    }
-  }
-  return result.status ?? 1;
+  return spawnResultStatus(result);
 };
 
 const parseEnvOutput = (output: string): NodeJS.ProcessEnv | null => {

--- a/commands/up.ts
+++ b/commands/up.ts
@@ -7,7 +7,7 @@ const {
   reportSpawnError,
   removeTempFile,
   runCommand,
-  spawnResultStatus,
+  runVisibleCommand,
   writeStderrLine,
 } = require('./commandHelpers.ts');
 
@@ -24,14 +24,6 @@ const configValue = (key: string, env = process.env): string => {
     return '';
   }
   return result.stdout.trim();
-};
-
-const runVisible = (command: string, args: string[] = [], env = process.env): number => {
-  const result = runCommand(command, args, { env, stdio: 'inherit' });
-  if (result.error) {
-    return reportSpawnError(command, result.error);
-  }
-  return spawnResultStatus(result);
 };
 
 const parseEnvOutput = (output: string): NodeJS.ProcessEnv | null => {
@@ -90,15 +82,15 @@ const runUpCli = (): void => {
       HOMEBREW_NO_ENV_HINTS: '1',
       HOMEBREW_NO_ASK: '1',
     };
-    runVisible('brew', ['upgrade'], childEnv);
+    runVisibleCommand('brew', ['upgrade'], { env: childEnv });
 
     if (configValue('up.cleanup', childEnv) === 'true') {
       progress('Cleaning up Homebrew packages');
-      runVisible('brew', ['cleanup'], childEnv);
+      runVisibleCommand('brew', ['cleanup'], { env: childEnv });
     }
 
     progress('Checking Homebrew installation');
-    runVisible('brew', ['doctor'], childEnv);
+    runVisibleCommand('brew', ['doctor'], { env: childEnv });
   }
 
   if (configValue('up.nvm', childEnv) === 'true') {
@@ -116,27 +108,27 @@ const runUpCli = (): void => {
 
   if (commandExists('npm', { env: childEnv }) && configValue('up.npm', childEnv) === 'true') {
     progress('Updating global npm packages');
-    runVisible('npm', ['update', '-g'], childEnv);
+    runVisibleCommand('npm', ['update', '-g'], { env: childEnv });
   }
 
   if (commandExists('mas', { env: childEnv })) {
     progress('Updating App Store apps');
-    runVisible('mas', ['upgrade'], childEnv);
+    runVisibleCommand('mas', ['upgrade'], { env: childEnv });
   }
 
   if (commandExists('softwareupdate', { env: childEnv }) && configValue('up.softwareupdate', childEnv) === 'true') {
     progress('Installing macOS updates');
-    runVisible('softwareupdate', ['-ia'], childEnv);
+    runVisibleCommand('softwareupdate', ['-ia'], { env: childEnv });
   }
 
   if (configValue('up.ballin', childEnv) === 'true') {
     progress('Updating ballin-scripts');
-    runVisible('ballin_update', [], childEnv);
+    runVisibleCommand('ballin_update', [], { env: childEnv });
   }
 
   if (configValue('up.gu', childEnv) === 'true') {
     progress('Backing up development environment');
-    process.exitCode = runVisible('gu', [], childEnv);
+    process.exitCode = runVisibleCommand('gu', [], { env: childEnv });
   }
 };
 

--- a/test/ballin_update.test.ts
+++ b/test/ballin_update.test.ts
@@ -222,6 +222,40 @@ exit "$FAKE_INSTALL_STATUS"
     ]);
   });
 
+  it('reports a missing installer with the shared command error format', () => {
+    fs.rmSync(path.join(repoDir, 'install.sh'));
+
+    const result = runUpdate();
+
+    assert.equal(result.status, 127);
+    assert.equal(result.stdout, '👟 getting fresh kicks...\n\n');
+    assert.include(result.stderr, './install.sh: command not found');
+    assert.deepEqual(commandLog(), [
+      `${repoDir}|git:fetch origin +main:refs/remotes/origin/main`,
+      `${repoDir}|git:checkout main`,
+      `${repoDir}|git:merge origin/main`,
+    ]);
+  });
+
+  it('uses a shell-style signal exit status when the installer is signaled', () => {
+    writeExecutable('install.sh', `#!/usr/bin/env bash
+printf '%s|install.sh:%s\\n' "$PWD" "$*" >> "$BALLIN_UPDATE_TEST_LOG"
+kill -TERM "$$"
+`, repoDir);
+
+    const result = runUpdate();
+
+    assert.equal(result.status, 143);
+    assert.equal(result.stdout, '👟 getting fresh kicks...\n\n');
+    assert.equal(result.stderr, '');
+    assert.deepEqual(commandLog(), [
+      `${repoDir}|git:fetch origin +main:refs/remotes/origin/main`,
+      `${repoDir}|git:checkout main`,
+      `${repoDir}|git:merge origin/main`,
+      `${repoDir}|install.sh:`,
+    ]);
+  });
+
   it('stops before merge and install when fetch fails', () => {
     const result = runUpdate({ FAKE_GIT_FETCH_STATUS: '23' });
 


### PR DESCRIPTION
## Summary

- Move shared spawn-error reporting, shell-style spawn status handling, and visible command execution into `commands/commandHelpers.ts`.
- Reuse the shared directory predicate in `ballin_update`, where the helper already existed locally before this cleanup.
- Keep `up` and the final `ballin_update` installer step focused on orchestration by delegating command execution details to shared helpers.
- Centralize `ballin_update` command environment setup for git and installer subprocesses.
- Add coverage for missing and signaled `ballin_update` installer execution.

## Validation

- `npm test` (156 passing)

Closes #153