### PR TITLE
[codex] Add analytics backend skeleton

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,5 +49,14 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Test
-        run: npm test
+      - name: Lint
+        run: npm run lint
+
+      - name: Typecheck
+        run: npm run typecheck
+
+      - name: Typecheck analytics worker
+        run: npm run typecheck:analytics-worker
+
+      - name: Run unit tests
+        run: npm run test:unit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,14 +49,5 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Lint
-        run: npm run lint
-
-      - name: Typecheck
-        run: npm run typecheck
-
-      - name: Typecheck analytics worker
-        run: npm run typecheck:analytics-worker
-
-      - name: Run unit tests
-        run: npm run test:unit
+      - name: Test
+        run: npm test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,5 +55,8 @@ jobs:
       - name: Typecheck
         run: npm run typecheck
 
+      - name: Typecheck analytics worker
+        run: npm run typecheck:analytics-worker
+
       - name: Run unit tests
         run: npm run test:unit

--- a/analytics-worker/README.md
+++ b/analytics-worker/README.md
@@ -1,0 +1,109 @@
+# Analytics Worker
+
+This is the proposed backend for the minimal `ballin-scripts` active-install
+analytics described in issue #166. It is intentionally isolated from the CLI so
+the command package does not gain runtime analytics SDK dependencies.
+
+The backend is a Cloudflare Worker with a D1 database binding. It accepts a
+single narrow event shape, hashes the client install ID before storage, and
+stores only daily aggregates needed for DAU/WAU/MAU, command counts, and failure
+counts.
+
+## Data Policy
+
+The worker may store:
+
+- daily bucket, in `YYYY-MM-DD` format
+- server-hashed install ID
+- command name from a fixed allowlist
+- status from a fixed allowlist
+- duration bucket from a fixed allowlist
+- coarse version/runtime fields from a fixed allowlist
+- aggregate counts
+
+The worker must not store:
+
+- raw install IDs
+- IP addresses
+- command arguments
+- usernames
+- local paths
+- Gist IDs or URLs
+- dotfile contents
+- package lists
+- editor settings or extension lists
+- raw errors, stdout, or stderr
+- environment variables
+- arbitrary config values
+
+## Endpoint
+
+`POST /v1/events`
+
+Example payload:
+
+```json
+{
+  "schemaVersion": 1,
+  "installId": "826f9faa-9995-4f66-a01b-73b4f7aebdf1",
+  "dateBucket": "2026-06-27",
+  "command": "up",
+  "status": "success",
+  "durationBucket": "10-60s",
+  "appVersion": "1.0.0",
+  "nodeMajor": "24",
+  "os": "darwin",
+  "osVersion": "15"
+}
+```
+
+Responses:
+
+- `204` when the event is accepted
+- `400` for invalid JSON or invalid event fields
+- `404` for unknown paths
+- `405` for unsupported methods
+
+The worker should ignore request IP for analytics purposes. Cloudflare may still
+process request metadata operationally before the worker runs; the application
+schema does not read or persist it.
+
+## Local Setup
+
+This repository does not require a live Cloudflare project yet. When ready:
+
+1. Copy `wrangler.toml.example` to `wrangler.toml`.
+2. Create a D1 database:
+
+   ```shell
+   wrangler d1 create ballin-scripts-analytics
+   ```
+
+3. Fill in the database ID in `wrangler.toml`.
+4. Set the hash secret:
+
+   ```shell
+   wrangler secret put INSTALL_ID_HASH_SECRET
+   ```
+
+5. Apply migrations:
+
+   ```shell
+   wrangler d1 migrations apply ballin-scripts-analytics
+   ```
+
+6. Deploy:
+
+   ```shell
+   wrangler deploy
+   ```
+
+## Retention
+
+The scheduled worker deletes daily rows older than 395 days. That keeps roughly
+13 months of daily data, enough for DAU/WAU/MAU trends without keeping an
+indefinite install history.
+
+## Queries
+
+Example D1 queries for the key maintenance questions live in `queries/`.

--- a/analytics-worker/README.md
+++ b/analytics-worker/README.md
@@ -40,6 +40,12 @@ The worker must not store:
 
 `POST /v1/events`
 
+Required header:
+
+```text
+X-Ballin-Analytics-Token: <configured ingest token>
+```
+
 Example payload:
 
 ```json
@@ -61,12 +67,25 @@ Responses:
 
 - `204` when the event is accepted
 - `400` for invalid JSON or invalid event fields
+- `401` when the ingest token is missing or invalid
 - `404` for unknown paths
 - `405` for unsupported methods
+
+The event is rejected unless:
+
+- `installId` is a lowercase UUID
+- `dateBucket` is today, yesterday, or tomorrow in UTC
+- `appVersion` is a released numeric version such as `1.0.0`
+- the JSON body is 2048 bytes or smaller
 
 The worker should ignore request IP for analytics purposes. Cloudflare may still
 process request metadata operationally before the worker runs; the application
 schema does not read or persist it.
+
+The ingest token is a deployment gate for the backend skeleton, not a permanent
+abuse solution for a distributed CLI. Before production traffic is enabled,
+configure Cloudflare-side rate limiting or equivalent edge protection for
+`POST /v1/events`.
 
 ## Local Setup
 
@@ -86,13 +105,20 @@ This repository does not require a live Cloudflare project yet. When ready:
    wrangler secret put INSTALL_ID_HASH_SECRET
    ```
 
-5. Apply migrations:
+5. Set the ingest token:
+
+   ```shell
+   wrangler secret put INGEST_TOKEN
+   ```
+
+6. Configure Cloudflare-side rate limiting for `POST /v1/events`.
+7. Apply migrations:
 
    ```shell
    wrangler d1 migrations apply ballin-scripts-analytics
    ```
 
-6. Deploy:
+8. Deploy:
 
    ```shell
    wrangler deploy

--- a/analytics-worker/README.md
+++ b/analytics-worker/README.md
@@ -75,8 +75,11 @@ The event is rejected unless:
 
 - `installId` is a lowercase UUID
 - `dateBucket` is today, yesterday, or tomorrow in UTC
+- `command` is one of `ballin`, `ballin_config`, `ballin_uninstall`,
+  `ballin_update`, `gu`, or `up`
 - `appVersion` is a released numeric version such as `1.0.0`
 - the JSON body is 2048 bytes or smaller
+- the JSON body contains no fields outside the documented schema
 
 The worker should ignore request IP for analytics purposes. Cloudflare may still
 process request metadata operationally before the worker runs; the application

--- a/analytics-worker/migrations/0001_initial.sql
+++ b/analytics-worker/migrations/0001_initial.sql
@@ -1,7 +1,6 @@
 CREATE TABLE IF NOT EXISTS install_days (
   date_bucket TEXT NOT NULL,
   install_id_hash TEXT NOT NULL,
-  first_seen_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
   PRIMARY KEY (date_bucket, install_id_hash)
 );
 

--- a/analytics-worker/migrations/0001_initial.sql
+++ b/analytics-worker/migrations/0001_initial.sql
@@ -1,0 +1,42 @@
+CREATE TABLE IF NOT EXISTS install_days (
+  date_bucket TEXT NOT NULL,
+  install_id_hash TEXT NOT NULL,
+  first_seen_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+  PRIMARY KEY (date_bucket, install_id_hash)
+);
+
+CREATE TABLE IF NOT EXISTS command_events_daily (
+  date_bucket TEXT NOT NULL,
+  command TEXT NOT NULL,
+  status TEXT NOT NULL,
+  duration_bucket TEXT NOT NULL,
+  count INTEGER NOT NULL DEFAULT 0,
+  PRIMARY KEY (date_bucket, command, status, duration_bucket)
+);
+
+CREATE TABLE IF NOT EXISTS version_events_daily (
+  date_bucket TEXT NOT NULL,
+  command TEXT NOT NULL,
+  app_version TEXT NOT NULL,
+  node_major TEXT NOT NULL,
+  os TEXT NOT NULL,
+  os_version TEXT NOT NULL,
+  count INTEGER NOT NULL DEFAULT 0,
+  PRIMARY KEY (
+    date_bucket,
+    command,
+    app_version,
+    node_major,
+    os,
+    os_version
+  )
+);
+
+CREATE INDEX IF NOT EXISTS install_days_install_id_hash_idx
+  ON install_days (install_id_hash);
+
+CREATE INDEX IF NOT EXISTS command_events_daily_date_command_idx
+  ON command_events_daily (date_bucket, command);
+
+CREATE INDEX IF NOT EXISTS version_events_daily_date_command_idx
+  ON version_events_daily (date_bucket, command);

--- a/analytics-worker/queries/active-installs.sql
+++ b/analytics-worker/queries/active-installs.sql
@@ -1,0 +1,21 @@
+-- Daily active installs for one date.
+SELECT count(*) AS dau
+FROM install_days
+WHERE date_bucket = ?1;
+
+-- Weekly active installs over an inclusive date range.
+SELECT count(DISTINCT install_id_hash) AS wau
+FROM install_days
+WHERE date_bucket BETWEEN ?1 AND ?2;
+
+-- Monthly active installs over an inclusive date range.
+SELECT count(DISTINCT install_id_hash) AS mau
+FROM install_days
+WHERE date_bucket BETWEEN ?1 AND ?2;
+
+-- Daily active installs by day.
+SELECT date_bucket, count(*) AS active_installs
+FROM install_days
+WHERE date_bucket BETWEEN ?1 AND ?2
+GROUP BY date_bucket
+ORDER BY date_bucket;

--- a/analytics-worker/queries/command-counts.sql
+++ b/analytics-worker/queries/command-counts.sql
@@ -1,0 +1,25 @@
+-- Command counts by day and command.
+SELECT date_bucket, command, sum(count) AS events
+FROM command_events_daily
+WHERE date_bucket BETWEEN ?1 AND ?2
+GROUP BY date_bucket, command
+ORDER BY date_bucket, command;
+
+-- Failure counts by day and command.
+SELECT date_bucket, command, sum(count) AS failures
+FROM command_events_daily
+WHERE date_bucket BETWEEN ?1 AND ?2
+  AND status = 'failure'
+GROUP BY date_bucket, command
+ORDER BY date_bucket, command;
+
+-- Failure rate by command over an inclusive date range.
+SELECT
+  command,
+  sum(CASE WHEN status = 'failure' THEN count ELSE 0 END) AS failures,
+  sum(count) AS total,
+  1.0 * sum(CASE WHEN status = 'failure' THEN count ELSE 0 END) / sum(count) AS failure_rate
+FROM command_events_daily
+WHERE date_bucket BETWEEN ?1 AND ?2
+GROUP BY command
+ORDER BY failure_rate DESC, total DESC;

--- a/analytics-worker/queries/runtime-adoption.sql
+++ b/analytics-worker/queries/runtime-adoption.sql
@@ -1,0 +1,13 @@
+-- Runtime/version adoption by day.
+SELECT
+  date_bucket,
+  command,
+  app_version,
+  node_major,
+  os,
+  os_version,
+  sum(count) AS events
+FROM version_events_daily
+WHERE date_bucket BETWEEN ?1 AND ?2
+GROUP BY date_bucket, command, app_version, node_major, os, os_version
+ORDER BY date_bucket, command, events DESC;

--- a/analytics-worker/src/index.ts
+++ b/analytics-worker/src/index.ts
@@ -40,7 +40,26 @@ type ParseOptions = {
   now: Date;
 };
 
-const allowedCommands = new Set(['up', 'gu', 'ballin_update', 'ballin']);
+const allowedCommands = new Set([
+  'ballin',
+  'ballin_config',
+  'ballin_uninstall',
+  'ballin_update',
+  'gu',
+  'up',
+]);
+const allowedPayloadKeys = new Set([
+  'schemaVersion',
+  'installId',
+  'dateBucket',
+  'command',
+  'status',
+  'durationBucket',
+  'appVersion',
+  'nodeMajor',
+  'os',
+  'osVersion',
+]);
 const allowedStatuses = new Set(['success', 'failure', 'unknown']);
 const allowedDurations = new Set(['unknown', '<1s', '1-10s', '10-60s', '1-10m', '10m+']);
 const allowedOs = new Set(['darwin', 'linux', 'win32', 'unknown']);
@@ -77,6 +96,10 @@ const isObject = (value: unknown): value is Record<string, unknown> => (
   typeof value === 'object' && value !== null && !Array.isArray(value)
 );
 
+const hasOnlyAllowedPayloadKeys = (payload: Record<string, unknown>): boolean => (
+  Object.keys(payload).every((key) => allowedPayloadKeys.has(key))
+);
+
 const stringField = (payload: Record<string, unknown>, key: string): string | null => {
   const value = payload[key];
   return typeof value === 'string' && value.length > 0 ? value : null;
@@ -100,6 +123,9 @@ const isDateBucketWithinSkew = (dateBucket: string, now: Date): boolean => {
 const parseAnalyticsEvent = (payload: unknown, options: ParseOptions): AnalyticsEvent | string => {
   if (!isObject(payload)) {
     return 'event payload must be a JSON object';
+  }
+  if (!hasOnlyAllowedPayloadKeys(payload)) {
+    return 'event payload contains unsupported fields';
   }
   if (payload.schemaVersion !== 1) {
     return 'schemaVersion must be 1';
@@ -229,14 +255,14 @@ const handleEventRequest = async (request: Request, env: Env): Promise<Response>
   if (request.headers.get(ingestTokenHeader) !== env.INGEST_TOKEN) {
     return emptyResponse(401);
   }
-  const contentLength = Number(request.headers.get('content-length') ?? '0');
-  if (!Number.isFinite(contentLength) || contentLength <= 0 || contentLength > maxBodyBytes) {
-    return jsonResponse(400, { error: 'invalid content length' });
+  const body = await request.text();
+  if (new TextEncoder().encode(body).byteLength > maxBodyBytes) {
+    return jsonResponse(400, { error: 'request body is too large' });
   }
 
   let payload: unknown;
   try {
-    payload = await request.json();
+    payload = JSON.parse(body);
   } catch {
     return jsonResponse(400, { error: 'invalid JSON' });
   }

--- a/analytics-worker/src/index.ts
+++ b/analytics-worker/src/index.ts
@@ -1,0 +1,251 @@
+type D1Database = {
+  prepare: (query: string) => D1PreparedStatement;
+  batch: (statements: D1PreparedStatement[]) => Promise<unknown[]>;
+};
+
+type D1PreparedStatement = {
+  bind: (...values: unknown[]) => D1PreparedStatement;
+  run: () => Promise<unknown>;
+};
+
+type ExecutionContext = {
+  waitUntil: (promise: Promise<unknown>) => void;
+};
+
+type ScheduledController = {
+  scheduledTime: number;
+  cron: string;
+};
+
+type Env = {
+  ANALYTICS_DB: D1Database;
+  INSTALL_ID_HASH_SECRET: string;
+};
+
+type AnalyticsEvent = {
+  schemaVersion: number;
+  installId: string;
+  dateBucket: string;
+  command: string;
+  status: string;
+  durationBucket?: string;
+  appVersion: string;
+  nodeMajor: string;
+  os: string;
+  osVersion: string;
+};
+
+const allowedCommands = new Set(['up', 'gu', 'ballin_update', 'ballin']);
+const allowedStatuses = new Set(['success', 'failure', 'unknown']);
+const allowedDurations = new Set(['unknown', '<1s', '1-10s', '10-60s', '1-10m', '10m+']);
+const allowedOs = new Set(['darwin', 'linux', 'win32', 'unknown']);
+const installIdPattern = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const dateBucketPattern = /^\d{4}-\d{2}-\d{2}$/;
+const versionPattern = /^[0-9]+(?:\.[0-9]+){0,2}(?:[-+][0-9A-Za-z.-]+)?$/;
+const majorVersionPattern = /^[0-9]+$/;
+const coarseOsVersionPattern = /^[0-9]+(?:\.[0-9]+)?$|^unknown$/;
+const retentionDays = 395;
+
+const jsonResponse = (status: number, body: { error: string }): Response => (
+  new Response(JSON.stringify(body), {
+    status,
+    headers: {
+      'content-type': 'application/json; charset=utf-8',
+      'cache-control': 'no-store',
+    },
+  })
+);
+
+const emptyResponse = (status: number): Response => (
+  new Response(null, {
+    status,
+    headers: {
+      'cache-control': 'no-store',
+    },
+  })
+);
+
+const isObject = (value: unknown): value is Record<string, unknown> => (
+  typeof value === 'object' && value !== null && !Array.isArray(value)
+);
+
+const stringField = (payload: Record<string, unknown>, key: string): string | null => {
+  const value = payload[key];
+  return typeof value === 'string' && value.length > 0 ? value : null;
+};
+
+const validateDateBucket = (dateBucket: string): boolean => {
+  if (!dateBucketPattern.test(dateBucket)) {
+    return false;
+  }
+  const parsed = new Date(`${dateBucket}T00:00:00.000Z`);
+  return !Number.isNaN(parsed.getTime()) && parsed.toISOString().startsWith(dateBucket);
+};
+
+const parseAnalyticsEvent = (payload: unknown): AnalyticsEvent | string => {
+  if (!isObject(payload)) {
+    return 'event payload must be a JSON object';
+  }
+  if (payload.schemaVersion !== 1) {
+    return 'schemaVersion must be 1';
+  }
+
+  const installId = stringField(payload, 'installId');
+  const dateBucket = stringField(payload, 'dateBucket');
+  const command = stringField(payload, 'command');
+  const status = stringField(payload, 'status');
+  const durationBucket = stringField(payload, 'durationBucket') ?? 'unknown';
+  const appVersion = stringField(payload, 'appVersion');
+  const nodeMajor = stringField(payload, 'nodeMajor');
+  const os = stringField(payload, 'os');
+  const osVersion = stringField(payload, 'osVersion');
+
+  if (!installId || !installIdPattern.test(installId)) {
+    return 'installId must be a UUID';
+  }
+  if (!dateBucket || !validateDateBucket(dateBucket)) {
+    return 'dateBucket must be YYYY-MM-DD';
+  }
+  if (!command || !allowedCommands.has(command)) {
+    return 'command is not supported';
+  }
+  if (!status || !allowedStatuses.has(status)) {
+    return 'status is not supported';
+  }
+  if (!allowedDurations.has(durationBucket)) {
+    return 'durationBucket is not supported';
+  }
+  if (!appVersion || !versionPattern.test(appVersion)) {
+    return 'appVersion must be a coarse semantic version';
+  }
+  if (!nodeMajor || !majorVersionPattern.test(nodeMajor)) {
+    return 'nodeMajor must be a major version number';
+  }
+  if (!os || !allowedOs.has(os)) {
+    return 'os is not supported';
+  }
+  if (!osVersion || !coarseOsVersionPattern.test(osVersion)) {
+    return 'osVersion must be coarse';
+  }
+
+  return {
+    schemaVersion: 1,
+    installId,
+    dateBucket,
+    command,
+    status,
+    durationBucket,
+    appVersion,
+    nodeMajor,
+    os,
+    osVersion,
+  };
+};
+
+const hashInstallId = async (installId: string, secret: string): Promise<string> => {
+  const encoder = new TextEncoder();
+  const key = await crypto.subtle.importKey(
+    'raw',
+    encoder.encode(secret),
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign'],
+  );
+  const signature = await crypto.subtle.sign('HMAC', key, encoder.encode(installId));
+  return [...new Uint8Array(signature)]
+    .map((byte) => byte.toString(16).padStart(2, '0'))
+    .join('');
+};
+
+const storeAnalyticsEvent = async (env: Env, event: AnalyticsEvent): Promise<void> => {
+  const installIdHash = await hashInstallId(event.installId, env.INSTALL_ID_HASH_SECRET);
+
+  await env.ANALYTICS_DB.batch([
+    env.ANALYTICS_DB.prepare(`
+      INSERT OR IGNORE INTO install_days (date_bucket, install_id_hash)
+      VALUES (?1, ?2)
+    `).bind(event.dateBucket, installIdHash),
+    env.ANALYTICS_DB.prepare(`
+      INSERT INTO command_events_daily (date_bucket, command, status, duration_bucket, count)
+      VALUES (?1, ?2, ?3, ?4, 1)
+      ON CONFLICT(date_bucket, command, status, duration_bucket)
+      DO UPDATE SET count = count + 1
+    `).bind(event.dateBucket, event.command, event.status, event.durationBucket),
+    env.ANALYTICS_DB.prepare(`
+      INSERT INTO version_events_daily (
+        date_bucket,
+        command,
+        app_version,
+        node_major,
+        os,
+        os_version,
+        count
+      )
+      VALUES (?1, ?2, ?3, ?4, ?5, ?6, 1)
+      ON CONFLICT(date_bucket, command, app_version, node_major, os, os_version)
+      DO UPDATE SET count = count + 1
+    `).bind(
+      event.dateBucket,
+      event.command,
+      event.appVersion,
+      event.nodeMajor,
+      event.os,
+      event.osVersion,
+    ),
+  ]);
+};
+
+const handleEventRequest = async (request: Request, env: Env): Promise<Response> => {
+  if (request.method !== 'POST') {
+    return emptyResponse(405);
+  }
+  if (!request.headers.get('content-type')?.toLowerCase().includes('application/json')) {
+    return jsonResponse(400, { error: 'content-type must be application/json' });
+  }
+  if (!env.INSTALL_ID_HASH_SECRET) {
+    return jsonResponse(500, { error: 'analytics backend is not configured' });
+  }
+
+  let payload: unknown;
+  try {
+    payload = await request.json();
+  } catch {
+    return jsonResponse(400, { error: 'invalid JSON' });
+  }
+
+  const event = parseAnalyticsEvent(payload);
+  if (typeof event === 'string') {
+    return jsonResponse(400, { error: event });
+  }
+
+  await storeAnalyticsEvent(env, event);
+  return emptyResponse(204);
+};
+
+const cutoffDateBucket = (scheduledTime: number): string => {
+  const cutoff = new Date(scheduledTime - retentionDays * 24 * 60 * 60 * 1000);
+  return cutoff.toISOString().slice(0, 10);
+};
+
+const cleanupOldRows = async (env: Env, scheduledTime: number): Promise<void> => {
+  const cutoff = cutoffDateBucket(scheduledTime);
+  await env.ANALYTICS_DB.batch([
+    env.ANALYTICS_DB.prepare('DELETE FROM install_days WHERE date_bucket < ?1').bind(cutoff),
+    env.ANALYTICS_DB.prepare('DELETE FROM command_events_daily WHERE date_bucket < ?1').bind(cutoff),
+    env.ANALYTICS_DB.prepare('DELETE FROM version_events_daily WHERE date_bucket < ?1').bind(cutoff),
+  ]);
+};
+
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    const url = new URL(request.url);
+    if (url.pathname !== '/v1/events') {
+      return emptyResponse(404);
+    }
+    return handleEventRequest(request, env);
+  },
+
+  async scheduled(controller: ScheduledController, env: Env, ctx: ExecutionContext): Promise<void> {
+    ctx.waitUntil(cleanupOldRows(env, controller.scheduledTime));
+  },
+};

--- a/analytics-worker/src/index.ts
+++ b/analytics-worker/src/index.ts
@@ -20,6 +20,7 @@ type ScheduledController = {
 type Env = {
   ANALYTICS_DB: D1Database;
   INSTALL_ID_HASH_SECRET: string;
+  INGEST_TOKEN: string;
 };
 
 type AnalyticsEvent = {
@@ -35,16 +36,23 @@ type AnalyticsEvent = {
   osVersion: string;
 };
 
+type ParseOptions = {
+  now: Date;
+};
+
 const allowedCommands = new Set(['up', 'gu', 'ballin_update', 'ballin']);
 const allowedStatuses = new Set(['success', 'failure', 'unknown']);
 const allowedDurations = new Set(['unknown', '<1s', '1-10s', '10-60s', '1-10m', '10m+']);
 const allowedOs = new Set(['darwin', 'linux', 'win32', 'unknown']);
-const installIdPattern = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const installIdPattern = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
 const dateBucketPattern = /^\d{4}-\d{2}-\d{2}$/;
-const versionPattern = /^[0-9]+(?:\.[0-9]+){0,2}(?:[-+][0-9A-Za-z.-]+)?$/;
+const versionPattern = /^[0-9]+(?:\.[0-9]+){0,2}$/;
 const majorVersionPattern = /^[0-9]+$/;
 const coarseOsVersionPattern = /^[0-9]+(?:\.[0-9]+)?$|^unknown$/;
+const ingestTokenHeader = 'x-ballin-analytics-token';
+const maxBodyBytes = 2048;
 const retentionDays = 395;
+const allowedDateSkewDays = 1;
 
 const jsonResponse = (status: number, body: { error: string }): Response => (
   new Response(JSON.stringify(body), {
@@ -82,7 +90,14 @@ const validateDateBucket = (dateBucket: string): boolean => {
   return !Number.isNaN(parsed.getTime()) && parsed.toISOString().startsWith(dateBucket);
 };
 
-const parseAnalyticsEvent = (payload: unknown): AnalyticsEvent | string => {
+const isDateBucketWithinSkew = (dateBucket: string, now: Date): boolean => {
+  const dateBucketTime = Date.parse(`${dateBucket}T00:00:00.000Z`);
+  const currentBucketTime = Date.parse(`${now.toISOString().slice(0, 10)}T00:00:00.000Z`);
+  const maxDifference = allowedDateSkewDays * 24 * 60 * 60 * 1000;
+  return Math.abs(dateBucketTime - currentBucketTime) <= maxDifference;
+};
+
+const parseAnalyticsEvent = (payload: unknown, options: ParseOptions): AnalyticsEvent | string => {
   if (!isObject(payload)) {
     return 'event payload must be a JSON object';
   }
@@ -101,10 +116,13 @@ const parseAnalyticsEvent = (payload: unknown): AnalyticsEvent | string => {
   const osVersion = stringField(payload, 'osVersion');
 
   if (!installId || !installIdPattern.test(installId)) {
-    return 'installId must be a UUID';
+    return 'installId must be a lowercase UUID';
   }
   if (!dateBucket || !validateDateBucket(dateBucket)) {
     return 'dateBucket must be YYYY-MM-DD';
+  }
+  if (!isDateBucketWithinSkew(dateBucket, options.now)) {
+    return 'dateBucket is outside the accepted clock skew';
   }
   if (!command || !allowedCommands.has(command)) {
     return 'command is not supported';
@@ -116,7 +134,7 @@ const parseAnalyticsEvent = (payload: unknown): AnalyticsEvent | string => {
     return 'durationBucket is not supported';
   }
   if (!appVersion || !versionPattern.test(appVersion)) {
-    return 'appVersion must be a coarse semantic version';
+    return 'appVersion must be a released semantic version';
   }
   if (!nodeMajor || !majorVersionPattern.test(nodeMajor)) {
     return 'nodeMajor must be a major version number';
@@ -205,6 +223,16 @@ const handleEventRequest = async (request: Request, env: Env): Promise<Response>
   if (!env.INSTALL_ID_HASH_SECRET) {
     return jsonResponse(500, { error: 'analytics backend is not configured' });
   }
+  if (!env.INGEST_TOKEN) {
+    return jsonResponse(500, { error: 'analytics ingest gate is not configured' });
+  }
+  if (request.headers.get(ingestTokenHeader) !== env.INGEST_TOKEN) {
+    return emptyResponse(401);
+  }
+  const contentLength = Number(request.headers.get('content-length') ?? '0');
+  if (!Number.isFinite(contentLength) || contentLength <= 0 || contentLength > maxBodyBytes) {
+    return jsonResponse(400, { error: 'invalid content length' });
+  }
 
   let payload: unknown;
   try {
@@ -213,7 +241,7 @@ const handleEventRequest = async (request: Request, env: Env): Promise<Response>
     return jsonResponse(400, { error: 'invalid JSON' });
   }
 
-  const event = parseAnalyticsEvent(payload);
+  const event = parseAnalyticsEvent(payload, { now: new Date() });
   if (typeof event === 'string') {
     return jsonResponse(400, { error: event });
   }

--- a/analytics-worker/wrangler.toml.example
+++ b/analytics-worker/wrangler.toml.example
@@ -1,0 +1,11 @@
+name = "ballin-scripts-analytics"
+main = "src/index.ts"
+compatibility_date = "2026-06-27"
+
+[[d1_databases]]
+binding = "ANALYTICS_DB"
+database_name = "ballin-scripts-analytics"
+database_id = "replace-with-cloudflare-d1-database-id"
+
+[triggers]
+crons = ["17 3 * * *"]

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,3 +6,5 @@ Start here when setting up or auditing what `ballin-scripts` manages.
   tool setup, and configurable `up` settings.
 - [Supported capabilities](capabilities.md): the current `up` integrations and
   `gu` backup snapshots.
+- [Analytics backend](analytics-backend.md): backend choice, data policy, and
+  deployment notes for active-install analytics.

--- a/docs/analytics-backend.md
+++ b/docs/analytics-backend.md
@@ -16,7 +16,7 @@ CLI.
   IDs.
 - The CLI does not need a runtime analytics SDK.
 - Retention is controlled by the Worker and D1 schema.
-- The deployment can stay tiny: one Worker, one D1 database, and one secret.
+- The deployment can stay tiny: one Worker, one D1 database, and two secrets.
 
 ## Alternatives Considered
 
@@ -32,6 +32,14 @@ CLI.
 The Worker deletes rows older than 395 days. That keeps roughly 13 months of
 daily active-install and command-count data.
 
+## Abuse Controls
+
+The skeleton requires an ingest token before accepting events and rejects
+oversized payloads. A distributed CLI cannot keep a token truly secret, so this
+is a deployment gate rather than the complete production abuse story. Before
+real production traffic is enabled, configure Cloudflare-side rate limiting or
+equivalent edge protection for `POST /v1/events`.
+
 ## Production Checklist
 
 Before enabling the CLI to send production events:
@@ -40,6 +48,8 @@ Before enabling the CLI to send production events:
 - create the D1 database
 - apply `analytics-worker/migrations/0001_initial.sql`
 - set `INSTALL_ID_HASH_SECRET`
+- set `INGEST_TOKEN`
+- configure Cloudflare-side rate limiting or equivalent edge protection
 - deploy the Worker
 - configure the CLI endpoint in the client implementation
 - re-check that the client payload matches the documented allowlist

--- a/docs/analytics-backend.md
+++ b/docs/analytics-backend.md
@@ -1,0 +1,45 @@
+# Analytics Backend
+
+Issue #166 selected a small Cloudflare Worker backed by D1 for the first
+`ballin-scripts` analytics backend. The goal is active-install visibility, not a
+general product analytics platform.
+
+The backend skeleton lives in [`analytics-worker/`](../analytics-worker/). It is
+not deployed by default and does not require a Cloudflare account to work on the
+CLI.
+
+## Why Cloudflare Worker and D1
+
+- The event schema is owned by this project and can reject anything outside the
+  privacy allowlist.
+- D1 can compute exact DAU/WAU/MAU from daily buckets and server-hashed install
+  IDs.
+- The CLI does not need a runtime analytics SDK.
+- Retention is controlled by the Worker and D1 schema.
+- The deployment can stay tiny: one Worker, one D1 database, and one secret.
+
+## Alternatives Considered
+
+- PostHog has good dashboards and capture APIs, but it is a broader analytics
+  stack than the current maintenance question needs.
+- Plausible is privacy-focused, but its visitor model is shaped around web
+  traffic headers rather than CLI install IDs.
+- Workers Analytics Engine is useful for high-cardinality metric streams, but D1
+  is simpler for exact low-volume active-install counts.
+
+## Retention
+
+The Worker deletes rows older than 395 days. That keeps roughly 13 months of
+daily active-install and command-count data.
+
+## Production Checklist
+
+Before enabling the CLI to send production events:
+
+- create the Cloudflare Worker project
+- create the D1 database
+- apply `analytics-worker/migrations/0001_initial.sql`
+- set `INSTALL_ID_HASH_SECRET`
+- deploy the Worker
+- configure the CLI endpoint in the client implementation
+- re-check that the client payload matches the documented allowlist

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "lint": "eslint .",
     "typecheck": "tsc --noEmit",
+    "typecheck:analytics-worker": "tsc --noEmit --strict --target ES2023 --module ESNext --lib ES2023,WebWorker --ignoreConfig analytics-worker/src/index.ts",
     "test:unit": "mocha",
     "test": "npm run lint && npm run typecheck && npm run test:unit"
   },

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "typecheck": "tsc --noEmit",
     "typecheck:analytics-worker": "tsc --noEmit --strict --target ES2023 --module ESNext --lib ES2023,WebWorker --ignoreConfig analytics-worker/src/index.ts",
     "test:unit": "mocha",
-    "test": "npm run lint && npm run typecheck && npm run test:unit"
+    "test": "npm run lint && npm run typecheck && npm run typecheck:analytics-worker && npm run test:unit"
   },
   "engines": {
     "node": ">=24.12"


### PR DESCRIPTION
## Summary

- add an isolated `analytics-worker/` Cloudflare Worker skeleton for issue #166
- define the D1 schema, daily aggregate tables, retention cleanup, and example DAU/WAU/MAU queries
- document the backend choice, data policy, deployment checklist, and alternatives considered

## Notes

This does not require a live Cloudflare project yet. The Worker is a repo-local backend skeleton with `wrangler.toml.example`; production setup still needs a Cloudflare Worker, D1 database, `INSTALL_ID_HASH_SECRET`, and deployment before any CLI client can send real events.

The worker validates a narrow event schema, hashes install IDs server-side before storage, stores daily aggregates, and includes a scheduled cleanup for rows older than 395 days.

Closes #166

## Validation

- `npm test`
- `./node_modules/.bin/tsc --noEmit --strict --target ES2023 --module ESNext --lib ES2023,WebWorker --ignoreConfig analytics-worker/src/index.ts`
