### PR TITLE
[codex] Harden config migration object defaults

### DIFF
--- a/config/updateConfig.ts
+++ b/config/updateConfig.ts
@@ -13,6 +13,9 @@ const updates: string[] = [];
 const isConfigObject = (value: ConfigValue): value is ConfigObject => (
   value !== null && typeof value === 'object' && !Array.isArray(value)
 );
+const formatUpdateValue = (value: ConfigValue): string => (
+  isConfigObject(value) ? JSON.stringify(value) : `${value}`
+);
 
 const hostFromLegacyGistUrl = (url: ConfigValue): string | null => {
   if (typeof url !== 'string' || !url) {
@@ -37,12 +40,12 @@ Object.keys(defaultConfig).forEach((key) => {
   const defaultVal = defaultConfig[key] as ConfigValue;
   if (!(key in userConfig)) {
     userConfig[key] = defaultVal;
-    updates.push(`${key}: ${defaultVal}`);
+    updates.push(`${key}: ${formatUpdateValue(defaultVal)}`);
   }
   if (isConfigObject(defaultVal)) {
     if (!isConfigObject(userConfig[key])) {
       userConfig[key] = defaultVal;
-      updates.push(`${key}: ${defaultVal}`);
+      updates.push(`${key}: ${formatUpdateValue(defaultVal)}`);
       return;
     }
 
@@ -54,7 +57,7 @@ Object.keys(defaultConfig).forEach((key) => {
           ? hostFromLegacyGistUrl(nestedUserConfig.url) ?? nestedDefaultConfig[nestedKey]
           : nestedDefaultConfig[nestedKey];
         nestedUserConfig[nestedKey] = nestedDefaultVal;
-        updates.push(`${key}.${nestedKey}: ${nestedDefaultVal}`);
+        updates.push(`${key}.${nestedKey}: ${formatUpdateValue(nestedDefaultVal)}`);
       }
     });
   }

--- a/config/updateConfig.ts
+++ b/config/updateConfig.ts
@@ -10,6 +10,9 @@ type ConfigValue = ConfigLeaf | ConfigObject;
 
 const { configObj: userConfig } = fetchConfig();
 const updates: string[] = [];
+const isConfigObject = (value: ConfigValue): value is ConfigObject => (
+  value !== null && typeof value === 'object' && !Array.isArray(value)
+);
 
 const hostFromLegacyGistUrl = (url: ConfigValue): string | null => {
   if (typeof url !== 'string' || !url) {
@@ -36,7 +39,13 @@ Object.keys(defaultConfig).forEach((key) => {
     userConfig[key] = defaultVal;
     updates.push(`${key}: ${defaultVal}`);
   }
-  if (typeof defaultVal === 'object' && (defaultVal as unknown) !== 'null') {
+  if (isConfigObject(defaultVal)) {
+    if (!isConfigObject(userConfig[key])) {
+      userConfig[key] = defaultVal;
+      updates.push(`${key}: ${defaultVal}`);
+      return;
+    }
+
     Object.keys(defaultVal as ConfigObject).forEach((nestedKey) => {
       const nestedUserConfig = userConfig[key] as ConfigObject;
       const nestedDefaultConfig = defaultVal as ConfigObject;

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -304,11 +304,7 @@ describe('config', () => {
     it('updates the isolated fixture when invoked through updateConfig.ts', () => {
       fs.writeFileSync(configPath, '{}', 'utf8');
 
-      const result = spawnSync(process.execPath, [path.join(__dirname, '..', 'config', 'updateConfig.ts')], {
-        cwd: path.join(__dirname, '..'),
-        encoding: 'utf8',
-        env: process.env,
-      });
+      const result = runUpdateConfig();
 
       assert.equal(result.status, 0);
       assert.deepEqual(fetchConfig().configObj, defaultConfig);
@@ -321,11 +317,7 @@ describe('config', () => {
         },
       }), 'utf8');
 
-      const result = spawnSync(process.execPath, [path.join(__dirname, '..', 'config', 'updateConfig.ts')], {
-        cwd: path.join(__dirname, '..'),
-        encoding: 'utf8',
-        env: process.env,
-      });
+      const result = runUpdateConfig();
 
       assert.equal(result.status, 0);
       assert.deepEqual(fetchConfig().configObj.analytics, {
@@ -357,7 +349,7 @@ describe('config', () => {
 
         assert.equal(result.status, 0);
         assert.deepEqual(fetchConfig().configObj, defaultConfig);
-        assert.include(result.stdout, `${key}: [object Object]`);
+        assert.include(result.stdout, `${key}: ${JSON.stringify(defaultConfig[key])}`);
       });
     });
 
@@ -371,11 +363,7 @@ describe('config', () => {
         },
       }), 'utf8');
 
-      const result = spawnSync(process.execPath, [path.join(__dirname, '..', 'config', 'updateConfig.ts')], {
-        cwd: path.join(__dirname, '..'),
-        encoding: 'utf8',
-        env: process.env,
-      });
+      const result = runUpdateConfig();
 
       assert.equal(result.status, 0);
       assert.equal(getConfig('gu.host'), 'github.example.test');
@@ -392,11 +380,7 @@ describe('config', () => {
         },
       }), 'utf8');
 
-      const result = spawnSync(process.execPath, [path.join(__dirname, '..', 'config', 'updateConfig.ts')], {
-        cwd: path.join(__dirname, '..'),
-        encoding: 'utf8',
-        env: process.env,
-      });
+      const result = runUpdateConfig();
 
       assert.equal(result.status, 0);
       assert.equal(getConfig('gu.host'), 'github.com');

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -281,6 +281,13 @@ describe('config', () => {
   });
 
   describe('updateConfig', () => {
+    const updateConfigPath = path.join(__dirname, '..', 'config', 'updateConfig.ts');
+    const runUpdateConfig = () => spawnSync(process.execPath, [updateConfigPath], {
+      cwd: path.join(__dirname, '..'),
+      encoding: 'utf8',
+      env: process.env,
+    });
+
     it('updates the isolated fixture when required directly', () => {
       fs.writeFileSync(configPath, '{}', 'utf8');
 
@@ -323,6 +330,34 @@ describe('config', () => {
       assert.equal(result.status, 0);
       assert.deepEqual(fetchConfig().configObj.analytics, {
         enabled: 'false',
+      });
+    });
+
+    [
+      {
+        name: 'gu: null',
+        config: { ...defaultConfig, gu: null },
+        key: 'gu',
+      },
+      {
+        name: 'gu: "bad"',
+        config: { ...defaultConfig, gu: 'bad' },
+        key: 'gu',
+      },
+      {
+        name: 'analytics: false',
+        config: { ...defaultConfig, analytics: false },
+        key: 'analytics',
+      },
+    ].forEach(({ name, config, key }) => {
+      it(`replaces malformed object-shaped config section ${name}`, () => {
+        fs.writeFileSync(configPath, JSON.stringify(config), 'utf8');
+
+        const result = runUpdateConfig();
+
+        assert.equal(result.status, 0);
+        assert.deepEqual(fetchConfig().configObj, defaultConfig);
+        assert.include(result.stdout, `${key}: [object Object]`);
       });
     });
 


### PR DESCRIPTION
## Summary
- replace malformed object-shaped config sections with their default object during migration
- keep nested-default merging for valid objects, including legacy gu.url host derivation
- print object-valued migration updates as readable JSON instead of [object Object]
- add regression coverage for gu: null, gu: "bad", and analytics: false

## Root cause
updateConfig.ts assumed user config values were objects whenever the matching default config section was object-shaped, so malformed primitive values could be traversed as containers.

## Validation
- npm run test:unit -- --grep 'updateConfig|config'
- npm test

Closes #179