### PR TITLE
[codex] Add analytics client plumbing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /node_modules
 ballin.config.json
 /.gu-cache
+/.analytics

--- a/commands/analytics.ts
+++ b/commands/analytics.ts
@@ -7,6 +7,7 @@ const { fetchConfig } = require('../config/index.ts');
 
 import type { ClientRequest, IncomingMessage } from 'http';
 import type { RequestOptions } from 'https';
+import type { Socket } from 'net';
 
 type AnalyticsConfig = {
   enabled?: string;
@@ -201,6 +202,12 @@ const ignoreRequestFailure = (request: ClientRequest): void => {
   request.on('error', () => {});
 };
 
+const unrefRequestSocket = (request: ClientRequest): void => {
+  request.on('socket', (socket: Socket) => {
+    socket.unref();
+  });
+};
+
 const sendAnalyticsPayload: AnalyticsSender = (payload, options) => {
   if (!options.endpoint || !options.ingestToken) {
     return;
@@ -220,11 +227,11 @@ const sendAnalyticsPayload: AnalyticsSender = (payload, options) => {
     });
 
     ignoreRequestFailure(request);
+    unrefRequestSocket(request);
     request.setTimeout(options.timeoutMs ?? defaultTimeoutMs, () => {
       request.destroy();
     });
     request.end(body);
-    request.unref();
   } catch {
     // Analytics must never affect command behavior.
   }

--- a/commands/analytics.ts
+++ b/commands/analytics.ts
@@ -3,15 +3,13 @@ const crypto = require('crypto');
 const https = require('https');
 const os = require('os');
 const path = require('path');
-const { configPath, fetchConfig, stringify } = require('../config/index.ts');
+const { fetchConfig } = require('../config/index.ts');
 
 import type { ClientRequest, IncomingMessage } from 'http';
 import type { RequestOptions } from 'https';
 
 type AnalyticsConfig = {
   enabled?: string;
-  noticeShown?: string;
-  installId?: string | null;
 };
 
 type AnalyticsPayload = {
@@ -44,10 +42,16 @@ type AnalyticsSender = (payload: AnalyticsPayload, options: SenderOptions) => vo
 
 type AnalyticsRuntime = SenderOptions & {
   env?: NodeJS.ProcessEnv;
-  isInteractive?: boolean;
-  noticeWriter?: (message: string) => void;
+  installIdPath?: string;
   sender?: AnalyticsSender;
+};
+
+type AnalyticsInstallIdOptions = {
+  analyticsConfig?: AnalyticsConfig;
   generateInstallId?: () => string;
+  installIdPath?: string;
+  noticeWriter?: (message: string) => void;
+  repoDir?: string;
 };
 
 type ConfigObject = { [key: string]: unknown };
@@ -65,6 +69,7 @@ const allowedCommands = new Set([
 const allowedStatuses = new Set(['success', 'failure', 'unknown']);
 const allowedDurations = new Set(['unknown', '<1s', '1-10s', '10-60s', '1-10m', '10m+']);
 const allowedOs = new Set(['darwin', 'linux', 'win32']);
+const installIdPattern = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
 const analyticsNotice = [
   'ballin-scripts collects minimal anonymous command analytics.',
   'No command arguments, paths, usernames, Gist IDs, dotfiles, package lists, raw errors, or environment values are sent.',
@@ -73,6 +78,7 @@ const analyticsNotice = [
 ].join('\n');
 
 const packageJsonPath = path.join(__dirname, '..', 'package.json');
+const defaultRepoDir = path.join(__dirname, '..');
 
 const loadAppVersion = (): string => {
   try {
@@ -83,32 +89,59 @@ const loadAppVersion = (): string => {
   }
 };
 
-const defaultNoticeWriter = (message: string): void => {
-  process.stderr.write(`${message}\n`);
-};
-
-const isInteractiveRun = (): boolean => Boolean(process.stdin.isTTY && process.stderr.isTTY);
-
 const isAnalyticsConfig = (value: unknown): value is AnalyticsConfig => (
   typeof value === 'object' && value !== null && !Array.isArray(value)
 );
 
-const readAnalyticsConfig = (): { root: ConfigObject; analytics: AnalyticsConfig } => {
+const readAnalyticsConfig = (): { analytics: AnalyticsConfig } => {
   const { configObj } = fetchConfig() as { configObj: ConfigObject };
   return {
-    root: configObj,
     analytics: isAnalyticsConfig(configObj.analytics) ? configObj.analytics : {},
   };
-};
-
-const writeAnalyticsConfig = (root: ConfigObject, analytics: AnalyticsConfig): void => {
-  root.analytics = analytics;
-  fs.writeFileSync(configPath, stringify(root), 'utf8');
 };
 
 const analyticsDisabledByEnv = (env: NodeJS.ProcessEnv): boolean => (
   env.BALLIN_NO_ANALYTICS === '1' || Boolean(env.CI)
 );
+
+const installIdPathForRepo = (repoDir = defaultRepoDir): string => (
+  path.join(repoDir, '.analytics', 'install-id')
+);
+
+const readLocalInstallId = (installIdPath = installIdPathForRepo()): string | null => {
+  try {
+    const installId = fs.readFileSync(installIdPath, 'utf8').trim();
+    return installIdPattern.test(installId) ? installId : null;
+  } catch {
+    return null;
+  }
+};
+
+const writeLocalInstallId = (installId: string, installIdPath = installIdPathForRepo()): boolean => {
+  try {
+    fs.mkdirSync(path.dirname(installIdPath), { recursive: true });
+    fs.writeFileSync(installIdPath, `${installId}\n`, 'utf8');
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+const ensureAnalyticsInstallId = (options: AnalyticsInstallIdOptions = {}): string | null => {
+  if (options.analyticsConfig?.enabled !== 'true') {
+    return null;
+  }
+
+  const installIdPath = options.installIdPath ?? installIdPathForRepo(options.repoDir);
+  const existingInstallId = readLocalInstallId(installIdPath);
+  if (existingInstallId) {
+    return existingInstallId;
+  }
+
+  options.noticeWriter?.(analyticsNotice);
+  const installId = (options.generateInstallId ?? crypto.randomUUID)();
+  return writeLocalInstallId(installId, installIdPath) ? installId : null;
+};
 
 const dateBucket = (now: Date): string => now.toISOString().slice(0, 10);
 
@@ -207,31 +240,12 @@ const recordAnalyticsEvent = (input: AnalyticsRecordInput, runtime: AnalyticsRun
       return;
     }
 
-    const { root, analytics } = readAnalyticsConfig();
+    const { analytics } = readAnalyticsConfig();
     if (analytics.enabled !== 'true') {
       return;
     }
 
-    let installId = analytics.installId;
-    if (analytics.noticeShown !== 'true') {
-      const interactive = runtime.isInteractive ?? isInteractiveRun();
-      if (!interactive) {
-        return;
-      }
-      (runtime.noticeWriter ?? defaultNoticeWriter)(analyticsNotice);
-      installId = (runtime.generateInstallId ?? crypto.randomUUID)();
-      writeAnalyticsConfig(root, {
-        ...analytics,
-        noticeShown: 'true',
-        installId,
-      });
-    } else if (!installId) {
-      installId = (runtime.generateInstallId ?? crypto.randomUUID)();
-      writeAnalyticsConfig(root, {
-        ...analytics,
-        installId,
-      });
-    }
+    const installId = readLocalInstallId(runtime.installIdPath);
     if (!installId) {
       return;
     }
@@ -256,6 +270,9 @@ module.exports = {
   analyticsDisabledByEnv,
   analyticsNotice,
   buildAnalyticsPayload,
+  ensureAnalyticsInstallId,
+  installIdPathForRepo,
+  readLocalInstallId,
   recordAnalyticsEvent,
   sendAnalyticsPayload,
 };

--- a/commands/analytics.ts
+++ b/commands/analytics.ts
@@ -48,6 +48,7 @@ type AnalyticsRuntime = SenderOptions & {
 
 type AnalyticsInstallIdOptions = {
   analyticsConfig?: AnalyticsConfig;
+  env?: NodeJS.ProcessEnv;
   generateInstallId?: () => string;
   installIdPath?: string;
   noticeWriter?: (message: string) => void;
@@ -73,6 +74,7 @@ const installIdPattern = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-
 const analyticsNotice = [
   'ballin-scripts collects minimal anonymous command analytics.',
   'No command arguments, paths, usernames, Gist IDs, dotfiles, package lists, raw errors, or environment values are sent.',
+  'Setup creates a local anonymous install ID now, but it does not send analytics during install.',
   'Opt out with: ballin_config set analytics.enabled false',
   'Or for a single environment: BALLIN_NO_ANALYTICS=1',
 ].join('\n');
@@ -128,6 +130,9 @@ const writeLocalInstallId = (installId: string, installIdPath = installIdPathFor
 };
 
 const ensureAnalyticsInstallId = (options: AnalyticsInstallIdOptions = {}): string | null => {
+  if (analyticsDisabledByEnv(options.env ?? process.env)) {
+    return null;
+  }
   if (options.analyticsConfig?.enabled !== 'true') {
     return null;
   }

--- a/commands/analytics.ts
+++ b/commands/analytics.ts
@@ -1,0 +1,261 @@
+const fs = require('fs');
+const crypto = require('crypto');
+const https = require('https');
+const os = require('os');
+const path = require('path');
+const { configPath, fetchConfig, stringify } = require('../config/index.ts');
+
+import type { ClientRequest, IncomingMessage } from 'http';
+import type { RequestOptions } from 'https';
+
+type AnalyticsConfig = {
+  enabled?: string;
+  noticeShown?: string;
+  installId?: string | null;
+};
+
+type AnalyticsPayload = {
+  schemaVersion: 1;
+  installId: string;
+  dateBucket: string;
+  command: string;
+  status: string;
+  durationBucket: string;
+  appVersion: string;
+  nodeMajor: string;
+  os: string;
+  osVersion: string;
+};
+
+type AnalyticsRecordInput = {
+  command: string;
+  status?: string;
+  durationBucket?: string;
+  now?: Date;
+};
+
+type SenderOptions = {
+  endpoint?: string;
+  ingestToken?: string;
+  timeoutMs?: number;
+};
+
+type AnalyticsSender = (payload: AnalyticsPayload, options: SenderOptions) => void;
+
+type AnalyticsRuntime = SenderOptions & {
+  env?: NodeJS.ProcessEnv;
+  isInteractive?: boolean;
+  noticeWriter?: (message: string) => void;
+  sender?: AnalyticsSender;
+  generateInstallId?: () => string;
+};
+
+type ConfigObject = { [key: string]: unknown };
+
+const schemaVersion = 1;
+const defaultTimeoutMs = 750;
+const allowedCommands = new Set([
+  'ballin',
+  'ballin_config',
+  'ballin_uninstall',
+  'ballin_update',
+  'gu',
+  'up',
+]);
+const allowedStatuses = new Set(['success', 'failure', 'unknown']);
+const allowedDurations = new Set(['unknown', '<1s', '1-10s', '10-60s', '1-10m', '10m+']);
+const allowedOs = new Set(['darwin', 'linux', 'win32']);
+const analyticsNotice = [
+  'ballin-scripts collects minimal anonymous command analytics.',
+  'No command arguments, paths, usernames, Gist IDs, dotfiles, package lists, raw errors, or environment values are sent.',
+  'Opt out with: ballin_config set analytics.enabled false',
+  'Or for a single environment: BALLIN_NO_ANALYTICS=1',
+].join('\n');
+
+const packageJsonPath = path.join(__dirname, '..', 'package.json');
+
+const loadAppVersion = (): string => {
+  try {
+    const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8')) as { version?: unknown };
+    return typeof packageJson.version === 'string' ? packageJson.version : '0.0.0';
+  } catch {
+    return '0.0.0';
+  }
+};
+
+const defaultNoticeWriter = (message: string): void => {
+  process.stderr.write(`${message}\n`);
+};
+
+const isInteractiveRun = (): boolean => Boolean(process.stdin.isTTY && process.stderr.isTTY);
+
+const isAnalyticsConfig = (value: unknown): value is AnalyticsConfig => (
+  typeof value === 'object' && value !== null && !Array.isArray(value)
+);
+
+const readAnalyticsConfig = (): { root: ConfigObject; analytics: AnalyticsConfig } => {
+  const { configObj } = fetchConfig() as { configObj: ConfigObject };
+  return {
+    root: configObj,
+    analytics: isAnalyticsConfig(configObj.analytics) ? configObj.analytics : {},
+  };
+};
+
+const writeAnalyticsConfig = (root: ConfigObject, analytics: AnalyticsConfig): void => {
+  root.analytics = analytics;
+  fs.writeFileSync(configPath, stringify(root), 'utf8');
+};
+
+const analyticsDisabledByEnv = (env: NodeJS.ProcessEnv): boolean => (
+  env.BALLIN_NO_ANALYTICS === '1' || Boolean(env.CI)
+);
+
+const dateBucket = (now: Date): string => now.toISOString().slice(0, 10);
+
+const nodeMajor = (): string => process.versions.node.split('.')[0] ?? '0';
+
+const osFamily = (): string => {
+  const platform = os.platform();
+  return allowedOs.has(platform) ? platform : 'unknown';
+};
+
+const coarseOsVersion = (): string => {
+  const [major, minor] = os.release().split('.');
+  if (!major || !/^[0-9]+$/.test(major)) {
+    return 'unknown';
+  }
+  return minor && /^[0-9]+$/.test(minor) ? `${major}.${minor}` : major;
+};
+
+const buildAnalyticsPayload = (
+  input: Required<Pick<AnalyticsRecordInput, 'command' | 'status' | 'durationBucket' | 'now'>>,
+  installId: string,
+): AnalyticsPayload => ({
+  schemaVersion,
+  installId,
+  dateBucket: dateBucket(input.now),
+  command: input.command,
+  status: input.status,
+  durationBucket: input.durationBucket,
+  appVersion: loadAppVersion(),
+  nodeMajor: nodeMajor(),
+  os: osFamily(),
+  osVersion: coarseOsVersion(),
+});
+
+const requestOptions = (endpoint: string, ingestToken: string): RequestOptions => {
+  const url = new URL(endpoint);
+  return {
+    method: 'POST',
+    protocol: url.protocol,
+    hostname: url.hostname,
+    port: url.port,
+    path: `${url.pathname}${url.search}`,
+    headers: {
+      'content-type': 'application/json',
+      'x-ballin-analytics-token': ingestToken,
+    },
+  };
+};
+
+const ignoreRequestFailure = (request: ClientRequest): void => {
+  request.on('error', () => {});
+};
+
+const sendAnalyticsPayload: AnalyticsSender = (payload, options) => {
+  if (!options.endpoint || !options.ingestToken) {
+    return;
+  }
+
+  try {
+    const body = JSON.stringify(payload);
+    const optionsWithHeaders = requestOptions(options.endpoint, options.ingestToken);
+    const request = https.request({
+      ...optionsWithHeaders,
+      headers: {
+        ...optionsWithHeaders.headers,
+        'content-length': Buffer.byteLength(body),
+      },
+    }, (response: IncomingMessage) => {
+      response.resume();
+    });
+
+    ignoreRequestFailure(request);
+    request.setTimeout(options.timeoutMs ?? defaultTimeoutMs, () => {
+      request.destroy();
+    });
+    request.end(body);
+    request.unref();
+  } catch {
+    // Analytics must never affect command behavior.
+  }
+};
+
+const recordAnalyticsEvent = (input: AnalyticsRecordInput, runtime: AnalyticsRuntime = {}): void => {
+  try {
+    const env = runtime.env ?? process.env;
+    if (analyticsDisabledByEnv(env)) {
+      return;
+    }
+    if (!allowedCommands.has(input.command)) {
+      return;
+    }
+
+    const status = input.status ?? 'unknown';
+    const durationBucket = input.durationBucket ?? 'unknown';
+    if (!allowedStatuses.has(status) || !allowedDurations.has(durationBucket)) {
+      return;
+    }
+
+    const { root, analytics } = readAnalyticsConfig();
+    if (analytics.enabled !== 'true') {
+      return;
+    }
+
+    let installId = analytics.installId;
+    if (analytics.noticeShown !== 'true') {
+      const interactive = runtime.isInteractive ?? isInteractiveRun();
+      if (!interactive) {
+        return;
+      }
+      (runtime.noticeWriter ?? defaultNoticeWriter)(analyticsNotice);
+      installId = (runtime.generateInstallId ?? crypto.randomUUID)();
+      writeAnalyticsConfig(root, {
+        ...analytics,
+        noticeShown: 'true',
+        installId,
+      });
+    } else if (!installId) {
+      installId = (runtime.generateInstallId ?? crypto.randomUUID)();
+      writeAnalyticsConfig(root, {
+        ...analytics,
+        installId,
+      });
+    }
+    if (!installId) {
+      return;
+    }
+
+    const payload = buildAnalyticsPayload({
+      command: input.command,
+      status,
+      durationBucket,
+      now: input.now ?? new Date(),
+    }, installId);
+    (runtime.sender ?? sendAnalyticsPayload)(payload, {
+      endpoint: runtime.endpoint,
+      ingestToken: runtime.ingestToken,
+      timeoutMs: runtime.timeoutMs ?? defaultTimeoutMs,
+    });
+  } catch {
+    // Analytics must never affect command behavior or exit status.
+  }
+};
+
+module.exports = {
+  analyticsDisabledByEnv,
+  analyticsNotice,
+  buildAnalyticsPayload,
+  recordAnalyticsEvent,
+  sendAnalyticsPayload,
+};

--- a/commands/analytics.ts
+++ b/commands/analytics.ts
@@ -75,6 +75,7 @@ const analyticsNotice = [
   'ballin-scripts collects minimal anonymous command analytics.',
   'No command arguments, paths, usernames, Gist IDs, dotfiles, package lists, raw errors, or environment values are sent.',
   'Setup creates a local anonymous install ID now, but it does not send analytics during install.',
+  'Later analytics events include that install ID so the backend can count active installs; the backend hashes it before storage.',
   'Opt out with: ballin_config set analytics.enabled false',
   'Or for a single environment: BALLIN_NO_ANALYTICS=1',
 ].join('\n');

--- a/commands/install_setup.ts
+++ b/commands/install_setup.ts
@@ -29,6 +29,11 @@ const setupAnalyticsInstallId = (repoDir: string, configPath: string): void => {
   }
 };
 
+const setupAnalytics = (repoDir: string): boolean => {
+  setupAnalyticsInstallId(repoDir, path.join(repoDir, 'ballin.config.json'));
+  return true;
+};
+
 const configure = (repoDir: string, docsUrl: string): boolean => {
   const configPath = path.join(repoDir, 'ballin.config.json');
   const defaultConfigPath = path.join(repoDir, 'config', '.defaultConfig.json');
@@ -41,7 +46,6 @@ const configure = (repoDir: string, docsUrl: string): boolean => {
       return false;
     }
     writeStdoutLine("\n🧠 Created 'ballin.config.json' file in root using default settings");
-    setupAnalyticsInstallId(repoDir, configPath);
     return true;
   }
 
@@ -69,7 +73,6 @@ const configure = (repoDir: string, docsUrl: string): boolean => {
     writeStdoutLine(`\n🙌 ${updateOutput}`);
     writeStdoutLine(`\n👀 Docs: ${docsUrl}`);
   }
-  setupAnalyticsInstallId(repoDir, configPath);
 
   return true;
 };
@@ -114,8 +117,13 @@ const runInstallSetupCli = (): void => {
     return;
   }
 
+  if (command === 'setup-analytics' && repoDir) {
+    process.exitCode = setupAnalytics(repoDir) ? 0 : 1;
+    return;
+  }
+
   if (!command || !repoDir || !option) {
-    writeStdoutLine('Usage: install_setup.ts <configure|symlink-binaries> <repo-dir> <docs-url|bin-dir>');
+    writeStdoutLine('Usage: install_setup.ts <configure|symlink-binaries|setup-analytics> <repo-dir> [docs-url|bin-dir]');
     process.exitCode = 1;
     return;
   }
@@ -131,5 +139,6 @@ if (require.main === module) {
 module.exports = {
   configure,
   runInstallSetupCli,
+  setupAnalytics,
   symlinkBinaries,
 };

--- a/commands/install_setup.ts
+++ b/commands/install_setup.ts
@@ -1,9 +1,32 @@
 const fs = require('fs');
 const path = require('path');
 const {
+  ensureAnalyticsInstallId,
+} = require('./analytics.ts');
+const {
   runCommand,
   writeStdoutLine,
 } = require('./commandHelpers.ts');
+
+type ConfigObject = { [key: string]: unknown };
+
+const isConfigObject = (value: unknown): value is ConfigObject => (
+  typeof value === 'object' && value !== null && !Array.isArray(value)
+);
+
+const setupAnalyticsInstallId = (repoDir: string, configPath: string): void => {
+  try {
+    const config = JSON.parse(fs.readFileSync(configPath, 'utf8')) as ConfigObject;
+    const analyticsConfig = isConfigObject(config.analytics) ? config.analytics : undefined;
+    ensureAnalyticsInstallId({
+      analyticsConfig,
+      repoDir,
+      noticeWriter: writeStdoutLine,
+    });
+  } catch {
+    // Analytics setup must never block install or update.
+  }
+};
 
 const configure = (repoDir: string, docsUrl: string): boolean => {
   const configPath = path.join(repoDir, 'ballin.config.json');
@@ -17,6 +40,7 @@ const configure = (repoDir: string, docsUrl: string): boolean => {
       return false;
     }
     writeStdoutLine("\n🧠 Created 'ballin.config.json' file in root using default settings");
+    setupAnalyticsInstallId(repoDir, configPath);
     return true;
   }
 
@@ -44,6 +68,7 @@ const configure = (repoDir: string, docsUrl: string): boolean => {
     writeStdoutLine(`\n🙌 ${updateOutput}`);
     writeStdoutLine(`\n👀 Docs: ${docsUrl}`);
   }
+  setupAnalyticsInstallId(repoDir, configPath);
 
   return true;
 };

--- a/commands/install_setup.ts
+++ b/commands/install_setup.ts
@@ -20,6 +20,7 @@ const setupAnalyticsInstallId = (repoDir: string, configPath: string): void => {
     const analyticsConfig = isConfigObject(config.analytics) ? config.analytics : undefined;
     ensureAnalyticsInstallId({
       analyticsConfig,
+      env: process.env,
       repoDir,
       noticeWriter: writeStdoutLine,
     });

--- a/config/.defaultConfig.json
+++ b/config/.defaultConfig.json
@@ -11,5 +11,10 @@
     "id": null,
     "token_file": ".gist",
     "url": "https://gist.github.com"
+  },
+  "analytics": {
+    "enabled": "true",
+    "noticeShown": "false",
+    "installId": null
   }
 }

--- a/config/.defaultConfig.json
+++ b/config/.defaultConfig.json
@@ -13,8 +13,6 @@
     "url": "https://gist.github.com"
   },
   "analytics": {
-    "enabled": "true",
-    "noticeShown": "false",
-    "installId": null
+    "enabled": "true"
   }
 }

--- a/config/updateConfig.ts
+++ b/config/updateConfig.ts
@@ -36,12 +36,7 @@ Object.keys(defaultConfig).forEach((key) => {
     userConfig[key] = defaultVal;
     updates.push(`${key}: ${defaultVal}`);
   }
-  if (defaultVal !== null && typeof defaultVal === 'object') {
-    if (userConfig[key] === null || typeof userConfig[key] !== 'object') {
-      userConfig[key] = defaultVal;
-      updates.push(`${key}: ${defaultVal}`);
-      return;
-    }
+  if (typeof defaultVal === 'object' && (defaultVal as unknown) !== 'null') {
     Object.keys(defaultVal as ConfigObject).forEach((nestedKey) => {
       const nestedUserConfig = userConfig[key] as ConfigObject;
       const nestedDefaultConfig = defaultVal as ConfigObject;

--- a/config/updateConfig.ts
+++ b/config/updateConfig.ts
@@ -17,7 +17,12 @@ Object.keys(defaultConfig).forEach((key) => {
     userConfig[key] = defaultVal;
     updates.push(`${key}: ${defaultVal}`);
   }
-  if (typeof defaultVal === 'object' && (defaultVal as unknown) !== 'null') {
+  if (defaultVal !== null && typeof defaultVal === 'object') {
+    if (userConfig[key] === null || typeof userConfig[key] !== 'object') {
+      userConfig[key] = defaultVal;
+      updates.push(`${key}: ${defaultVal}`);
+      return;
+    }
     Object.keys(defaultVal as ConfigObject).forEach((nestedKey) => {
       const nestedUserConfig = userConfig[key] as ConfigObject;
       const nestedDefaultConfig = defaultVal as ConfigObject;

--- a/docs/optional-capabilities.md
+++ b/docs/optional-capabilities.md
@@ -60,10 +60,11 @@ the installed-app list in your backup. No configuration setting is required.
 
 `ballin-scripts` can send minimal anonymous command analytics after showing an
 install/update notice. Setup creates a local anonymous install ID, but it does
-not send analytics during install. Analytics never include command arguments,
-local paths, usernames, Gist IDs, dotfile contents, package lists, editor
-settings, raw errors, environment variables, arbitrary config values, or the
-local install ID file.
+not send analytics during install. Later command analytics include that install
+ID so the backend can count active installs; the backend hashes it before
+storage. Analytics never include command arguments, local paths, usernames, Gist
+IDs, dotfile contents, package lists, editor settings, raw errors, environment
+variables, arbitrary config values, or the local install ID file.
 
 Disable analytics persistently:
 

--- a/docs/optional-capabilities.md
+++ b/docs/optional-capabilities.md
@@ -67,13 +67,12 @@ them before continuing.
 
 ## Analytics
 
-`ballin-scripts` can send minimal anonymous command analytics after showing an
-install/update notice. Setup creates a local anonymous install ID, but it does
-not send analytics during install. Later command analytics include that install
-ID so the backend can count active installs; the backend hashes it before
-storage. Analytics never include command arguments, local paths, usernames, Gist
-IDs, dotfile contents, package lists, editor settings, raw errors, environment
-variables, arbitrary config values, or the local install ID file.
+After showing an install/update notice, `ballin-scripts` can send minimal
+anonymous command analytics. Setup creates a local anonymous install ID without
+sending an event; later command events include that ID so the backend can count
+active installs and hash it before storage. Events never include arguments,
+paths, usernames, Gist IDs, dotfiles, package lists, raw errors, environment
+values, arbitrary config values, or the local install ID file.
 
 Disable analytics persistently:
 

--- a/docs/optional-capabilities.md
+++ b/docs/optional-capabilities.md
@@ -67,8 +67,8 @@ them before continuing.
 
 ## Analytics
 
-After an install/update notice, `ballin-scripts` can send anonymous command
-analytics to help understand which tools are used and whether they succeed.
+`ballin-scripts` can send anonymous command analytics to help understand which
+tools are used and whether they succeed.
 
 Disable analytics persistently:
 

--- a/docs/optional-capabilities.md
+++ b/docs/optional-capabilities.md
@@ -67,26 +67,17 @@ them before continuing.
 
 ## Analytics
 
-After showing an install/update notice, `ballin-scripts` can send minimal
-anonymous command analytics. Setup creates a local anonymous install ID without
-sending an event; later command events include that ID so the backend can count
-active installs and hash it before storage. Events never include arguments,
-paths, usernames, Gist IDs, dotfiles, package lists, raw errors, environment
-values, arbitrary config values, or the local install ID file.
+`ballin-scripts` can send minimal anonymous command analytics after showing an
+install/update notice. Setup creates a local anonymous install ID, but does not
+send an event. Analytics do not include command arguments, paths, usernames,
+Gist IDs, dotfiles, package lists, raw errors, environment values, arbitrary
+config values, or the local install ID file.
 
 Disable analytics persistently:
 
 ```shell
 ballin_config set analytics.enabled false
 ```
-
-Disable analytics for one environment:
-
-```shell
-BALLIN_NO_ANALYTICS=1
-```
-
-Analytics are also disabled automatically in CI.
 
 ## `up` settings
 

--- a/docs/optional-capabilities.md
+++ b/docs/optional-capabilities.md
@@ -59,10 +59,11 @@ the installed-app list in your backup. No configuration setting is required.
 ## Analytics
 
 `ballin-scripts` can send minimal anonymous command analytics after showing an
-install/update notice. Analytics never include command arguments, local paths,
-usernames, Gist IDs, dotfile contents, package lists, editor settings, raw
-errors, environment variables, arbitrary config values, or the local install ID
-file.
+install/update notice. Setup creates a local anonymous install ID, but it does
+not send analytics during install. Analytics never include command arguments,
+local paths, usernames, Gist IDs, dotfile contents, package lists, editor
+settings, raw errors, environment variables, arbitrary config values, or the
+local install ID file.
 
 Disable analytics persistently:
 

--- a/docs/optional-capabilities.md
+++ b/docs/optional-capabilities.md
@@ -56,6 +56,27 @@ brew install mas
 When `mas` is available, `up` updates installed App Store apps and `gu` includes
 the installed-app list in your backup. No configuration setting is required.
 
+## Analytics
+
+`ballin-scripts` can send minimal anonymous command analytics after showing a
+first-run notice. Analytics never include command arguments, local paths,
+usernames, Gist IDs, dotfile contents, package lists, editor settings, raw
+errors, environment variables, or arbitrary config values.
+
+Disable analytics persistently:
+
+```shell
+ballin_config set analytics.enabled false
+```
+
+Disable analytics for one environment:
+
+```shell
+BALLIN_NO_ANALYTICS=1
+```
+
+Analytics are also disabled automatically in CI.
+
 ## `up` settings
 
 Change a setting with `ballin_config set up.<name> true` or

--- a/docs/optional-capabilities.md
+++ b/docs/optional-capabilities.md
@@ -68,8 +68,7 @@ them before continuing.
 ## Analytics
 
 After an install/update notice, `ballin-scripts` can send anonymous command
-analytics: command name, status, coarse duration, version/platform, date, and an
-anonymous install ID that is hashed before storage.
+analytics to help understand which tools are used and whether they succeed.
 
 Disable analytics persistently:
 

--- a/docs/optional-capabilities.md
+++ b/docs/optional-capabilities.md
@@ -58,10 +58,11 @@ the installed-app list in your backup. No configuration setting is required.
 
 ## Analytics
 
-`ballin-scripts` can send minimal anonymous command analytics after showing a
-first-run notice. Analytics never include command arguments, local paths,
+`ballin-scripts` can send minimal anonymous command analytics after showing an
+install/update notice. Analytics never include command arguments, local paths,
 usernames, Gist IDs, dotfile contents, package lists, editor settings, raw
-errors, environment variables, or arbitrary config values.
+errors, environment variables, arbitrary config values, or the local install ID
+file.
 
 Disable analytics persistently:
 

--- a/docs/optional-capabilities.md
+++ b/docs/optional-capabilities.md
@@ -67,10 +67,9 @@ them before continuing.
 
 ## Analytics
 
-`ballin-scripts` can send minimal anonymous command analytics after showing an
-install/update notice. Events include the command name, status, coarse duration,
-app and system versions, date, and an anonymous install ID that is hashed before
-storage.
+After an install/update notice, `ballin-scripts` can send anonymous command
+analytics: command name, status, coarse duration, version/platform, date, and an
+anonymous install ID that is hashed before storage.
 
 Disable analytics persistently:
 

--- a/docs/optional-capabilities.md
+++ b/docs/optional-capabilities.md
@@ -68,10 +68,9 @@ them before continuing.
 ## Analytics
 
 `ballin-scripts` can send minimal anonymous command analytics after showing an
-install/update notice. Setup creates a local anonymous install ID, but does not
-send an event. Analytics do not include command arguments, paths, usernames,
-Gist IDs, dotfiles, package lists, raw errors, environment values, arbitrary
-config values, or the local install ID file.
+install/update notice. Events include the command name, status, coarse duration,
+app and system versions, date, and an anonymous install ID that is hashed before
+storage.
 
 Disable analytics persistently:
 

--- a/docs/optional-capabilities.md
+++ b/docs/optional-capabilities.md
@@ -67,8 +67,7 @@ them before continuing.
 
 ## Analytics
 
-`ballin-scripts` can send anonymous command analytics to help understand which
-tools are used and whether they succeed.
+`ballin-scripts` can send anonymous usage analytics.
 
 Disable analytics persistently:
 

--- a/install.sh
+++ b/install.sh
@@ -231,6 +231,11 @@ done
     exit 1
   fi
 
+  ############################## ANALYTICS SETUP ###############################
+  if [ -f "$repo_dir/commands/install_setup.ts" ]; then
+    node "$repo_dir/commands/install_setup.ts" setup-analytics "$repo_dir" || :
+  fi
+
   ############################## SYMLINK BINARIES ##############################
   if [ -f "$repo_dir/commands/install_setup.ts" ]; then
     if ! node "$repo_dir/commands/install_setup.ts" symlink-binaries "$repo_dir" "$bin_dir"; then

--- a/test/analytics.test.ts
+++ b/test/analytics.test.ts
@@ -10,6 +10,7 @@ const {
 
 import type { ClientRequest, IncomingMessage } from 'http';
 import type { RequestOptions } from 'https';
+import type { Socket } from 'net';
 
 type AnalyticsPayload = {
   schemaVersion: 1;
@@ -286,7 +287,7 @@ describe('analytics client', () => {
     let timeoutMs = 0;
     const timeoutHandler: { current?: () => void } = {};
     let destroyed = false;
-    let unrefCalled = false;
+    let socketUnrefCalled = false;
 
     https.request = (options: RequestOptions, callback: (response: IncomingMessage) => void): ClientRequest => {
       capturedOptions = options;
@@ -295,7 +296,6 @@ describe('analytics client', () => {
       callback(response);
 
       const request = new EventEmitter() as ClientRequest;
-      const requestWithUnref = request as ClientRequest & { unref: () => ClientRequest };
       request.setTimeout = (milliseconds: number, handler?: () => void) => {
         timeoutMs = milliseconds;
         timeoutHandler.current = handler;
@@ -303,14 +303,17 @@ describe('analytics client', () => {
       };
       request.end = ((body?: unknown) => {
         capturedBody = typeof body === 'string' || Buffer.isBuffer(body) ? body.toString() : '';
+        const socket = {
+          unref: () => {
+            socketUnrefCalled = true;
+            return socket;
+          },
+        } as Socket;
+        request.emit('socket', socket);
         return request;
       }) as ClientRequest['end'];
       request.destroy = () => {
         destroyed = true;
-        return request;
-      };
-      requestWithUnref.unref = () => {
-        unrefCalled = true;
         return request;
       };
       return request;
@@ -342,7 +345,7 @@ describe('analytics client', () => {
 
     assert.equal(timeoutMs, 25);
     assert.isTrue(destroyed);
-    assert.isTrue(unrefCalled);
+    assert.isTrue(socketUnrefCalled);
     assert.include(capturedBody, '"command":"up"');
     assert.isNotNull(capturedOptions);
     const options = capturedOptions as unknown as RequestOptions;

--- a/test/analytics.test.ts
+++ b/test/analytics.test.ts
@@ -4,7 +4,6 @@ const https = require('https');
 const { fetchConfig, configPath, stringify } = require('../config/index.ts');
 const {
   analyticsDisabledByEnv,
-  analyticsNotice,
   recordAnalyticsEvent,
   sendAnalyticsPayload,
 } = require('../commands/analytics.ts');
@@ -26,8 +25,9 @@ type AnalyticsPayload = {
 };
 
 const fs = require('fs');
+const os = require('os');
+const path = require('path');
 const fixedInstallId = '826f9faa-9995-4f66-a01b-73b4f7aebdf1';
-const otherInstallId = '11111111-1111-4111-8111-111111111111';
 const fixedNow = new Date('2026-06-27T20:15:00.000Z');
 const allowedPayloadKeys = [
   'schemaVersion',
@@ -43,6 +43,7 @@ const allowedPayloadKeys = [
 ];
 
 const fetchConfigJSON = () => fetchConfig().configJSON;
+let testInstallIdPath = '';
 
 const writeConfig = (configObj: Record<string, unknown>): void => {
   fs.writeFileSync(configPath, stringify(configObj), 'utf8');
@@ -52,6 +53,11 @@ const setAnalyticsConfig = (analytics: Record<string, unknown>): void => {
   const { configObj } = fetchConfig();
   configObj.analytics = analytics;
   writeConfig(configObj);
+};
+
+const writeInstallId = (installId = fixedInstallId): void => {
+  fs.mkdirSync(path.dirname(testInstallIdPath), { recursive: true });
+  fs.writeFileSync(testInstallIdPath, `${installId}\n`, 'utf8');
 };
 
 const recordWithSender = (
@@ -66,7 +72,7 @@ const recordWithSender = (
     endpoint: 'https://analytics.example.test/v1/events',
     ingestToken: 'test-token',
     env: {},
-    generateInstallId: () => fixedInstallId,
+    installIdPath: testInstallIdPath,
     sender: (payload: AnalyticsPayload) => {
       order.push('send');
       payloads.push(payload);
@@ -83,13 +89,17 @@ const recordWithSender = (
 
 describe('analytics client', () => {
   let savedConfig: string;
+  let tempDir: string;
 
   beforeEach(() => {
     savedConfig = fetchConfigJSON();
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ballin-analytics-'));
+    testInstallIdPath = path.join(tempDir, '.analytics', 'install-id');
   });
 
   afterEach(() => {
     fs.writeFileSync(configPath, savedConfig, 'utf8');
+    fs.rmSync(tempDir, { recursive: true, force: true });
   });
 
   it('treats BALLIN_NO_ANALYTICS and CI as hard opt-outs', () => {
@@ -101,14 +111,13 @@ describe('analytics client', () => {
   it('does not send when analytics are disabled in config', () => {
     setAnalyticsConfig({
       enabled: 'false',
-      noticeShown: 'true',
-      installId: fixedInstallId,
     });
+    writeInstallId();
 
     const { payloads, notices } = recordWithSender({
       command: 'up',
       now: fixedNow,
-    }, { isInteractive: true });
+    });
 
     assert.deepEqual(payloads, []);
     assert.deepEqual(notices, []);
@@ -123,9 +132,8 @@ describe('analytics client', () => {
     optOuts.forEach((env) => {
       setAnalyticsConfig({
         enabled: 'true',
-        noticeShown: 'true',
-        installId: fixedInstallId,
       });
+      writeInstallId();
 
       const { payloads } = recordWithSender({
         command: 'up',
@@ -136,78 +144,55 @@ describe('analytics client', () => {
     });
   });
 
-  it('gates the first send on an interactive notice and then persists the install ID', () => {
+  it('reads the local install ID and includes it in the payload', () => {
     setAnalyticsConfig({
       enabled: 'true',
-      noticeShown: 'false',
-      installId: null,
     });
+    writeInstallId();
 
     const { payloads, notices, order } = recordWithSender({
       command: 'up',
       status: 'success',
       durationBucket: '<1s',
       now: fixedNow,
-    }, { isInteractive: true });
+    });
     const updatedAnalytics = fetchConfig().configObj.analytics;
 
-    assert.deepEqual(order, ['notice', 'send']);
-    assert.equal(notices[0], analyticsNotice);
+    assert.deepEqual(order, ['send']);
+    assert.deepEqual(notices, []);
     assert.lengthOf(payloads, 1);
     assert.equal(payloads[0].installId, fixedInstallId);
-    assert.deepInclude(updatedAnalytics, {
+    assert.deepEqual(updatedAnalytics, {
       enabled: 'true',
-      noticeShown: 'true',
-      installId: fixedInstallId,
     });
   });
 
-  it('does not generate an install ID or send before the first interactive notice', () => {
+  it('skips sending when the local install ID is missing', () => {
     setAnalyticsConfig({
       enabled: 'true',
-      noticeShown: 'false',
-      installId: null,
     });
 
     const { payloads, notices } = recordWithSender({
       command: 'up',
       now: fixedNow,
-    }, { isInteractive: false });
+    });
 
     assert.deepEqual(payloads, []);
     assert.deepEqual(notices, []);
-    assert.isNull((fetchConfig().configObj.analytics as { installId: string | null }).installId);
-  });
-
-  it('can send after the first-run notice has already been shown', () => {
-    setAnalyticsConfig({
-      enabled: 'true',
-      noticeShown: 'true',
-      installId: otherInstallId,
-    });
-
-    const { payloads, notices } = recordWithSender({
-      command: 'gu',
-      now: fixedNow,
-    }, { isInteractive: false });
-
-    assert.deepEqual(notices, []);
-    assert.lengthOf(payloads, 1);
-    assert.equal(payloads[0].installId, otherInstallId);
   });
 
   it('never throws when analytics config or sender behavior fails', () => {
     setAnalyticsConfig({
       enabled: 'true',
-      noticeShown: 'true',
-      installId: fixedInstallId,
     });
+    writeInstallId();
 
     assert.doesNotThrow(() => {
       recordAnalyticsEvent({
         command: 'up',
         now: fixedNow,
       }, {
+        installIdPath: testInstallIdPath,
         sender: () => {
           throw new Error('network unavailable');
         },
@@ -218,9 +203,8 @@ describe('analytics client', () => {
   it('sends only the allowlisted payload fields', () => {
     setAnalyticsConfig({
       enabled: 'true',
-      noticeShown: 'true',
-      installId: fixedInstallId,
     });
+    writeInstallId();
 
     const { payloads } = recordWithSender({
       command: 'ballin_config',
@@ -251,9 +235,8 @@ describe('analytics client', () => {
   it('skips unsupported commands and invalid enum values', () => {
     setAnalyticsConfig({
       enabled: 'true',
-      noticeShown: 'true',
-      installId: fixedInstallId,
     });
+    writeInstallId();
 
     const unsupportedCommand = recordWithSender({
       command: 'git',

--- a/test/analytics.test.ts
+++ b/test/analytics.test.ts
@@ -65,6 +65,7 @@ const recordWithSender = (
   recordAnalyticsEvent(input, {
     endpoint: 'https://analytics.example.test/v1/events',
     ingestToken: 'test-token',
+    env: {},
     generateInstallId: () => fixedInstallId,
     sender: (payload: AnalyticsPayload) => {
       order.push('send');

--- a/test/analytics.test.ts
+++ b/test/analytics.test.ts
@@ -60,6 +60,11 @@ const writeInstallId = (installId = fixedInstallId): void => {
   fs.writeFileSync(testInstallIdPath, `${installId}\n`, 'utf8');
 };
 
+const writeRawInstallId = (installId: string): void => {
+  fs.mkdirSync(path.dirname(testInstallIdPath), { recursive: true });
+  fs.writeFileSync(testInstallIdPath, installId, 'utf8');
+};
+
 const recordWithSender = (
   input: Record<string, unknown>,
   runtime: Record<string, unknown> = {},
@@ -179,6 +184,22 @@ describe('analytics client', () => {
 
     assert.deepEqual(payloads, []);
     assert.deepEqual(notices, []);
+  });
+
+  it('skips sending and does not rewrite an invalid local install ID', () => {
+    setAnalyticsConfig({
+      enabled: 'true',
+    });
+    writeRawInstallId('not-a-uuid\n');
+
+    const { payloads, notices } = recordWithSender({
+      command: 'up',
+      now: fixedNow,
+    });
+
+    assert.deepEqual(payloads, []);
+    assert.deepEqual(notices, []);
+    assert.equal(fs.readFileSync(testInstallIdPath, 'utf8'), 'not-a-uuid\n');
   });
 
   it('never throws when analytics config or sender behavior fails', () => {

--- a/test/analytics.test.ts
+++ b/test/analytics.test.ts
@@ -1,0 +1,355 @@
+const { assert } = require('chai');
+const { EventEmitter } = require('events');
+const https = require('https');
+const { fetchConfig, configPath, stringify } = require('../config/index.ts');
+const {
+  analyticsDisabledByEnv,
+  analyticsNotice,
+  recordAnalyticsEvent,
+  sendAnalyticsPayload,
+} = require('../commands/analytics.ts');
+
+import type { ClientRequest, IncomingMessage } from 'http';
+import type { RequestOptions } from 'https';
+
+type AnalyticsPayload = {
+  schemaVersion: 1;
+  installId: string;
+  dateBucket: string;
+  command: string;
+  status: string;
+  durationBucket: string;
+  appVersion: string;
+  nodeMajor: string;
+  os: string;
+  osVersion: string;
+};
+
+const fs = require('fs');
+const fixedInstallId = '826f9faa-9995-4f66-a01b-73b4f7aebdf1';
+const otherInstallId = '11111111-1111-4111-8111-111111111111';
+const fixedNow = new Date('2026-06-27T20:15:00.000Z');
+const allowedPayloadKeys = [
+  'schemaVersion',
+  'installId',
+  'dateBucket',
+  'command',
+  'status',
+  'durationBucket',
+  'appVersion',
+  'nodeMajor',
+  'os',
+  'osVersion',
+];
+
+const fetchConfigJSON = () => fetchConfig().configJSON;
+
+const writeConfig = (configObj: Record<string, unknown>): void => {
+  fs.writeFileSync(configPath, stringify(configObj), 'utf8');
+};
+
+const setAnalyticsConfig = (analytics: Record<string, unknown>): void => {
+  const { configObj } = fetchConfig();
+  configObj.analytics = analytics;
+  writeConfig(configObj);
+};
+
+const recordWithSender = (
+  input: Record<string, unknown>,
+  runtime: Record<string, unknown> = {},
+): { payloads: AnalyticsPayload[]; notices: string[]; order: string[] } => {
+  const payloads: AnalyticsPayload[] = [];
+  const notices: string[] = [];
+  const order: string[] = [];
+
+  recordAnalyticsEvent(input, {
+    endpoint: 'https://analytics.example.test/v1/events',
+    ingestToken: 'test-token',
+    generateInstallId: () => fixedInstallId,
+    sender: (payload: AnalyticsPayload) => {
+      order.push('send');
+      payloads.push(payload);
+    },
+    noticeWriter: (message: string) => {
+      order.push('notice');
+      notices.push(message);
+    },
+    ...runtime,
+  });
+
+  return { payloads, notices, order };
+};
+
+describe('analytics client', () => {
+  let savedConfig: string;
+
+  beforeEach(() => {
+    savedConfig = fetchConfigJSON();
+  });
+
+  afterEach(() => {
+    fs.writeFileSync(configPath, savedConfig, 'utf8');
+  });
+
+  it('treats BALLIN_NO_ANALYTICS and CI as hard opt-outs', () => {
+    assert.isTrue(analyticsDisabledByEnv({ BALLIN_NO_ANALYTICS: '1' }));
+    assert.isTrue(analyticsDisabledByEnv({ CI: 'true' }));
+    assert.isFalse(analyticsDisabledByEnv({ BALLIN_NO_ANALYTICS: '0' }));
+  });
+
+  it('does not send when analytics are disabled in config', () => {
+    setAnalyticsConfig({
+      enabled: 'false',
+      noticeShown: 'true',
+      installId: fixedInstallId,
+    });
+
+    const { payloads, notices } = recordWithSender({
+      command: 'up',
+      now: fixedNow,
+    }, { isInteractive: true });
+
+    assert.deepEqual(payloads, []);
+    assert.deepEqual(notices, []);
+  });
+
+  it('does not send when environment opt-outs are set', () => {
+    const optOuts = [
+      { BALLIN_NO_ANALYTICS: '1' },
+      { CI: 'true' },
+    ];
+
+    optOuts.forEach((env) => {
+      setAnalyticsConfig({
+        enabled: 'true',
+        noticeShown: 'true',
+        installId: fixedInstallId,
+      });
+
+      const { payloads } = recordWithSender({
+        command: 'up',
+        now: fixedNow,
+      }, { env });
+
+      assert.deepEqual(payloads, []);
+    });
+  });
+
+  it('gates the first send on an interactive notice and then persists the install ID', () => {
+    setAnalyticsConfig({
+      enabled: 'true',
+      noticeShown: 'false',
+      installId: null,
+    });
+
+    const { payloads, notices, order } = recordWithSender({
+      command: 'up',
+      status: 'success',
+      durationBucket: '<1s',
+      now: fixedNow,
+    }, { isInteractive: true });
+    const updatedAnalytics = fetchConfig().configObj.analytics;
+
+    assert.deepEqual(order, ['notice', 'send']);
+    assert.equal(notices[0], analyticsNotice);
+    assert.lengthOf(payloads, 1);
+    assert.equal(payloads[0].installId, fixedInstallId);
+    assert.deepInclude(updatedAnalytics, {
+      enabled: 'true',
+      noticeShown: 'true',
+      installId: fixedInstallId,
+    });
+  });
+
+  it('does not generate an install ID or send before the first interactive notice', () => {
+    setAnalyticsConfig({
+      enabled: 'true',
+      noticeShown: 'false',
+      installId: null,
+    });
+
+    const { payloads, notices } = recordWithSender({
+      command: 'up',
+      now: fixedNow,
+    }, { isInteractive: false });
+
+    assert.deepEqual(payloads, []);
+    assert.deepEqual(notices, []);
+    assert.isNull((fetchConfig().configObj.analytics as { installId: string | null }).installId);
+  });
+
+  it('can send after the first-run notice has already been shown', () => {
+    setAnalyticsConfig({
+      enabled: 'true',
+      noticeShown: 'true',
+      installId: otherInstallId,
+    });
+
+    const { payloads, notices } = recordWithSender({
+      command: 'gu',
+      now: fixedNow,
+    }, { isInteractive: false });
+
+    assert.deepEqual(notices, []);
+    assert.lengthOf(payloads, 1);
+    assert.equal(payloads[0].installId, otherInstallId);
+  });
+
+  it('never throws when analytics config or sender behavior fails', () => {
+    setAnalyticsConfig({
+      enabled: 'true',
+      noticeShown: 'true',
+      installId: fixedInstallId,
+    });
+
+    assert.doesNotThrow(() => {
+      recordAnalyticsEvent({
+        command: 'up',
+        now: fixedNow,
+      }, {
+        sender: () => {
+          throw new Error('network unavailable');
+        },
+      });
+    });
+  });
+
+  it('sends only the allowlisted payload fields', () => {
+    setAnalyticsConfig({
+      enabled: 'true',
+      noticeShown: 'true',
+      installId: fixedInstallId,
+    });
+
+    const { payloads } = recordWithSender({
+      command: 'ballin_config',
+      status: 'failure',
+      durationBucket: '1-10s',
+      args: ['get', 'gu.id'],
+      path: '/Users/example',
+      rawError: 'secret',
+      now: fixedNow,
+    });
+    const payload = payloads[0];
+
+    assert.sameMembers(Object.keys(payload), allowedPayloadKeys);
+    assert.deepInclude(payload, {
+      schemaVersion: 1,
+      installId: fixedInstallId,
+      dateBucket: '2026-06-27',
+      command: 'ballin_config',
+      status: 'failure',
+      durationBucket: '1-10s',
+    });
+    assert.match(payload.appVersion, /^[0-9]+(?:\.[0-9]+){0,2}$/);
+    assert.match(payload.nodeMajor, /^[0-9]+$/);
+    assert.include(['darwin', 'linux', 'win32', 'unknown'], payload.os);
+    assert.match(payload.osVersion, /^[0-9]+(?:\.[0-9]+)?$|^unknown$/);
+  });
+
+  it('skips unsupported commands and invalid enum values', () => {
+    setAnalyticsConfig({
+      enabled: 'true',
+      noticeShown: 'true',
+      installId: fixedInstallId,
+    });
+
+    const unsupportedCommand = recordWithSender({
+      command: 'git',
+      now: fixedNow,
+    });
+    const unsupportedStatus = recordWithSender({
+      command: 'up',
+      status: 'maybe',
+      now: fixedNow,
+    });
+    const unsupportedDuration = recordWithSender({
+      command: 'up',
+      durationBucket: '42s',
+      now: fixedNow,
+    });
+
+    assert.deepEqual(unsupportedCommand.payloads, []);
+    assert.deepEqual(unsupportedStatus.payloads, []);
+    assert.deepEqual(unsupportedDuration.payloads, []);
+  });
+
+  it('sends through https with a short timeout and swallows request failures', () => {
+    const originalRequest = https.request;
+    let capturedOptions: RequestOptions | null = null;
+    let capturedBody = '';
+    let timeoutMs = 0;
+    const timeoutHandler: { current?: () => void } = {};
+    let destroyed = false;
+    let unrefCalled = false;
+
+    https.request = (options: RequestOptions, callback: (response: IncomingMessage) => void): ClientRequest => {
+      capturedOptions = options;
+      const response = new EventEmitter() as IncomingMessage;
+      response.resume = () => response;
+      callback(response);
+
+      const request = new EventEmitter() as ClientRequest;
+      const requestWithUnref = request as ClientRequest & { unref: () => ClientRequest };
+      request.setTimeout = (milliseconds: number, handler?: () => void) => {
+        timeoutMs = milliseconds;
+        timeoutHandler.current = handler;
+        return request;
+      };
+      request.end = ((body?: unknown) => {
+        capturedBody = typeof body === 'string' || Buffer.isBuffer(body) ? body.toString() : '';
+        return request;
+      }) as ClientRequest['end'];
+      request.destroy = () => {
+        destroyed = true;
+        return request;
+      };
+      requestWithUnref.unref = () => {
+        unrefCalled = true;
+        return request;
+      };
+      return request;
+    };
+
+    try {
+      sendAnalyticsPayload({
+        schemaVersion: 1,
+        installId: fixedInstallId,
+        dateBucket: '2026-06-27',
+        command: 'up',
+        status: 'success',
+        durationBucket: '<1s',
+        appVersion: '1.0.0',
+        nodeMajor: '24',
+        os: 'darwin',
+        osVersion: '15',
+      }, {
+        endpoint: 'https://analytics.example.test/v1/events',
+        ingestToken: 'test-token',
+        timeoutMs: 25,
+      });
+      if (timeoutHandler.current) {
+        timeoutHandler.current();
+      }
+    } finally {
+      https.request = originalRequest;
+    }
+
+    assert.equal(timeoutMs, 25);
+    assert.isTrue(destroyed);
+    assert.isTrue(unrefCalled);
+    assert.include(capturedBody, '"command":"up"');
+    assert.isNotNull(capturedOptions);
+    const options = capturedOptions as unknown as RequestOptions;
+    assert.deepInclude(options, {
+      method: 'POST',
+      protocol: 'https:',
+      hostname: 'analytics.example.test',
+      path: '/v1/events',
+    });
+    assert.deepInclude(options.headers, {
+      'content-type': 'application/json',
+      'x-ballin-analytics-token': 'test-token',
+    });
+  });
+});

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -303,5 +303,26 @@ describe('config', () => {
       assert.equal(result.status, 0);
       assert.deepEqual(fetchConfig().configObj, defaultConfig);
     });
+
+    it('adds missing nested analytics defaults without overwriting existing choices', () => {
+      fs.writeFileSync(configPath, JSON.stringify({
+        analytics: {
+          enabled: 'false',
+        },
+      }), 'utf8');
+
+      const result = spawnSync(process.execPath, [path.join(__dirname, '..', 'config', 'updateConfig.ts')], {
+        cwd: path.join(__dirname, '..'),
+        encoding: 'utf8',
+        env: process.env,
+      });
+
+      assert.equal(result.status, 0);
+      assert.deepEqual(fetchConfig().configObj.analytics, {
+        enabled: 'false',
+        noticeShown: 'false',
+        installId: null,
+      });
+    });
   });
 });

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -320,8 +320,6 @@ describe('config', () => {
       assert.equal(result.status, 0);
       assert.deepEqual(fetchConfig().configObj.analytics, {
         enabled: 'false',
-        noticeShown: 'false',
-        installId: null,
       });
     });
   });

--- a/test/install.test.ts
+++ b/test/install.test.ts
@@ -58,6 +58,20 @@ if [ "$1" = "$HOME/.ballin-scripts/commands/install_setup.ts" ]; then
     fi
     exit "$FAKE_NODE_STATUS"
   fi
+  if [ "$1" = 'setup-analytics' ]; then
+    repo_dir="$2"
+    config_json=$(<"$repo_dir/ballin.config.json")
+    case "$config_json" in
+      *'"enabled":"false"'*) exit 0 ;;
+    esac
+    if [ "$BALLIN_NO_ANALYTICS" = '1' ] || [ -n "$CI" ]; then
+      exit 0
+    fi
+    mkdir -p "$repo_dir/.analytics"
+    printf '%s\\n' '826f9faa-9995-4f66-a01b-73b4f7aebdf1' > "$repo_dir/.analytics/install-id"
+    printf '%s\\n' 'ballin-scripts collects minimal anonymous command analytics.'
+    exit 0
+  fi
   if [ "$1" != 'symlink-binaries' ]; then
     exit 2
   fi
@@ -344,7 +358,7 @@ case "$1:$2" in
   -l:) exit 0 ;;
   -r:returning-gist-id)
     if [ "$3" = 'ballin_config' ]; then
-      printf '%s\\n' '{"up":{"cleanup":"false","ballin":"true","gu":"true","softwareupdate":"false","npm":"true","nvm":"true"},"gu":{"id":"previous-gist-id","token_file":".config/ballin/restored-gist","url":"https://old-gist.example.test"}}'
+      printf '%s\\n' '{"up":{"cleanup":"false","ballin":"true","gu":"true","softwareupdate":"false","npm":"true","nvm":"true"},"gu":{"id":"previous-gist-id","token_file":".config/ballin/restored-gist","url":"https://old-gist.example.test"},"analytics":{"enabled":"false"}}'
       exit 0
     fi
     printf '%s\\n' '### Backup of your dev environment'
@@ -367,6 +381,8 @@ esac
     assert.equal(restoredConfig.gu.id, 'returning-gist-id');
     assert.equal(restoredConfig.gu.token_file, '.config/ballin/restored-gist');
     assert.equal(restoredConfig.gu.url, 'https://old-gist.example.test');
+    assert.equal(restoredConfig.analytics.enabled, 'false');
+    assert.isFalse(fs.existsSync(path.join(repoDir, '.analytics', 'install-id')));
     assert.equal(fs.readFileSync(path.join(homeDir, '.config', 'ballin', 'restored-gist'), 'utf8'), 'token\n');
   });
 

--- a/test/install_setup.test.ts
+++ b/test/install_setup.test.ts
@@ -8,6 +8,7 @@ const {
 } = require('../commands/analytics.ts');
 const {
   configure,
+  setupAnalytics,
   symlinkBinaries,
 } = require('../commands/install_setup.ts');
 
@@ -138,14 +139,14 @@ describe('install setup', () => {
     );
   });
 
-  it('shows the analytics notice and creates a local install ID on first config creation', () => {
+  it('does not create a local install ID while creating config', () => {
     installConfigSources();
 
     const { output, result } = withoutAnalyticsOptOutEnv(() => captureStdout(() => configure(repoDir, docsUrl)));
 
     assert.isTrue(result);
-    assert.include(output, analyticsNotice);
-    assert.match(readInstallId(), /^[0-9a-f-]{36}\n$/);
+    assert.notInclude(output, analyticsNotice);
+    assert.isFalse(fs.existsSync(installIdPath()));
   });
 
   it('runs config creation through the setup CLI', () => {
@@ -178,7 +179,7 @@ describe('install setup', () => {
     );
   });
 
-  it('shows the analytics notice and creates a local install ID for existing enabled config', () => {
+  it('shows the analytics notice and creates a local install ID for enabled config', () => {
     installConfigSources();
     fs.writeFileSync(path.join(repoDir, 'ballin.config.json'), JSON.stringify({
       analytics: {
@@ -186,7 +187,7 @@ describe('install setup', () => {
       },
     }));
 
-    const { output, result } = withoutAnalyticsOptOutEnv(() => captureStdout(() => configure(repoDir, docsUrl)));
+    const { output, result } = withoutAnalyticsOptOutEnv(() => captureStdout(() => setupAnalytics(repoDir)));
 
     assert.isTrue(result);
     assert.include(output, analyticsNotice);
@@ -203,7 +204,7 @@ describe('install setup', () => {
     fs.mkdirSync(path.dirname(installIdPath()), { recursive: true });
     fs.writeFileSync(installIdPath(), `${fixedInstallId}\n`, 'utf8');
 
-    const { output, result } = withoutAnalyticsOptOutEnv(() => captureStdout(() => configure(repoDir, docsUrl)));
+    const { output, result } = withoutAnalyticsOptOutEnv(() => captureStdout(() => setupAnalytics(repoDir)));
 
     assert.isTrue(result);
     assert.notInclude(output, analyticsNotice);
@@ -218,7 +219,7 @@ describe('install setup', () => {
       },
     }));
 
-    const { output, result } = withoutAnalyticsOptOutEnv(() => captureStdout(() => configure(repoDir, docsUrl)));
+    const { output, result } = withoutAnalyticsOptOutEnv(() => captureStdout(() => setupAnalytics(repoDir)));
 
     assert.isTrue(result);
     assert.notInclude(output, analyticsNotice);
@@ -238,7 +239,7 @@ describe('install setup', () => {
         },
       }));
 
-      const { output, result } = withEnv(env, () => captureStdout(() => configure(repoDir, docsUrl)));
+      const { output, result } = withEnv(env, () => captureStdout(() => setupAnalytics(repoDir)));
 
       assert.isTrue(result);
       assert.notInclude(output, analyticsNotice);
@@ -256,7 +257,7 @@ describe('install setup', () => {
     fs.mkdirSync(path.dirname(installIdPath()), { recursive: true });
     fs.writeFileSync(installIdPath(), 'not-a-uuid\n', 'utf8');
 
-    const { output, result } = withoutAnalyticsOptOutEnv(() => captureStdout(() => configure(repoDir, docsUrl)));
+    const { output, result } = withoutAnalyticsOptOutEnv(() => captureStdout(() => setupAnalytics(repoDir)));
 
     assert.isTrue(result);
     assert.include(output, analyticsNotice);
@@ -278,6 +279,31 @@ describe('install setup', () => {
     assert.include(result.stdout, `symlinked binaries into ${binDir}`);
     assert.isTrue(fs.lstatSync(path.join(binDir, 'ballin')).isSymbolicLink());
     assert.equal(fs.readlinkSync(path.join(binDir, 'ballin')), path.join(sourceBinDir, 'ballin'));
+  });
+
+  it('runs analytics setup through the setup CLI', () => {
+    installConfigSources();
+    fs.writeFileSync(path.join(repoDir, 'ballin.config.json'), JSON.stringify({
+      analytics: {
+        enabled: 'true',
+      },
+    }));
+    const childEnv = { ...process.env };
+    delete childEnv.CI;
+    delete childEnv.BALLIN_NO_ANALYTICS;
+
+    const result = spawnSync(process.execPath, [
+      installSetupPath,
+      'setup-analytics',
+      repoDir,
+    ], {
+      encoding: 'utf8',
+      env: childEnv,
+    });
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.include(result.stdout, analyticsNotice);
+    assert.match(readInstallId(), /^[0-9a-f-]{36}\n$/);
   });
 
   it('replaces existing command symlinks', () => {

--- a/test/install_setup.test.ts
+++ b/test/install_setup.test.ts
@@ -4,6 +4,9 @@ const fs = require('fs');
 const os = require('os');
 const path = require('path');
 const {
+  analyticsNotice,
+} = require('../commands/analytics.ts');
+const {
   configure,
   symlinkBinaries,
 } = require('../commands/install_setup.ts');
@@ -17,6 +20,7 @@ describe('install setup', () => {
   let sourceBinDir: string;
   let binDir: string;
   const docsUrl = 'https://example.test/docs';
+  const fixedInstallId = '826f9faa-9995-4f66-a01b-73b4f7aebdf1';
 
   const withoutStdout = (action: () => boolean): boolean => {
     const originalWrite = process.stdout.write;
@@ -27,6 +31,25 @@ describe('install setup', () => {
       process.stdout.write = originalWrite;
     }
   };
+
+  const captureStdout = (action: () => boolean): { output: string; result: boolean } => {
+    const originalWrite = process.stdout.write;
+    let output = '';
+    process.stdout.write = ((chunk: string) => {
+      output += chunk;
+      return true;
+    }) as typeof process.stdout.write;
+    try {
+      const result = action();
+      return { output, result };
+    } finally {
+      process.stdout.write = originalWrite;
+    }
+  };
+
+  const installIdPath = () => path.join(repoDir, '.analytics', 'install-id');
+
+  const readInstallId = () => fs.readFileSync(installIdPath(), 'utf8');
 
   const installConfigSources = () => {
     fs.mkdirSync(path.join(repoDir, 'config'), { recursive: true });
@@ -75,6 +98,16 @@ describe('install setup', () => {
     );
   });
 
+  it('shows the analytics notice and creates a local install ID on first config creation', () => {
+    installConfigSources();
+
+    const { output, result } = captureStdout(() => configure(repoDir, docsUrl));
+
+    assert.isTrue(result);
+    assert.include(output, analyticsNotice);
+    assert.match(readInstallId(), /^[0-9a-f-]{36}\n$/);
+  });
+
   it('runs config creation through the setup CLI', () => {
     installConfigSources();
 
@@ -103,6 +136,53 @@ describe('install setup', () => {
       fs.readFileSync(path.join(repoDir, 'ballin.config.json'), 'utf8'),
       '"up"',
     );
+  });
+
+  it('shows the analytics notice and creates a local install ID for existing enabled config', () => {
+    installConfigSources();
+    fs.writeFileSync(path.join(repoDir, 'ballin.config.json'), JSON.stringify({
+      analytics: {
+        enabled: 'true',
+      },
+    }));
+
+    const { output, result } = captureStdout(() => configure(repoDir, docsUrl));
+
+    assert.isTrue(result);
+    assert.include(output, analyticsNotice);
+    assert.match(readInstallId(), /^[0-9a-f-]{36}\n$/);
+  });
+
+  it('does not repeat the analytics notice when a local install ID already exists', () => {
+    installConfigSources();
+    fs.writeFileSync(path.join(repoDir, 'ballin.config.json'), JSON.stringify({
+      analytics: {
+        enabled: 'true',
+      },
+    }));
+    fs.mkdirSync(path.dirname(installIdPath()), { recursive: true });
+    fs.writeFileSync(installIdPath(), `${fixedInstallId}\n`, 'utf8');
+
+    const { output, result } = captureStdout(() => configure(repoDir, docsUrl));
+
+    assert.isTrue(result);
+    assert.notInclude(output, analyticsNotice);
+    assert.equal(readInstallId(), `${fixedInstallId}\n`);
+  });
+
+  it('does not create a local install ID when analytics are disabled', () => {
+    installConfigSources();
+    fs.writeFileSync(path.join(repoDir, 'ballin.config.json'), JSON.stringify({
+      analytics: {
+        enabled: 'false',
+      },
+    }));
+
+    const { output, result } = captureStdout(() => configure(repoDir, docsUrl));
+
+    assert.isTrue(result);
+    assert.notInclude(output, analyticsNotice);
+    assert.isFalse(fs.existsSync(installIdPath()));
   });
 
   it('runs the symlink step through the setup CLI', () => {

--- a/test/install_setup.test.ts
+++ b/test/install_setup.test.ts
@@ -51,6 +51,46 @@ describe('install setup', () => {
 
   const readInstallId = () => fs.readFileSync(installIdPath(), 'utf8');
 
+  const withEnv = (env: NodeJS.ProcessEnv, action: () => { output: string; result: boolean }) => {
+    const previousValues = new Map<string, string | undefined>();
+    Object.keys(env).forEach((key) => {
+      previousValues.set(key, process.env[key]);
+      process.env[key] = env[key];
+    });
+    try {
+      return action();
+    } finally {
+      previousValues.forEach((value, key) => {
+        if (value === undefined) {
+          delete process.env[key];
+        } else {
+          process.env[key] = value;
+        }
+      });
+    }
+  };
+
+  const withoutAnalyticsOptOutEnv = (action: () => { output: string; result: boolean }) => {
+    const previousCi = process.env.CI;
+    const previousNoAnalytics = process.env.BALLIN_NO_ANALYTICS;
+    delete process.env.CI;
+    delete process.env.BALLIN_NO_ANALYTICS;
+    try {
+      return action();
+    } finally {
+      if (previousCi === undefined) {
+        delete process.env.CI;
+      } else {
+        process.env.CI = previousCi;
+      }
+      if (previousNoAnalytics === undefined) {
+        delete process.env.BALLIN_NO_ANALYTICS;
+      } else {
+        process.env.BALLIN_NO_ANALYTICS = previousNoAnalytics;
+      }
+    }
+  };
+
   const installConfigSources = () => {
     fs.mkdirSync(path.join(repoDir, 'config'), { recursive: true });
     ['.defaultConfig.json', 'index.ts', 'updateConfig.ts'].forEach((fileName) => {
@@ -101,7 +141,7 @@ describe('install setup', () => {
   it('shows the analytics notice and creates a local install ID on first config creation', () => {
     installConfigSources();
 
-    const { output, result } = captureStdout(() => configure(repoDir, docsUrl));
+    const { output, result } = withoutAnalyticsOptOutEnv(() => captureStdout(() => configure(repoDir, docsUrl)));
 
     assert.isTrue(result);
     assert.include(output, analyticsNotice);
@@ -146,7 +186,7 @@ describe('install setup', () => {
       },
     }));
 
-    const { output, result } = captureStdout(() => configure(repoDir, docsUrl));
+    const { output, result } = withoutAnalyticsOptOutEnv(() => captureStdout(() => configure(repoDir, docsUrl)));
 
     assert.isTrue(result);
     assert.include(output, analyticsNotice);
@@ -163,7 +203,7 @@ describe('install setup', () => {
     fs.mkdirSync(path.dirname(installIdPath()), { recursive: true });
     fs.writeFileSync(installIdPath(), `${fixedInstallId}\n`, 'utf8');
 
-    const { output, result } = captureStdout(() => configure(repoDir, docsUrl));
+    const { output, result } = withoutAnalyticsOptOutEnv(() => captureStdout(() => configure(repoDir, docsUrl)));
 
     assert.isTrue(result);
     assert.notInclude(output, analyticsNotice);
@@ -178,11 +218,50 @@ describe('install setup', () => {
       },
     }));
 
-    const { output, result } = captureStdout(() => configure(repoDir, docsUrl));
+    const { output, result } = withoutAnalyticsOptOutEnv(() => captureStdout(() => configure(repoDir, docsUrl)));
 
     assert.isTrue(result);
     assert.notInclude(output, analyticsNotice);
     assert.isFalse(fs.existsSync(installIdPath()));
+  });
+
+  it('does not create a local install ID when analytics are disabled by environment', () => {
+    [
+      { BALLIN_NO_ANALYTICS: '1' },
+      { CI: 'true' },
+    ].forEach((env) => {
+      fs.rmSync(installIdPath(), { force: true });
+      installConfigSources();
+      fs.writeFileSync(path.join(repoDir, 'ballin.config.json'), JSON.stringify({
+        analytics: {
+          enabled: 'true',
+        },
+      }));
+
+      const { output, result } = withEnv(env, () => captureStdout(() => configure(repoDir, docsUrl)));
+
+      assert.isTrue(result);
+      assert.notInclude(output, analyticsNotice);
+      assert.isFalse(fs.existsSync(installIdPath()));
+    });
+  });
+
+  it('replaces an invalid local install ID during eligible analytics setup', () => {
+    installConfigSources();
+    fs.writeFileSync(path.join(repoDir, 'ballin.config.json'), JSON.stringify({
+      analytics: {
+        enabled: 'true',
+      },
+    }));
+    fs.mkdirSync(path.dirname(installIdPath()), { recursive: true });
+    fs.writeFileSync(installIdPath(), 'not-a-uuid\n', 'utf8');
+
+    const { output, result } = withoutAnalyticsOptOutEnv(() => captureStdout(() => configure(repoDir, docsUrl)));
+
+    assert.isTrue(result);
+    assert.include(output, analyticsNotice);
+    assert.match(readInstallId(), /^[0-9a-f-]{36}\n$/);
+    assert.notEqual(readInstallId(), 'not-a-uuid\n');
   });
 
   it('runs the symlink step through the setup CLI', () => {


### PR DESCRIPTION
Refs #167

## Summary

- keep analytics opt-out as backed-up config via analytics.enabled only
- move install identity to local-only state at .analytics/install-id so gu backup/restore does not copy one machine's install ID to another
- ignore local analytics state so the installed checkout does not become dirty or stash the install ID during update recovery
- run analytics setup after Gist config adoption so restored opt-outs win before local install ID creation
- keep event sending isolated, non-blocking, SDK-free, and limited to the worker allowlisted payload fields
- unref the HTTPS socket instead of the ClientRequest so analytics sends remain non-blocking
- keep user-facing analytics docs minimal and centered on anonymous usage analytics plus the persistent config opt-out
- preserve main's existing updateConfig behavior; follow-up config migration hardening is tracked in #179

## Validation

- CI=true npm run test:unit -- --grep "analytics client|install setup|config|install" (127 passing)
- npm test (204 passing)
- bash -n install.sh
- latest docs-only simplification; no additional local test run