### PR TITLE
[codex] Instrument command analytics events

### DIFF
--- a/commands/analytics.ts
+++ b/commands/analytics.ts
@@ -313,6 +313,7 @@ const runWithCommandAnalytics = (
 ): void => {
   const nowMs = runtime.nowMs ?? Date.now;
   const startedAt = nowMs();
+  process.exitCode = undefined;
   try {
     runCommand();
     recordAnalyticsEvent({

--- a/commands/analytics.ts
+++ b/commands/analytics.ts
@@ -47,6 +47,10 @@ type AnalyticsRuntime = SenderOptions & {
   sender?: AnalyticsSender;
 };
 
+type CommandAnalyticsRuntime = AnalyticsRuntime & {
+  nowMs?: () => number;
+};
+
 type AnalyticsInstallIdOptions = {
   analyticsConfig?: AnalyticsConfig;
   env?: NodeJS.ProcessEnv;
@@ -167,6 +171,22 @@ const coarseOsVersion = (): string => {
   return minor && /^[0-9]+$/.test(minor) ? `${major}.${minor}` : major;
 };
 
+const durationBucketFromMs = (durationMs: number): string => {
+  if (durationMs < 1000) {
+    return '<1s';
+  }
+  if (durationMs < 10_000) {
+    return '1-10s';
+  }
+  if (durationMs < 60_000) {
+    return '10-60s';
+  }
+  if (durationMs < 600_000) {
+    return '1-10m';
+  }
+  return '10m+';
+};
+
 const buildAnalyticsPayload = (
   input: Required<Pick<AnalyticsRecordInput, 'command' | 'status' | 'durationBucket' | 'now'>>,
   installId: string,
@@ -279,13 +299,46 @@ const recordAnalyticsEvent = (input: AnalyticsRecordInput, runtime: AnalyticsRun
   }
 };
 
+const analyticsStatusFromExitCode = (exitCode: string | number | null | undefined): string => {
+  if (exitCode === undefined || exitCode === null || exitCode === 0 || exitCode === '0') {
+    return 'success';
+  }
+  return 'failure';
+};
+
+const runWithCommandAnalytics = (
+  command: string,
+  runCommand: () => void,
+  runtime: CommandAnalyticsRuntime = {},
+): void => {
+  const nowMs = runtime.nowMs ?? Date.now;
+  const startedAt = nowMs();
+  try {
+    runCommand();
+    recordAnalyticsEvent({
+      command,
+      status: analyticsStatusFromExitCode(process.exitCode),
+      durationBucket: durationBucketFromMs(Math.max(0, nowMs() - startedAt)),
+    }, runtime);
+  } catch (error) {
+    recordAnalyticsEvent({
+      command,
+      status: 'failure',
+      durationBucket: durationBucketFromMs(Math.max(0, nowMs() - startedAt)),
+    }, runtime);
+    throw error;
+  }
+};
+
 module.exports = {
   analyticsDisabledByEnv,
   analyticsNotice,
   buildAnalyticsPayload,
+  durationBucketFromMs,
   ensureAnalyticsInstallId,
   installIdPathForRepo,
   readLocalInstallId,
   recordAnalyticsEvent,
+  runWithCommandAnalytics,
   sendAnalyticsPayload,
 };

--- a/commands/ballin.ts
+++ b/commands/ballin.ts
@@ -1,3 +1,7 @@
+const {
+  runWithCommandAnalytics,
+} = require('./analytics.ts');
+
 const format = {
   fileName: '\x1b[4mfile name\x1b[0m',
   key: '\x1b[4mkey\x1b[0m',
@@ -39,8 +43,12 @@ const writeStdout = (text: string): void => {
   process.stdout.write(text);
 };
 
-const runBallinCli = (): void => {
+function runBallinCommand(): void {
   writeStdout(ballinHelp);
+}
+
+const runBallinCli = (): void => {
+  runWithCommandAnalytics('ballin', runBallinCommand);
 };
 
 module.exports = {

--- a/commands/ballin_update.ts
+++ b/commands/ballin_update.ts
@@ -1,5 +1,8 @@
 const path = require('path');
 const {
+  runWithCommandAnalytics,
+} = require('./analytics.ts');
+const {
   isDirectory,
   runCommand,
   runVisibleCommand,
@@ -73,7 +76,7 @@ const checkoutUpdateBranch = (repoDir: string): boolean => {
   return true;
 };
 
-const runBallinUpdateCli = (): void => {
+function runBallinUpdateCommand(): void {
   const repoDir = path.join(process.env.HOME ?? '', '.ballin-scripts');
 
   writeStdoutLine('👟 getting fresh kicks...');
@@ -121,6 +124,10 @@ const runBallinUpdateCli = (): void => {
     cwd: repoDir,
     env: commandEnv(repoDir),
   });
+}
+
+const runBallinUpdateCli = (): void => {
+  runWithCommandAnalytics('ballin_update', runBallinUpdateCommand);
 };
 
 module.exports = {

--- a/commands/gu.ts
+++ b/commands/gu.ts
@@ -2,6 +2,9 @@ const fs = require('fs');
 const os = require('os');
 const path = require('path');
 const {
+  runWithCommandAnalytics,
+} = require('./analytics.ts');
+const {
   commandExists,
   ensureDir,
   makeTempFile,
@@ -617,7 +620,7 @@ const collectSnapshots = (homeDir: string): SnapshotCommand[] => {
   return snapshots;
 };
 
-const runGuCli = (args = process.argv.slice(2)): void => {
+function runGuCommand(args = process.argv.slice(2)): void {
   const homeDir = process.env.HOME ?? '';
   const command = args[0];
 
@@ -708,6 +711,10 @@ const runGuCli = (args = process.argv.slice(2)): void => {
   if (failed) {
     process.exitCode = 1;
   }
+}
+
+const runGuCli = (args = process.argv.slice(2)): void => {
+  runWithCommandAnalytics('gu', () => runGuCommand(args));
 };
 
 module.exports = {

--- a/commands/up.ts
+++ b/commands/up.ts
@@ -1,6 +1,9 @@
 const fs = require('fs');
 const path = require('path');
 const {
+  runWithCommandAnalytics,
+} = require('./analytics.ts');
+const {
   commandExists,
   makeTempFile,
   progress,
@@ -72,7 +75,7 @@ const runNvmInstall = (env: NodeJS.ProcessEnv): NodeJS.ProcessEnv | null => {
   }
 };
 
-const runUpCli = (): void => {
+function runUpCommand(): void {
   let childEnv = process.env;
 
   if (commandExists('brew')) {
@@ -130,6 +133,10 @@ const runUpCli = (): void => {
     progress('Backing up development environment');
     process.exitCode = runVisibleCommand('gu', [], { env: childEnv });
   }
+}
+
+const runUpCli = (): void => {
+  runWithCommandAnalytics('up', runUpCommand);
 };
 
 module.exports = {

--- a/test/analytics.test.ts
+++ b/test/analytics.test.ts
@@ -4,7 +4,9 @@ const https = require('https');
 const { fetchConfig, configPath, stringify } = require('../config/index.ts');
 const {
   analyticsDisabledByEnv,
+  durationBucketFromMs,
   recordAnalyticsEvent,
+  runWithCommandAnalytics,
   sendAnalyticsPayload,
 } = require('../commands/analytics.ts');
 
@@ -278,6 +280,124 @@ describe('analytics client', () => {
     assert.deepEqual(unsupportedCommand.payloads, []);
     assert.deepEqual(unsupportedStatus.payloads, []);
     assert.deepEqual(unsupportedDuration.payloads, []);
+  });
+
+  it('buckets command durations coarsely', () => {
+    assert.equal(durationBucketFromMs(0), '<1s');
+    assert.equal(durationBucketFromMs(999), '<1s');
+    assert.equal(durationBucketFromMs(1000), '1-10s');
+    assert.equal(durationBucketFromMs(9999), '1-10s');
+    assert.equal(durationBucketFromMs(10_000), '10-60s');
+    assert.equal(durationBucketFromMs(59_999), '10-60s');
+    assert.equal(durationBucketFromMs(60_000), '1-10m');
+    assert.equal(durationBucketFromMs(599_999), '1-10m');
+    assert.equal(durationBucketFromMs(600_000), '10m+');
+  });
+
+  it('records one command-level success event after the command finishes', () => {
+    setAnalyticsConfig({
+      enabled: 'true',
+    });
+    writeInstallId();
+    const events: string[] = [];
+    const payloads: AnalyticsPayload[] = [];
+    let currentNow = 10_000;
+    const previousExitCode = process.exitCode;
+    process.exitCode = undefined;
+
+    try {
+      runWithCommandAnalytics('ballin', () => {
+        events.push('command');
+        currentNow = 10_800;
+      }, {
+        endpoint: 'https://analytics.example.test/v1/events',
+        ingestToken: 'test-token',
+        env: {},
+        installIdPath: testInstallIdPath,
+        nowMs: () => currentNow,
+        sender: (payload: AnalyticsPayload) => {
+          events.push('send');
+          payloads.push(payload);
+        },
+      });
+    } finally {
+      process.exitCode = previousExitCode;
+    }
+
+    assert.deepEqual(events, ['command', 'send']);
+    assert.deepInclude(payloads[0], {
+      command: 'ballin',
+      status: 'success',
+      durationBucket: '<1s',
+    });
+  });
+
+  it('records command-level failures from exitCode without changing it', () => {
+    setAnalyticsConfig({
+      enabled: 'true',
+    });
+    writeInstallId();
+    const payloads: AnalyticsPayload[] = [];
+    let currentNow = 1000;
+    const previousExitCode = process.exitCode;
+    process.exitCode = undefined;
+
+    try {
+      runWithCommandAnalytics('gu', () => {
+        currentNow = 13_000;
+        process.exitCode = 17;
+      }, {
+        endpoint: 'https://analytics.example.test/v1/events',
+        ingestToken: 'test-token',
+        env: {},
+        installIdPath: testInstallIdPath,
+        nowMs: () => currentNow,
+        sender: (payload: AnalyticsPayload) => {
+          payloads.push(payload);
+        },
+      });
+
+      assert.equal(process.exitCode, 17);
+    } finally {
+      process.exitCode = previousExitCode;
+    }
+
+    assert.deepInclude(payloads[0], {
+      command: 'gu',
+      status: 'failure',
+      durationBucket: '10-60s',
+    });
+  });
+
+  it('records command-level failures when the command throws and rethrows', () => {
+    setAnalyticsConfig({
+      enabled: 'true',
+    });
+    writeInstallId();
+    const payloads: AnalyticsPayload[] = [];
+    let currentNow = 0;
+
+    assert.throws(() => {
+      runWithCommandAnalytics('up', () => {
+        currentNow = 60_000;
+        throw new Error('simulated command failure');
+      }, {
+        endpoint: 'https://analytics.example.test/v1/events',
+        ingestToken: 'test-token',
+        env: {},
+        installIdPath: testInstallIdPath,
+        nowMs: () => currentNow,
+        sender: (payload: AnalyticsPayload) => {
+          payloads.push(payload);
+        },
+      });
+    }, 'simulated command failure');
+
+    assert.deepInclude(payloads[0], {
+      command: 'up',
+      status: 'failure',
+      durationBucket: '1-10m',
+    });
   });
 
   it('sends through https with a short timeout and swallows request failures', () => {

--- a/test/analytics.test.ts
+++ b/test/analytics.test.ts
@@ -369,6 +369,39 @@ describe('analytics client', () => {
     });
   });
 
+  it('isolates command-level status from a stale process exitCode', () => {
+    setAnalyticsConfig({
+      enabled: 'true',
+    });
+    writeInstallId();
+    const payloads: AnalyticsPayload[] = [];
+    const previousExitCode = process.exitCode;
+    process.exitCode = 17;
+
+    try {
+      runWithCommandAnalytics('ballin_update', () => {}, {
+        endpoint: 'https://analytics.example.test/v1/events',
+        ingestToken: 'test-token',
+        env: {},
+        installIdPath: testInstallIdPath,
+        nowMs: () => 1000,
+        sender: (payload: AnalyticsPayload) => {
+          payloads.push(payload);
+        },
+      });
+
+      assert.isUndefined(process.exitCode);
+    } finally {
+      process.exitCode = previousExitCode;
+    }
+
+    assert.deepInclude(payloads[0], {
+      command: 'ballin_update',
+      status: 'success',
+      durationBucket: '<1s',
+    });
+  });
+
   it('records command-level failures when the command throws and rethrows', () => {
     setAnalyticsConfig({
       enabled: 'true',


### PR DESCRIPTION
Closes #168

## Summary

- add a shared command analytics wrapper that records one command-level event after a CLI invocation completes
- bucket command duration coarsely and derive success/failure from the command exit code without leaking stale in-process `process.exitCode` state
- hook the initial #168 command set: `up`, `gu`, `ballin_update`, and `ballin`
- keep analytics failure-tolerant and within the existing allowlisted payload path; no command args, feature details, raw errors, paths, Gist data, env vars, or config values are added

## Validation

- `npm run test:unit -- --grep "analytics client"` (15 passing)
- `npm test` (209 passing)