### PR TITLE
Avoid Gist host prompt on configured updates

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -107,6 +107,7 @@ fi
       "$ballin_config" set gu.host "$BALLIN_GU_HOST"
       gu_host="$("$ballin_config" get gu.host)"
     elif [ "$gu_id" = 'null' ] || [ "$gu_host_existed" = false ]; then
+      echo ''
       read -rp "🤔 What GitHub host should be used for Gist backups? [${gu_host}] " input_host
       if [ -n "$input_host" ]; then
         "$ballin_config" set gu.host "$input_host"

--- a/install.sh
+++ b/install.sh
@@ -97,17 +97,17 @@ fi
   if ! (
     cd "$repo_dir" || exit
     gu_host="$("$ballin_config" get gu.host)"
+    gu_id="$("$ballin_config" get gu.id)"
     if [ -n "${BALLIN_GU_HOST:-}" ]; then
       "$ballin_config" set gu.host "$BALLIN_GU_HOST"
       gu_host="$("$ballin_config" get gu.host)"
-    else
+    elif [ "$gu_id" = 'null' ]; then
       read -rp "🤔 What GitHub host should be used for Gist backups? [${gu_host}] " input_host
       if [ -n "$input_host" ]; then
         "$ballin_config" set gu.host "$input_host"
         gu_host="$("$ballin_config" get gu.host)"
       fi
     fi
-    gu_id="$("$ballin_config" get gu.id)"
     export GH_HOST="$gu_host"
 
     if [ ! -x "$(command -v gh)" ]; then

--- a/install.sh
+++ b/install.sh
@@ -61,6 +61,11 @@ config_existed=true
 if [ ! -f "$repo_dir/ballin.config.json" ]; then
   config_existed=false
 fi
+gu_host_existed=false
+if [ "$config_existed" = true ] \
+  && [ "$(node -e "const fs = require('fs'); const config = JSON.parse(fs.readFileSync(process.argv[1], 'utf8')); process.stdout.write(config.gu && Object.prototype.hasOwnProperty.call(config.gu, 'host') ? 'true' : 'false')" "$repo_dir/ballin.config.json" 2>/dev/null)" = 'true' ]; then
+  gu_host_existed=true
+fi
 
 # Configuration must succeed before Gist credentials or command symlinks are touched.
 if [ -f "$repo_dir/commands/install_setup.ts" ] \
@@ -101,7 +106,7 @@ fi
     if [ -n "${BALLIN_GU_HOST:-}" ]; then
       "$ballin_config" set gu.host "$BALLIN_GU_HOST"
       gu_host="$("$ballin_config" get gu.host)"
-    elif [ "$gu_id" = 'null' ]; then
+    elif [ "$gu_id" = 'null' ] || [ "$gu_host_existed" = false ]; then
       read -rp "🤔 What GitHub host should be used for Gist backups? [${gu_host}] " input_host
       if [ -n "$input_host" ]; then
         "$ballin_config" set gu.host "$input_host"

--- a/test/install.test.ts
+++ b/test/install.test.ts
@@ -376,6 +376,7 @@ exit "$FAKE_NODE_STATUS"
     assert.equal(result.status, 0, result.stderr);
     assert.notInclude(result.stdout, '👀 Docs:');
     assert.notInclude(result.stdout, "Created 'ballin.config.json'");
+    assert.notInclude(result.stdout, 'What GitHub host should be used for Gist backups?');
     assert.include(result.stdout, '😎 ballin!');
   });
 

--- a/test/install.test.ts
+++ b/test/install.test.ts
@@ -380,6 +380,27 @@ exit "$FAKE_NODE_STATUS"
     assert.include(result.stdout, '😎 ballin!');
   });
 
+  it('prompts once when migration adds gu.host to an existing Gist config', () => {
+    installBaseCommands();
+    installAdoptableConfigCommand();
+    installFakeGhCommand();
+    fs.writeFileSync(path.join(homeDir, '.configured-gist-id'), 'existing-gist-id\n');
+    fs.writeFileSync(path.join(repoDir, 'ballin.config.json'), '{"gu":{"id":"existing-gist-id"}}\n');
+
+    const result = runInstall({
+      env: {
+        FAKE_GH_HOST: 'github.enterprise.test',
+        FAKE_UPDATE_OUTPUT: 'New configuration options have been added!\ngu.host: github.example.test\n',
+      },
+      input: 'github.enterprise.test\n',
+    });
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.include(commandLog(), 'ballin_config:set gu.host github.enterprise.test\n');
+    assert.include(commandLog(), 'gh:auth status --hostname github.enterprise.test');
+    assert.notInclude(commandLog(), 'gh:gist');
+  });
+
   it('reports newly added configuration and links to the guide', () => {
     installBaseCommands();
     installConfigCommand();


### PR DESCRIPTION
## Summary

- skip the Gist host prompt during installer reruns when gu.id and gu.host were already configured
- prompt once when config migration adds gu.host to a legacy config that already has gu.id
- keep BALLIN_GU_HOST as an explicit override
- add regression coverage for ordinary updates and legacy migrated-host confirmation

## Context

Follow-up to #171. After merging, ballin_update reran the installer and prompted for the Gist host even though the backup Gist was already configured. This keeps ordinary configured updates quiet, while still giving legacy users a one-time chance to confirm or correct a host that was newly added by migration.

## Validation

- bash -n install.sh
- npm run test:unit -- --grep install
- npm test