### PR TITLE
[codex] Document analytics consent and payload

### DIFF
--- a/commands/analytics.ts
+++ b/commands/analytics.ts
@@ -77,9 +77,10 @@ const allowedDurations = new Set(['unknown', '<1s', '1-10s', '10-60s', '1-10m', 
 const allowedOs = new Set(['darwin', 'linux', 'win32']);
 const installIdPattern = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
 const analyticsNotice = [
-  'ballin-scripts collects minimal anonymous active-install analytics after this notice to understand active installs, top-level command usage, and success or failure.',
-  'Setup creates a random local install ID now; no analytics are sent during install. Later events include only: schema version, install ID, date bucket, command, status, duration bucket, app version, Node major, OS family, and coarse OS version.',
-  'The backend hashes the install ID and deletes analytics rows older than 395 days.',
+  'ballin-scripts collects minimal anonymous active-install analytics after this notice: active installs, top-level command usage, and success or failure.',
+  'Setup creates a random local install ID now; no analytics are sent during install.',
+  'Later events include only: schema version, install ID, date bucket, command, status, duration bucket, app version, Node major, OS family, and coarse OS version.',
+  'The backend hashes install IDs and deletes analytics rows older than 395 days.',
   'Never sent: command arguments, usernames, paths, Gist IDs or URLs, dotfiles, package lists, editor settings or extensions, raw errors, command output, environment variables, or config values.',
   'CI never sends analytics; analytics failures never affect command behavior.',
   'Disable: ballin_config set analytics.enabled false',

--- a/commands/analytics.ts
+++ b/commands/analytics.ts
@@ -77,12 +77,10 @@ const allowedDurations = new Set(['unknown', '<1s', '1-10s', '10-60s', '1-10m', 
 const allowedOs = new Set(['darwin', 'linux', 'win32']);
 const installIdPattern = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
 const analyticsNotice = [
-  'ballin-scripts collects minimal anonymous active-install analytics after this notice: active installs, top-level command usage, and success or failure.',
-  'Setup creates a random local install ID now; no analytics are sent during install.',
-  'Later events include only: schema version, install ID, date bucket, command, status, duration bucket, app version, Node major, OS family, and coarse OS version.',
-  'The backend hashes install IDs and deletes analytics rows older than 395 days.',
-  'Never sent: command arguments, usernames, paths, Gist IDs or URLs, dotfiles, package lists, editor settings or extensions, raw errors, command output, environment variables, or config values.',
-  'CI never sends analytics; analytics failures never affect command behavior.',
+  'ballin-scripts collects minimal anonymous active-install analytics after this notice.',
+  'Sent: schema version, random install ID, date bucket, command, status, duration bucket, app version, Node major, OS family, and coarse OS version.',
+  'Never sent: command arguments, usernames, paths, Gist IDs or URLs, dotfiles, package lists, editor settings or extensions, raw errors or output, environment variables, or config values.',
+  'Setup creates the install ID now, but sends nothing during install. CI never sends analytics; failures never affect commands. Install IDs are backend-hashed; rows older than 395 days are deleted.',
   'Disable: ballin_config set analytics.enabled false',
   'Or for this environment: BALLIN_NO_ANALYTICS=1',
 ].join('\n');

--- a/commands/analytics.ts
+++ b/commands/analytics.ts
@@ -81,7 +81,6 @@ const defaultAnalyticsDocsUrl = 'https://github.com/JBallin/ballin-scripts/blob/
 const analyticsNoticeFor = (docsUrl = defaultAnalyticsDocsUrl): string => [
   'ballin-scripts collects minimal anonymous active-install analytics after this notice.',
   'Disable: ballin_config set analytics.enabled false',
-  'Or for this environment: BALLIN_NO_ANALYTICS=1',
   `Details: ${docsUrl}`,
 ].join('\n');
 const analyticsNotice = analyticsNoticeFor();

--- a/commands/analytics.ts
+++ b/commands/analytics.ts
@@ -77,15 +77,13 @@ const allowedDurations = new Set(['unknown', '<1s', '1-10s', '10-60s', '1-10m', 
 const allowedOs = new Set(['darwin', 'linux', 'win32']);
 const installIdPattern = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
 const analyticsNotice = [
-  'ballin-scripts collects minimal anonymous active-install analytics after this notice.',
-  'Analytics help understand active installs, top-level command usage, and command success or failure.',
-  'Setup creates a random local install ID now, but it does not send analytics during install.',
-  'Later command events can include only: schema version, install ID, date bucket, command name, status, duration bucket, app version, Node major, OS family, and coarse OS version.',
-  'The backend hashes the install ID before storage and deletes analytics rows older than 395 days.',
-  'Analytics never send command arguments, usernames, local paths, Gist IDs or URLs, dotfile contents, package lists, editor settings or extensions, raw errors, command output, environment variables, or config values.',
-  'CI environments never send analytics, and analytics failures never affect command behavior.',
-  'Opt out with: ballin_config set analytics.enabled false',
-  'Or for a single environment: BALLIN_NO_ANALYTICS=1',
+  'ballin-scripts collects minimal anonymous active-install analytics after this notice to understand active installs, top-level command usage, and success or failure.',
+  'Setup creates a random local install ID now; no analytics are sent during install. Later events include only: install ID, date bucket, command, status, duration bucket, app version, Node major, OS family, and coarse OS version.',
+  'The backend hashes the install ID and deletes analytics rows older than 395 days.',
+  'Never sent: command arguments, usernames, paths, Gist IDs or URLs, dotfiles, package lists, editor settings or extensions, raw errors, command output, environment variables, or config values.',
+  'CI never sends analytics; analytics failures never affect command behavior.',
+  'Disable: ballin_config set analytics.enabled false',
+  'Or for this environment: BALLIN_NO_ANALYTICS=1',
 ].join('\n');
 
 const packageJsonPath = path.join(__dirname, '..', 'package.json');

--- a/commands/analytics.ts
+++ b/commands/analytics.ts
@@ -77,10 +77,13 @@ const allowedDurations = new Set(['unknown', '<1s', '1-10s', '10-60s', '1-10m', 
 const allowedOs = new Set(['darwin', 'linux', 'win32']);
 const installIdPattern = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
 const analyticsNotice = [
-  'ballin-scripts collects minimal anonymous command analytics.',
-  'No command arguments, paths, usernames, Gist IDs, dotfiles, package lists, raw errors, or environment values are sent.',
-  'Setup creates a local anonymous install ID now, but it does not send analytics during install.',
-  'Later analytics events include that install ID so the backend can count active installs; the backend hashes it before storage.',
+  'ballin-scripts collects minimal anonymous active-install analytics after this notice.',
+  'Analytics help understand active installs, top-level command usage, and command success or failure.',
+  'Setup creates a random local install ID now, but it does not send analytics during install.',
+  'Later command events can include only: schema version, install ID, date bucket, command name, status, duration bucket, app version, Node major, OS family, and coarse OS version.',
+  'The backend hashes the install ID before storage and deletes analytics rows older than 395 days.',
+  'Analytics never send command arguments, usernames, local paths, Gist IDs or URLs, dotfile contents, package lists, editor settings or extensions, raw errors, command output, environment variables, or config values.',
+  'CI environments never send analytics, and analytics failures never affect command behavior.',
   'Opt out with: ballin_config set analytics.enabled false',
   'Or for a single environment: BALLIN_NO_ANALYTICS=1',
 ].join('\n');

--- a/commands/analytics.ts
+++ b/commands/analytics.ts
@@ -79,7 +79,7 @@ const allowedOs = new Set(['darwin', 'linux', 'win32']);
 const installIdPattern = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
 const defaultAnalyticsDocsUrl = 'https://github.com/JBallin/ballin-scripts/blob/main/docs/analytics.md';
 const analyticsNoticeFor = (docsUrl = defaultAnalyticsDocsUrl): string => [
-  'ballin-scripts collects minimal anonymous active-install analytics after this notice.',
+  'ballin-scripts collects minimal anonymous usage analytics after this notice.',
   'Disable: ballin_config set analytics.enabled false',
   `Details: ${docsUrl}`,
 ].join('\n');

--- a/commands/analytics.ts
+++ b/commands/analytics.ts
@@ -78,7 +78,7 @@ const allowedOs = new Set(['darwin', 'linux', 'win32']);
 const installIdPattern = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
 const analyticsNotice = [
   'ballin-scripts collects minimal anonymous active-install analytics after this notice to understand active installs, top-level command usage, and success or failure.',
-  'Setup creates a random local install ID now; no analytics are sent during install. Later events include only: install ID, date bucket, command, status, duration bucket, app version, Node major, OS family, and coarse OS version.',
+  'Setup creates a random local install ID now; no analytics are sent during install. Later events include only: schema version, install ID, date bucket, command, status, duration bucket, app version, Node major, OS family, and coarse OS version.',
   'The backend hashes the install ID and deletes analytics rows older than 395 days.',
   'Never sent: command arguments, usernames, paths, Gist IDs or URLs, dotfiles, package lists, editor settings or extensions, raw errors, command output, environment variables, or config values.',
   'CI never sends analytics; analytics failures never affect command behavior.',

--- a/commands/analytics.ts
+++ b/commands/analytics.ts
@@ -53,6 +53,7 @@ type CommandAnalyticsRuntime = AnalyticsRuntime & {
 
 type AnalyticsInstallIdOptions = {
   analyticsConfig?: AnalyticsConfig;
+  docsUrl?: string;
   env?: NodeJS.ProcessEnv;
   generateInstallId?: () => string;
   installIdPath?: string;
@@ -76,14 +77,14 @@ const allowedStatuses = new Set(['success', 'failure', 'unknown']);
 const allowedDurations = new Set(['unknown', '<1s', '1-10s', '10-60s', '1-10m', '10m+']);
 const allowedOs = new Set(['darwin', 'linux', 'win32']);
 const installIdPattern = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
-const analyticsNotice = [
+const defaultAnalyticsDocsUrl = 'https://github.com/JBallin/ballin-scripts/blob/main/docs/analytics.md';
+const analyticsNoticeFor = (docsUrl = defaultAnalyticsDocsUrl): string => [
   'ballin-scripts collects minimal anonymous active-install analytics after this notice.',
-  'Sent: schema version, random install ID, date bucket, command, status, duration bucket, app version, Node major, OS family, and coarse OS version.',
-  'Never sent: command arguments, usernames, paths, Gist IDs or URLs, dotfiles, package lists, editor settings or extensions, raw errors or output, environment variables, or config values.',
-  'Setup creates the install ID now, but sends nothing during install. CI never sends analytics; failures never affect commands. Install IDs are backend-hashed; rows older than 395 days are deleted.',
   'Disable: ballin_config set analytics.enabled false',
   'Or for this environment: BALLIN_NO_ANALYTICS=1',
+  `Details: ${docsUrl}`,
 ].join('\n');
+const analyticsNotice = analyticsNoticeFor();
 
 const packageJsonPath = path.join(__dirname, '..', 'package.json');
 const defaultRepoDir = path.join(__dirname, '..');
@@ -149,7 +150,7 @@ const ensureAnalyticsInstallId = (options: AnalyticsInstallIdOptions = {}): stri
     return existingInstallId;
   }
 
-  options.noticeWriter?.(analyticsNotice);
+  options.noticeWriter?.(analyticsNoticeFor(options.docsUrl));
   const installId = (options.generateInstallId ?? crypto.randomUUID)();
   return writeLocalInstallId(installId, installIdPath) ? installId : null;
 };
@@ -334,6 +335,7 @@ const runWithCommandAnalytics = (
 module.exports = {
   analyticsDisabledByEnv,
   analyticsNotice,
+  analyticsNoticeFor,
   buildAnalyticsPayload,
   durationBucketFromMs,
   ensureAnalyticsInstallId,

--- a/commands/install_setup.ts
+++ b/commands/install_setup.ts
@@ -14,12 +14,13 @@ const isConfigObject = (value: unknown): value is ConfigObject => (
   typeof value === 'object' && value !== null && !Array.isArray(value)
 );
 
-const setupAnalyticsInstallId = (repoDir: string, configPath: string): void => {
+const setupAnalyticsInstallId = (repoDir: string, configPath: string, docsUrl?: string): void => {
   try {
     const config = JSON.parse(fs.readFileSync(configPath, 'utf8')) as ConfigObject;
     const analyticsConfig = isConfigObject(config.analytics) ? config.analytics : undefined;
     ensureAnalyticsInstallId({
       analyticsConfig,
+      docsUrl,
       env: process.env,
       repoDir,
       noticeWriter: writeStdoutLine,
@@ -29,8 +30,8 @@ const setupAnalyticsInstallId = (repoDir: string, configPath: string): void => {
   }
 };
 
-const setupAnalytics = (repoDir: string): boolean => {
-  setupAnalyticsInstallId(repoDir, path.join(repoDir, 'ballin.config.json'));
+const setupAnalytics = (repoDir: string, docsUrl?: string): boolean => {
+  setupAnalyticsInstallId(repoDir, path.join(repoDir, 'ballin.config.json'), docsUrl);
   return true;
 };
 
@@ -118,7 +119,7 @@ const runInstallSetupCli = (): void => {
   }
 
   if (command === 'setup-analytics' && repoDir) {
-    process.exitCode = setupAnalytics(repoDir) ? 0 : 1;
+    process.exitCode = setupAnalytics(repoDir, option) ? 0 : 1;
     return;
   }
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -3,7 +3,8 @@
 Start here when setting up or auditing what `ballin-scripts` manages.
 
 - [Optional capabilities](optional-capabilities.md): Node.js setup, optional
-  tool setup, analytics consent, and configurable `up` settings.
+  tool setup, analytics opt-out, and configurable `up` settings.
+- [Analytics](analytics.md): analytics consent, payload, opt-out, and retention.
 - [Supported capabilities](capabilities.md): the current `up` integrations and
   `gu` backup snapshots.
 - [Analytics backend](analytics-backend.md): backend choice, data policy, and

--- a/docs/README.md
+++ b/docs/README.md
@@ -3,7 +3,7 @@
 Start here when setting up or auditing what `ballin-scripts` manages.
 
 - [Optional capabilities](optional-capabilities.md): Node.js setup, optional
-  tool setup, and configurable `up` settings.
+  tool setup, analytics consent, and configurable `up` settings.
 - [Supported capabilities](capabilities.md): the current `up` integrations and
   `gu` backup snapshots.
 - [Analytics backend](analytics-backend.md): backend choice, data policy, and

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,4 +8,4 @@ Start here when setting up or auditing what `ballin-scripts` manages.
 - [Supported capabilities](capabilities.md): the current `up` integrations and
   `gu` backup snapshots.
 - [Analytics backend](analytics-backend.md): backend deployment and data-policy
-  notes for active-install analytics.
+  notes for usage analytics.

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,8 +4,9 @@ Start here when setting up or auditing what `ballin-scripts` manages.
 
 - [Optional capabilities](optional-capabilities.md): Node.js setup, optional
   tool setup, analytics opt-out, and configurable `up` settings.
-- [Analytics](analytics.md): analytics consent, payload, opt-out, and retention.
+- [Analytics](analytics.md): analytics consent, payload, opt-out, retention, and
+  current status.
 - [Supported capabilities](capabilities.md): the current `up` integrations and
   `gu` backup snapshots.
-- [Analytics backend](analytics-backend.md): backend choice, data policy, and
-  deployment notes for active-install analytics.
+- [Analytics backend](analytics-backend.md): backend deployment and data-policy
+  notes for active-install analytics.

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,8 +4,7 @@ Start here when setting up or auditing what `ballin-scripts` manages.
 
 - [Optional capabilities](optional-capabilities.md): Node.js setup, optional
   tool setup, analytics opt-out, and configurable `up` settings.
-- [Analytics](analytics.md): analytics consent, payload, opt-out, retention, and
-  current status.
+- [Analytics](analytics.md): analytics consent, payload, opt-out, and retention.
 - [Supported capabilities](capabilities.md): the current `up` integrations and
   `gu` backup snapshots.
 - [Analytics backend](analytics-backend.md): backend deployment and data-policy

--- a/docs/analytics-backend.md
+++ b/docs/analytics-backend.md
@@ -12,11 +12,10 @@ CLI.
 
 The CLI client and Worker skeleton are present, but production analytics sends
 are still disabled until the endpoint and token are configured in the client.
-Before enabling them, re-check the first-run notice and
-[optional capabilities guide](optional-capabilities.md#analytics) against the
-implemented payload and confirm the Worker deployment, D1 binding, migrations,
+Before enabling them, confirm the Worker deployment, D1 binding, migrations,
 secrets, retention cleanup, and Cloudflare-side rate limiting or equivalent
-abuse controls.
+abuse controls. Also re-check the implemented payload against the first-run
+notice and [optional capabilities guide](optional-capabilities.md#analytics).
 
 ## Why Cloudflare Worker and D1
 

--- a/docs/analytics-backend.md
+++ b/docs/analytics-backend.md
@@ -1,8 +1,8 @@
 # Analytics Backend
 
-`ballin-scripts` uses a small Cloudflare Worker backed by D1 for active-install
-analytics. The goal is maintenance visibility, not a general product analytics
-platform.
+`ballin-scripts` uses a small Cloudflare Worker backed by D1 for usage
+analytics. The goal is to see whether anyone is using the app and how, not to
+run a general product analytics platform.
 
 The backend skeleton lives in [`analytics-worker/`](../analytics-worker/). It is
 not deployed by default and does not require a Cloudflare account to work on the
@@ -19,8 +19,7 @@ notice and [Analytics](analytics.md).
 
 - The event schema is owned by this project and can reject anything outside the
   privacy allowlist.
-- D1 can compute exact DAU/WAU/MAU from daily buckets and server-hashed install
-  IDs.
+- D1 can count active installs from daily buckets and server-hashed install IDs.
 - The CLI does not need a runtime analytics SDK.
 - Retention is controlled by the Worker and D1 schema.
 - The deployment can stay tiny: one Worker, one D1 database, and two secrets.
@@ -32,12 +31,12 @@ notice and [Analytics](analytics.md).
 - Plausible is privacy-focused, but its visitor model is shaped around web
   traffic headers rather than CLI install IDs.
 - Workers Analytics Engine is useful for high-cardinality metric streams, but D1
-  is simpler for exact low-volume active-install counts.
+  is simpler for exact low-volume usage counts.
 
 ## Retention
 
 The Worker deletes rows older than 395 days. That keeps roughly 13 months of
-daily active-install and command-count data.
+daily install and command-count data.
 
 ## Abuse Controls
 

--- a/docs/analytics-backend.md
+++ b/docs/analytics-backend.md
@@ -8,7 +8,7 @@ The backend skeleton lives in [`analytics-worker/`](../analytics-worker/). It is
 not deployed by default and does not require a Cloudflare account to work on the
 CLI.
 
-## Production Gate
+## Production Setup
 
 Production sends stay disabled until the CLI endpoint and token are configured.
 Before enabling them, confirm deployment, D1 binding, migrations, secrets,

--- a/docs/analytics-backend.md
+++ b/docs/analytics-backend.md
@@ -8,7 +8,7 @@ The backend skeleton lives in [`analytics-worker/`](../analytics-worker/). It is
 not deployed by default and does not require a Cloudflare account to work on the
 CLI.
 
-## Current Production Status
+## Production Gate
 
 Production sends stay disabled until the CLI endpoint and token are configured.
 Before enabling them, confirm deployment, D1 binding, migrations, secrets,

--- a/docs/analytics-backend.md
+++ b/docs/analytics-backend.md
@@ -8,6 +8,16 @@ The backend skeleton lives in [`analytics-worker/`](../analytics-worker/). It is
 not deployed by default and does not require a Cloudflare account to work on the
 CLI.
 
+## Current Production Status
+
+The CLI client and Worker skeleton are present, but production analytics sends
+are still disabled until the endpoint and token are configured in the client.
+Before enabling them, re-check the first-run notice and
+[optional capabilities guide](optional-capabilities.md#analytics) against the
+implemented payload and confirm the Worker deployment, D1 binding, migrations,
+secrets, retention cleanup, and Cloudflare-side rate limiting or equivalent
+abuse controls.
+
 ## Why Cloudflare Worker and D1
 
 - The event schema is owned by this project and can reject anything outside the
@@ -52,4 +62,6 @@ Before enabling the CLI to send production events:
 - configure Cloudflare-side rate limiting or equivalent edge protection
 - deploy the Worker
 - configure the CLI endpoint in the client implementation
-- re-check that the client payload matches the documented allowlist
+- re-check that the client payload, first-run notice, and
+  `docs/optional-capabilities.md` analytics section match the documented
+  allowlist

--- a/docs/analytics-backend.md
+++ b/docs/analytics-backend.md
@@ -10,13 +10,11 @@ CLI.
 
 ## Current Production Status
 
-The CLI client and Worker skeleton are present, but production analytics sends
-are still disabled until the endpoint and token are configured in the client.
-That follow-up is tracked in
-[#185](https://github.com/JBallin/ballin-scripts/issues/185). Before enabling
-them, confirm the Worker deployment, D1 binding, migrations, secrets, retention
-cleanup, and Cloudflare-side rate limiting or equivalent abuse controls. Also
-re-check the implemented payload against the first-run notice and
+The CLI client and Worker skeleton are present, but production sends stay
+disabled until [#185](https://github.com/JBallin/ballin-scripts/issues/185)
+configures the endpoint and token. Before enabling them, confirm the Worker
+deployment, D1 binding, migrations, secrets, retention cleanup, and abuse
+controls, then re-check the implemented payload against the first-run notice and
 [optional capabilities guide](optional-capabilities.md#analytics).
 
 ## Why Cloudflare Worker and D1

--- a/docs/analytics-backend.md
+++ b/docs/analytics-backend.md
@@ -12,10 +12,12 @@ CLI.
 
 The CLI client and Worker skeleton are present, but production analytics sends
 are still disabled until the endpoint and token are configured in the client.
-Before enabling them, confirm the Worker deployment, D1 binding, migrations,
-secrets, retention cleanup, and Cloudflare-side rate limiting or equivalent
-abuse controls. Also re-check the implemented payload against the first-run
-notice and [optional capabilities guide](optional-capabilities.md#analytics).
+That follow-up is tracked in
+[#185](https://github.com/JBallin/ballin-scripts/issues/185). Before enabling
+them, confirm the Worker deployment, D1 binding, migrations, secrets, retention
+cleanup, and Cloudflare-side rate limiting or equivalent abuse controls. Also
+re-check the implemented payload against the first-run notice and
+[optional capabilities guide](optional-capabilities.md#analytics).
 
 ## Why Cloudflare Worker and D1
 

--- a/docs/analytics-backend.md
+++ b/docs/analytics-backend.md
@@ -1,8 +1,8 @@
 # Analytics Backend
 
 `ballin-scripts` uses a small Cloudflare Worker backed by D1 for usage
-analytics. The goal is to see whether anyone is using the app and how, not to
-run a general product analytics platform.
+analytics. The backend records only the minimal signals needed for active
+installs, top-level command usage, and command success or failure.
 
 The backend skeleton lives in [`analytics-worker/`](../analytics-worker/). It is
 not deployed by default and does not require a Cloudflare account to work on the

--- a/docs/analytics-backend.md
+++ b/docs/analytics-backend.md
@@ -1,8 +1,8 @@
 # Analytics Backend
 
-Issue #166 selected a small Cloudflare Worker backed by D1 for the first
-`ballin-scripts` analytics backend. The goal is active-install visibility, not a
-general product analytics platform.
+`ballin-scripts` uses a small Cloudflare Worker backed by D1 for active-install
+analytics. The goal is maintenance visibility, not a general product analytics
+platform.
 
 The backend skeleton lives in [`analytics-worker/`](../analytics-worker/). It is
 not deployed by default and does not require a Cloudflare account to work on the
@@ -10,12 +10,10 @@ CLI.
 
 ## Current Production Status
 
-Production sends stay disabled until
-[#185](https://github.com/JBallin/ballin-scripts/issues/185) configures the
-endpoint and token. Before enabling them, confirm deployment, D1 binding,
-migrations, secrets, retention cleanup, abuse controls, and payload alignment
-with the first-run notice and
-[optional capabilities guide](optional-capabilities.md#analytics).
+Production sends stay disabled until the CLI endpoint and token are configured.
+Before enabling them, confirm deployment, D1 binding, migrations, secrets,
+retention cleanup, abuse controls, and payload alignment with the first-run
+notice and [Analytics](analytics.md).
 
 ## Why Cloudflare Worker and D1
 
@@ -61,6 +59,5 @@ Before enabling the CLI to send production events:
 - configure Cloudflare-side rate limiting or equivalent edge protection
 - deploy the Worker
 - configure the CLI endpoint in the client implementation
-- re-check that the client payload, first-run notice, and
-  `docs/optional-capabilities.md` analytics section match the documented
-  allowlist
+- re-check that the client payload, first-run notice, and `docs/analytics.md`
+  match the documented allowlist

--- a/docs/analytics-backend.md
+++ b/docs/analytics-backend.md
@@ -10,11 +10,11 @@ CLI.
 
 ## Current Production Status
 
-The CLI client and Worker skeleton are present, but production sends stay
-disabled until [#185](https://github.com/JBallin/ballin-scripts/issues/185)
-configures the endpoint and token. Before enabling them, confirm the Worker
-deployment, D1 binding, migrations, secrets, retention cleanup, and abuse
-controls, then re-check the implemented payload against the first-run notice and
+Production sends stay disabled until
+[#185](https://github.com/JBallin/ballin-scripts/issues/185) configures the
+endpoint and token. Before enabling them, confirm deployment, D1 binding,
+migrations, secrets, retention cleanup, abuse controls, and payload alignment
+with the first-run notice and
 [optional capabilities guide](optional-capabilities.md#analytics).
 
 ## Why Cloudflare Worker and D1

--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -56,3 +56,5 @@ aggregate command/version/Node/OS counts, and deletes rows older than 395 days.
 
 Events are sent only when analytics are enabled and the CLI is configured with
 an analytics endpoint and token.
+
+For deployment details, see [Analytics backend](analytics-backend.md).

--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -1,8 +1,8 @@
 # Analytics
 
 `ballin-scripts` can send minimal anonymous usage analytics after the installer
-shows a first-run notice. Analytics help show whether anyone is using the app,
-which top-level commands they use, and whether those commands succeed or fail.
+shows a first-run notice. Analytics show active installs, top-level command
+usage, and command success or failure.
 
 Disable persistently:
 

--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -10,11 +10,13 @@ Disable persistently:
 ballin_config set analytics.enabled false
 ```
 
-Disable for one environment:
+Disable for one command:
 
 ```shell
-BALLIN_NO_ANALYTICS=1
+BALLIN_NO_ANALYTICS=1 up
 ```
+
+Replace `up` with the command you are running.
 
 CI never sends analytics. Analytics failures are ignored and never change
 command output, side effects, or exit status.

--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -1,0 +1,58 @@
+# Analytics
+
+`ballin-scripts` can send minimal anonymous active-install analytics after the
+installer shows a first-run notice. Analytics help answer whether installs are
+active, which top-level commands are used, and whether those commands succeed or
+fail.
+
+Disable persistently:
+
+```shell
+ballin_config set analytics.enabled false
+```
+
+Disable for one environment:
+
+```shell
+BALLIN_NO_ANALYTICS=1
+```
+
+CI never sends analytics. Analytics failures are ignored and never change
+command output, side effects, or exit status.
+
+## What Is Sent
+
+- schema version
+- random install ID
+- date bucket, such as `YYYY-MM-DD`
+- command name for currently instrumented top-level commands: `up`, `gu`,
+  `ballin_update`, and `ballin`
+- status: `success`, `failure`, or `unknown`
+- coarse duration bucket: `unknown`, `<1s`, `1-10s`, `10-60s`, `1-10m`, or
+  `10m+`
+- `ballin-scripts` version
+- Node.js major version
+- OS family: `darwin`, `linux`, `win32`, or `unknown`
+- coarse OS version
+
+## What Is Never Sent
+
+- command arguments
+- usernames
+- local paths
+- Gist IDs or URLs
+- dotfile contents
+- package lists
+- editor settings or extensions
+- raw errors or command output
+- environment variables
+- config values
+
+## Storage
+
+The installer creates a random local install ID under `.analytics/`. The
+backend hashes install IDs before storage, stores daily install rows plus
+aggregate command/version/Node/OS counts, and deletes rows older than 395 days.
+
+Production sends stay disabled until backend deployment, abuse controls, and
+final payload review are complete.

--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -54,5 +54,5 @@ The installer creates a random local install ID under `.analytics/`. The
 backend hashes install IDs before storage, stores daily install rows plus
 aggregate command/version/Node/OS counts, and deletes rows older than 395 days.
 
-Production sends stay disabled until backend deployment, abuse controls, and
-final payload review are complete.
+Events are sent only when analytics are enabled and the CLI is configured with
+an analytics endpoint and token.

--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -1,9 +1,8 @@
 # Analytics
 
-`ballin-scripts` can send minimal anonymous active-install analytics after the
-installer shows a first-run notice. Analytics help answer whether installs are
-active, which top-level commands are used, and whether those commands succeed or
-fail.
+`ballin-scripts` can send minimal anonymous usage analytics after the installer
+shows a first-run notice. Analytics help show whether anyone is using the app,
+which top-level commands they use, and whether those commands succeed or fail.
 
 Disable persistently:
 

--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -18,6 +18,12 @@ BALLIN_NO_ANALYTICS=1 up
 
 Replace `up` with the command you are running.
 
+Disable for a shell session or profile:
+
+```shell
+export BALLIN_NO_ANALYTICS=1
+```
+
 CI never sends analytics. Analytics failures are ignored and never change
 command output, side effects, or exit status.
 

--- a/docs/optional-capabilities.md
+++ b/docs/optional-capabilities.md
@@ -69,7 +69,7 @@ them before continuing.
 
 `ballin-scripts` can send minimal anonymous active-install analytics after a
 first-run notice. See [Analytics](analytics.md) for what is sent, what is never
-sent, retention, and production-send status.
+sent, retention, and current status.
 
 Disable persistently:
 

--- a/docs/optional-capabilities.md
+++ b/docs/optional-capabilities.md
@@ -69,7 +69,7 @@ them before continuing.
 
 `ballin-scripts` can send minimal anonymous active-install analytics after a
 first-run notice. See [Analytics](analytics.md) for what is sent, what is never
-sent, retention, and current status.
+sent, and how long it is kept.
 
 Disable persistently:
 

--- a/docs/optional-capabilities.md
+++ b/docs/optional-capabilities.md
@@ -111,8 +111,7 @@ command output, environment variables, or config values.
 Backend: a small Cloudflare Worker with D1 stores server-hashed daily install
 IDs plus aggregate command, status, duration, version, Node, and OS counts. Rows
 older than 395 days are deleted. Production sends stay disabled until
-deployment, abuse controls, and final payload review are complete in
-[#185](https://github.com/JBallin/ballin-scripts/issues/185). See the
+deployment, abuse controls, and final payload review are complete. See the
 [analytics backend notes](analytics-backend.md).
 
 ## `up` settings

--- a/docs/optional-capabilities.md
+++ b/docs/optional-capabilities.md
@@ -77,12 +77,6 @@ Disable persistently:
 ballin_config set analytics.enabled false
 ```
 
-Disable for one environment:
-
-```shell
-BALLIN_NO_ANALYTICS=1
-```
-
 ## `up` settings
 
 Change a setting with `ballin_config set up.<name> true` or

--- a/docs/optional-capabilities.md
+++ b/docs/optional-capabilities.md
@@ -68,13 +68,8 @@ them before continuing.
 ## Analytics
 
 `ballin-scripts` can send minimal anonymous active-install analytics after the
-installer shows a first-run notice. The goal is maintenance visibility: whether
-there are active installs, which top-level commands are used, and whether those
-commands succeed or fail.
-
-Analytics are enabled after the notice unless disabled by config, environment,
-or CI detection. Analytics failures are ignored and never change command output,
-side effects, or exit status.
+installer shows a first-run notice. It is for maintenance visibility: active
+installs, top-level command usage, and command success or failure.
 
 Disable analytics persistently:
 
@@ -88,12 +83,11 @@ Disable analytics for one environment:
 BALLIN_NO_ANALYTICS=1
 ```
 
-CI environments never send analytics.
-
-The local installer creates a random install ID under the checkout's
-`.analytics/` directory when analytics are enabled. That ID lets the backend
-count active installs across days. The backend hashes the install ID before
-storage.
+Analytics are enabled after the notice unless disabled by config, environment,
+or CI detection. CI never sends analytics. Analytics failures are ignored and
+never change command output, side effects, or exit status. The installer creates
+a random local install ID under `.analytics/` so the backend can count active
+installs across days; the backend hashes it before storage.
 
 Allowed event fields:
 
@@ -114,12 +108,11 @@ Analytics never send command arguments, usernames, local paths, Gist IDs or
 URLs, dotfile contents, package lists, editor settings or extensions, raw
 errors, command output, environment variables, or config values.
 
-The planned backend is a small Cloudflare Worker with D1 storage. It stores
+The planned backend is a small Cloudflare Worker with D1. It stores
 server-hashed daily install IDs and aggregate command, status, duration,
-version, Node, and OS counts, then deletes rows older than 395 days. The
-production endpoint is not enabled until the backend deployment, abuse controls,
-and final payload review are complete. See the
-[analytics backend notes](analytics-backend.md) for deployment details.
+version, Node, and OS counts, then deletes rows older than 395 days. Production
+sends stay disabled until deployment, abuse controls, and final payload review
+are complete. See the [analytics backend notes](analytics-backend.md).
 
 ## `up` settings
 

--- a/docs/optional-capabilities.md
+++ b/docs/optional-capabilities.md
@@ -67,13 +67,59 @@ them before continuing.
 
 ## Analytics
 
-`ballin-scripts` can send anonymous usage analytics.
+`ballin-scripts` can send minimal anonymous active-install analytics after the
+installer shows a first-run notice. The goal is maintenance visibility: whether
+there are active installs, which top-level commands are used, and whether those
+commands succeed or fail.
+
+Analytics are enabled after the notice unless disabled by config, environment,
+or CI detection. Analytics failures are ignored and never change command output,
+side effects, or exit status.
 
 Disable analytics persistently:
 
 ```shell
 ballin_config set analytics.enabled false
 ```
+
+Disable analytics for one environment:
+
+```shell
+BALLIN_NO_ANALYTICS=1
+```
+
+CI environments never send analytics.
+
+The local installer creates a random install ID under the checkout's
+`.analytics/` directory when analytics are enabled. That ID lets the backend
+count active installs across days. The backend hashes the install ID before
+storage.
+
+Allowed event fields:
+
+- schema version
+- random install ID
+- date bucket, such as `YYYY-MM-DD`
+- command name for currently instrumented top-level commands: `up`, `gu`,
+  `ballin_update`, and `ballin`
+- status: `success`, `failure`, or `unknown`
+- coarse duration bucket: `unknown`, `<1s`, `1-10s`, `10-60s`, `1-10m`, or
+  `10m+`
+- `ballin-scripts` version
+- Node.js major version
+- OS family: `darwin`, `linux`, `win32`, or `unknown`
+- coarse OS version
+
+Analytics never send command arguments, usernames, local paths, Gist IDs or
+URLs, dotfile contents, package lists, editor settings or extensions, raw
+errors, command output, environment variables, or config values.
+
+The planned backend is a small Cloudflare Worker with D1 storage. It stores
+server-hashed daily install IDs and aggregate command, status, duration,
+version, Node, and OS counts, then deletes rows older than 395 days. The
+production endpoint is not enabled until the backend deployment, abuse controls,
+and final payload review are complete. See the
+[analytics backend notes](analytics-backend.md) for deployment details.
 
 ## `up` settings
 

--- a/docs/optional-capabilities.md
+++ b/docs/optional-capabilities.md
@@ -67,9 +67,9 @@ them before continuing.
 
 ## Analytics
 
-`ballin-scripts` can send minimal anonymous active-install analytics after a
-first-run notice. See [Analytics](analytics.md) for what is sent, what is never
-sent, and how long it is kept.
+`ballin-scripts` can send minimal anonymous usage analytics after a first-run
+notice. See [Analytics](analytics.md) for what is sent, what is never sent, and
+how long it is kept.
 
 Disable persistently:
 

--- a/docs/optional-capabilities.md
+++ b/docs/optional-capabilities.md
@@ -71,13 +71,13 @@ them before continuing.
 installer shows a first-run notice. It is for maintenance visibility: active
 installs, top-level command usage, and command success or failure.
 
-Disable analytics persistently:
+Disable persistently:
 
 ```shell
 ballin_config set analytics.enabled false
 ```
 
-Disable analytics for one environment:
+Disable for one environment:
 
 ```shell
 BALLIN_NO_ANALYTICS=1
@@ -89,7 +89,7 @@ never change command output, side effects, or exit status. The installer creates
 a random local install ID under `.analytics/` so the backend can count active
 installs across days; the backend hashes it before storage.
 
-Allowed event fields:
+Sent fields:
 
 - schema version
 - random install ID
@@ -104,15 +104,14 @@ Allowed event fields:
 - OS family: `darwin`, `linux`, `win32`, or `unknown`
 - coarse OS version
 
-Analytics never send command arguments, usernames, local paths, Gist IDs or
-URLs, dotfile contents, package lists, editor settings or extensions, raw
-errors, command output, environment variables, or config values.
+Never sent: command arguments, usernames, local paths, Gist IDs or URLs,
+dotfile contents, package lists, editor settings or extensions, raw errors,
+command output, environment variables, or config values.
 
-The planned backend is a small Cloudflare Worker with D1. It stores
-server-hashed daily install IDs and aggregate command, status, duration,
-version, Node, and OS counts, then deletes rows older than 395 days. Production
-sends stay disabled until deployment, abuse controls, and final payload review
-are complete; that follow-up is tracked in
+Backend: a small Cloudflare Worker with D1 stores server-hashed daily install
+IDs plus aggregate command, status, duration, version, Node, and OS counts. Rows
+older than 395 days are deleted. Production sends stay disabled until
+deployment, abuse controls, and final payload review are complete in
 [#185](https://github.com/JBallin/ballin-scripts/issues/185). See the
 [analytics backend notes](analytics-backend.md).
 

--- a/docs/optional-capabilities.md
+++ b/docs/optional-capabilities.md
@@ -67,9 +67,9 @@ them before continuing.
 
 ## Analytics
 
-`ballin-scripts` can send minimal anonymous active-install analytics after the
-installer shows a first-run notice. It is for maintenance visibility: active
-installs, top-level command usage, and command success or failure.
+`ballin-scripts` can send minimal anonymous active-install analytics after a
+first-run notice. See [Analytics](analytics.md) for what is sent, what is never
+sent, retention, and production-send status.
 
 Disable persistently:
 
@@ -82,37 +82,6 @@ Disable for one environment:
 ```shell
 BALLIN_NO_ANALYTICS=1
 ```
-
-Analytics are enabled after the notice unless disabled by config, environment,
-or CI detection. CI never sends analytics. Analytics failures are ignored and
-never change command output, side effects, or exit status. The installer creates
-a random local install ID under `.analytics/` so the backend can count active
-installs across days; the backend hashes it before storage.
-
-Sent fields:
-
-- schema version
-- random install ID
-- date bucket, such as `YYYY-MM-DD`
-- command name for currently instrumented top-level commands: `up`, `gu`,
-  `ballin_update`, and `ballin`
-- status: `success`, `failure`, or `unknown`
-- coarse duration bucket: `unknown`, `<1s`, `1-10s`, `10-60s`, `1-10m`, or
-  `10m+`
-- `ballin-scripts` version
-- Node.js major version
-- OS family: `darwin`, `linux`, `win32`, or `unknown`
-- coarse OS version
-
-Never sent: command arguments, usernames, local paths, Gist IDs or URLs,
-dotfile contents, package lists, editor settings or extensions, raw errors,
-command output, environment variables, or config values.
-
-Backend: a small Cloudflare Worker with D1 stores server-hashed daily install
-IDs plus aggregate command, status, duration, version, Node, and OS counts. Rows
-older than 395 days are deleted. Production sends stay disabled until
-deployment, abuse controls, and final payload review are complete. See the
-[analytics backend notes](analytics-backend.md).
 
 ## `up` settings
 

--- a/docs/optional-capabilities.md
+++ b/docs/optional-capabilities.md
@@ -112,7 +112,9 @@ The planned backend is a small Cloudflare Worker with D1. It stores
 server-hashed daily install IDs and aggregate command, status, duration,
 version, Node, and OS counts, then deletes rows older than 395 days. Production
 sends stay disabled until deployment, abuse controls, and final payload review
-are complete. See the [analytics backend notes](analytics-backend.md).
+are complete; that follow-up is tracked in
+[#185](https://github.com/JBallin/ballin-scripts/issues/185). See the
+[analytics backend notes](analytics-backend.md).
 
 ## `up` settings
 

--- a/install.sh
+++ b/install.sh
@@ -4,6 +4,7 @@ printf '%s\n' "🏀 let's ball..."
 repo_dir="$HOME/.ballin-scripts"
 ballin_config="$repo_dir/bin/ballin_config"
 docs_url='https://github.com/JBallin/ballin-scripts/blob/main/docs/README.md'
+analytics_docs_url='https://github.com/JBallin/ballin-scripts/blob/main/docs/analytics.md'
 required_node_version='24.12'
 
 ################################## CLONE REPO ##################################
@@ -196,7 +197,7 @@ fi
 
   ############################## ANALYTICS SETUP ###############################
   if [ -f "$repo_dir/commands/install_setup.ts" ]; then
-    node "$repo_dir/commands/install_setup.ts" setup-analytics "$repo_dir" || :
+    node "$repo_dir/commands/install_setup.ts" setup-analytics "$repo_dir" "$analytics_docs_url" || :
   fi
 
   ############################## SYMLINK BINARIES ##############################

--- a/test/install.test.ts
+++ b/test/install.test.ts
@@ -60,6 +60,7 @@ if [ "$1" = "$HOME/.ballin-scripts/commands/install_setup.ts" ]; then
   fi
   if [ "$1" = 'setup-analytics' ]; then
     repo_dir="$2"
+    docs_url="$3"
     config_json=$(<"$repo_dir/ballin.config.json")
     case "$config_json" in
       *'"enabled":"false"'*) exit 0 ;;
@@ -70,6 +71,7 @@ if [ "$1" = "$HOME/.ballin-scripts/commands/install_setup.ts" ]; then
     mkdir -p "$repo_dir/.analytics"
     printf '%s\\n' '826f9faa-9995-4f66-a01b-73b4f7aebdf1' > "$repo_dir/.analytics/install-id"
     printf '%s\\n' 'ballin-scripts collects minimal anonymous active-install analytics after this notice.'
+    printf '%s\\n' "Details: $docs_url"
     exit 0
   fi
   if [ "$1" != 'symlink-binaries' ]; then

--- a/test/install.test.ts
+++ b/test/install.test.ts
@@ -69,7 +69,7 @@ if [ "$1" = "$HOME/.ballin-scripts/commands/install_setup.ts" ]; then
     fi
     mkdir -p "$repo_dir/.analytics"
     printf '%s\\n' '826f9faa-9995-4f66-a01b-73b4f7aebdf1' > "$repo_dir/.analytics/install-id"
-    printf '%s\\n' 'ballin-scripts collects minimal anonymous active-install analytics after this notice.'
+    printf '%s\\n' 'ballin-scripts collects minimal anonymous active-install analytics after this notice to understand active installs, top-level command usage, and success or failure.'
     exit 0
   fi
   if [ "$1" != 'symlink-binaries' ]; then

--- a/test/install.test.ts
+++ b/test/install.test.ts
@@ -79,7 +79,7 @@ if [ "$1" = "$HOME/.ballin-scripts/commands/install_setup.ts" ]; then
     fi
     mkdir -p "$repo_dir/.analytics"
     printf '%s\\n' '826f9faa-9995-4f66-a01b-73b4f7aebdf1' > "$repo_dir/.analytics/install-id"
-    printf '%s\\n' 'ballin-scripts collects minimal anonymous active-install analytics after this notice.'
+    printf '%s\\n' 'ballin-scripts collects minimal anonymous usage analytics after this notice.'
     printf '%s\\n' "Details: $docs_url"
     exit 0
   fi

--- a/test/install.test.ts
+++ b/test/install.test.ts
@@ -69,7 +69,7 @@ if [ "$1" = "$HOME/.ballin-scripts/commands/install_setup.ts" ]; then
     fi
     mkdir -p "$repo_dir/.analytics"
     printf '%s\\n' '826f9faa-9995-4f66-a01b-73b4f7aebdf1' > "$repo_dir/.analytics/install-id"
-    printf '%s\\n' 'ballin-scripts collects minimal anonymous command analytics.'
+    printf '%s\\n' 'ballin-scripts collects minimal anonymous active-install analytics after this notice.'
     exit 0
   fi
   if [ "$1" != 'symlink-binaries' ]; then

--- a/test/install.test.ts
+++ b/test/install.test.ts
@@ -69,7 +69,7 @@ if [ "$1" = "$HOME/.ballin-scripts/commands/install_setup.ts" ]; then
     fi
     mkdir -p "$repo_dir/.analytics"
     printf '%s\\n' '826f9faa-9995-4f66-a01b-73b4f7aebdf1' > "$repo_dir/.analytics/install-id"
-    printf '%s\\n' 'ballin-scripts collects minimal anonymous active-install analytics after this notice to understand active installs, top-level command usage, and success or failure.'
+    printf '%s\\n' 'ballin-scripts collects minimal anonymous active-install analytics after this notice.'
     exit 0
   fi
   if [ "$1" != 'symlink-binaries' ]; then

--- a/test/install_setup.test.ts
+++ b/test/install_setup.test.ts
@@ -5,6 +5,7 @@ const os = require('os');
 const path = require('path');
 const {
   analyticsNotice,
+  analyticsNoticeFor,
 } = require('../commands/analytics.ts');
 const {
   configure,
@@ -296,13 +297,14 @@ describe('install setup', () => {
       installSetupPath,
       'setup-analytics',
       repoDir,
+      docsUrl,
     ], {
       encoding: 'utf8',
       env: childEnv,
     });
 
     assert.equal(result.status, 0, result.stderr);
-    assert.include(result.stdout, analyticsNotice);
+    assert.include(result.stdout, analyticsNoticeFor(docsUrl));
     assert.match(readInstallId(), /^[0-9a-f-]{36}\n$/);
   });
 


### PR DESCRIPTION
Closes #169
Parent: #82
Follow-up: #185

## Summary

- add a standalone user-facing analytics doc for consent, payload, non-payload, and retention
- keep optional capabilities concise and link to the analytics doc for details
- shorten the installer notice and link it to the analytics doc
- keep backend docs focused on deployment and data policy without public issue references

## Validation

- npm test (225 passing)