### PR TITLE
[codex] Converge install and update setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,5 +173,5 @@ gu read zshrc.sh
 | `up` | Updates Homebrew, macOS, App Store apps, optional Node.js/npm tools, `ballin-scripts`, and optional backups. |
 | `gu` | Backs up dotfiles, editor settings, package lists, and tool state to a private Gist. |
 | `ballin_config` | Reads and updates local `ballin-scripts` settings. |
-| `ballin_update` | Pulls the latest `ballin-scripts` changes and reruns typed setup. |
+| `ballin_update` | Pulls the latest `ballin-scripts` changes and refreshes local setup. |
 | `ballin_uninstall` | Removes installed command symlinks and the local checkout. |

--- a/README.md
+++ b/README.md
@@ -173,5 +173,5 @@ gu read zshrc.sh
 | `up` | Updates Homebrew, macOS, App Store apps, optional Node.js/npm tools, `ballin-scripts`, and optional backups. |
 | `gu` | Backs up dotfiles, editor settings, package lists, and tool state to a private Gist. |
 | `ballin_config` | Reads and updates local `ballin-scripts` settings. |
-| `ballin_update` | Pulls the latest `ballin-scripts` changes and refreshes local setup. |
+| `ballin_update` | Updates `ballin-scripts` itself and refreshes installed commands and configuration. |
 | `ballin_uninstall` | Removes installed command symlinks and the local checkout. |

--- a/README.md
+++ b/README.md
@@ -173,5 +173,5 @@ gu read zshrc.sh
 | `up` | Updates Homebrew, macOS, App Store apps, optional Node.js/npm tools, `ballin-scripts`, and optional backups. |
 | `gu` | Backs up dotfiles, editor settings, package lists, and tool state to a private Gist. |
 | `ballin_config` | Reads and updates local `ballin-scripts` settings. |
-| `ballin_update` | Pulls the latest `ballin-scripts` changes and reruns the installer. |
+| `ballin_update` | Pulls the latest `ballin-scripts` changes and reruns typed setup. |
 | `ballin_uninstall` | Removes installed command symlinks and the local checkout. |

--- a/commands/ballin_update.ts
+++ b/commands/ballin_update.ts
@@ -3,124 +3,33 @@ const {
   runWithCommandAnalytics,
 } = require('./analytics.ts');
 const {
-  isDirectory,
-  runCommand,
   runVisibleCommand,
   writeStdoutLine,
 } = require('./commandHelpers.ts');
+const {
+  commandEnv,
+  updateInstalledRepo,
+} = require('./repo_update.ts');
 
-import type { StdioOptions } from 'child_process';
-
-const commandEnv = (cwd: string): NodeJS.ProcessEnv => ({
-  ...process.env,
-  PWD: cwd,
-});
-
-const runGit = (args: string[], cwd: string, stdio: StdioOptions): number | null => (
-  runCommand('git', args, {
-    cwd,
-    env: commandEnv(cwd),
-    stdio,
-  }).status
-);
-
-const runGitQuiet = (args: string[], cwd: string): number | null => (
-  runGit(args, cwd, 'ignore')
-);
-
-const updateBranch = 'main';
-const updateRemoteRef = `origin/${updateBranch}`;
-
-const runFetch = (cwd: string): number | null => (
-  runGit(
-    ['fetch', 'origin', `+${updateBranch}:refs/remotes/origin/${updateBranch}`],
-    cwd,
-    ['inherit', 'ignore', 'inherit'],
-  )
-);
-
-const isMergeInProgress = (cwd: string): boolean => (
-  runGitQuiet(['rev-parse', '-q', '--verify', 'MERGE_HEAD'], cwd) === 0
-);
-
-const stashChanges = (repoDir: string, recoveryContext: string): boolean => {
-  if (isMergeInProgress(repoDir) && runGitQuiet(['merge', '--abort'], repoDir) !== 0) {
-    writeStdoutLine(`git merge abort failed during ${recoveryContext}.`);
-    return false;
-  }
-
-  if (runGitQuiet(['stash', 'push', '--include-untracked'], repoDir) !== 0) {
-    writeStdoutLine(`git stash failed during ${recoveryContext}.`);
-    return false;
-  }
-
-  return true;
-};
-
-const checkoutUpdateBranch = (repoDir: string): boolean => {
-  if (runGitQuiet(['checkout', updateBranch], repoDir) === 0) {
-    return true;
-  }
-
-  writeStdoutLine(`git checkout ${updateBranch} failed. stashing changes and trying again...`);
-
-  if (!stashChanges(repoDir, 'checkout recovery')) {
-    return false;
-  }
-
-  if (runGitQuiet(['checkout', updateBranch], repoDir) !== 0) {
-    writeStdoutLine('git checkout failed during checkout recovery.');
-    return false;
-  }
-
-  return true;
-};
+const docsUrl = 'https://github.com/JBallin/ballin-scripts/blob/main/docs/README.md';
 
 function runBallinUpdateCommand(): void {
   const repoDir = path.join(process.env.HOME ?? '', '.ballin-scripts');
 
   writeStdoutLine('👟 getting fresh kicks...');
 
-  if (!isDirectory(repoDir)) {
-    writeStdoutLine(`install directory not found: ${repoDir}`);
+  if (!updateInstalledRepo(repoDir)) {
     process.exitCode = 1;
     return;
-  }
-
-  if (runFetch(repoDir) !== 0) {
-    writeStdoutLine(`git fetch origin ${updateBranch} failed`);
-    process.exitCode = 1;
-    return;
-  }
-
-  if (!checkoutUpdateBranch(repoDir)) {
-    process.exitCode = 1;
-    return;
-  }
-
-  if (runGitQuiet(['merge', updateRemoteRef], repoDir) !== 0) {
-    writeStdoutLine('git merge failed. stashing changes and trying again...');
-
-    if (!stashChanges(repoDir, 'merge recovery')) {
-      process.exitCode = 1;
-      return;
-    }
-
-    if (runGitQuiet(['checkout', updateBranch], repoDir) !== 0) {
-      writeStdoutLine('git checkout failed during merge recovery.');
-      process.exitCode = 1;
-      return;
-    }
-
-    if (runGitQuiet(['merge', updateRemoteRef], repoDir) !== 0) {
-      writeStdoutLine('git merge failed during merge recovery.');
-      process.exitCode = 1;
-      return;
-    }
   }
 
   writeStdoutLine();
-  process.exitCode = runVisibleCommand('./install.sh', [], {
+  process.exitCode = runVisibleCommand(process.execPath, [
+    'commands/install_setup.ts',
+    'setup',
+    repoDir,
+    docsUrl,
+  ], {
     cwd: repoDir,
     env: commandEnv(repoDir),
   });

--- a/commands/install_setup.ts
+++ b/commands/install_setup.ts
@@ -4,7 +4,10 @@ const {
   ensureAnalyticsInstallId,
 } = require('./analytics.ts');
 const {
+  commandExists,
+  readCommandOutput,
   runCommand,
+  runVisibleCommand,
   writeStdoutLine,
 } = require('./commandHelpers.ts');
 
@@ -34,25 +37,62 @@ const setupAnalytics = (repoDir: string): boolean => {
   return true;
 };
 
-const configure = (repoDir: string, docsUrl: string): boolean => {
-  const configPath = path.join(repoDir, 'ballin.config.json');
-  const defaultConfigPath = path.join(repoDir, 'config', '.defaultConfig.json');
-  const updateConfigPath = path.join(repoDir, 'config', 'updateConfig.ts');
+const configPathFor = (repoDir: string): string => path.join(repoDir, 'ballin.config.json');
 
-  if (!fs.existsSync(configPath)) {
+const commandEnv = (cwd: string, extraEnv: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv => ({
+  ...process.env,
+  ...extraEnv,
+  PWD: cwd,
+});
+
+const readLineFromStdin = (): string => {
+  const input = Buffer.alloc(1);
+  let line = '';
+
+  while (true) {
+    let bytesRead = 0;
     try {
-      fs.copyFileSync(defaultConfigPath, configPath);
+      bytesRead = fs.readSync(0, input, 0, 1, null);
     } catch {
-      return false;
+      return line;
     }
-    writeStdoutLine("\n🧠 Created 'ballin.config.json' file in root using default settings");
-    return true;
-  }
 
-  const childEnv: NodeJS.ProcessEnv = {
-    ...process.env,
-    PWD: path.join(repoDir, 'config'),
-  };
+    if (bytesRead === 0) {
+      return line;
+    }
+
+    const character = input.toString('utf8', 0, bytesRead);
+    if (character === '\n') {
+      return line;
+    }
+    if (character !== '\r') {
+      line += character;
+    }
+  }
+};
+
+const prompt = (message: string): string => {
+  process.stdout.write(message);
+  return readLineFromStdin();
+};
+
+const readJsonObject = (filePath: string): ConfigObject | null => {
+  try {
+    const parsed = JSON.parse(fs.readFileSync(filePath, 'utf8')) as unknown;
+    return isConfigObject(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+};
+
+const configHasGuHost = (repoDir: string): boolean => {
+  const config = readJsonObject(configPathFor(repoDir));
+  return isConfigObject(config?.gu) && Object.prototype.hasOwnProperty.call(config.gu, 'host');
+};
+
+const updateConfig = (repoDir: string, docsUrl: string): boolean => {
+  const updateConfigPath = path.join(repoDir, 'config', 'updateConfig.ts');
+  const childEnv = commandEnv(path.join(repoDir, 'config'));
   delete childEnv.BALLIN_TEST_CONFIG_PATH;
 
   const updateResult = runCommand(process.execPath, [updateConfigPath], {
@@ -72,6 +112,188 @@ const configure = (repoDir: string, docsUrl: string): boolean => {
   if (updateOutput) {
     writeStdoutLine(`\n🙌 ${updateOutput}`);
     writeStdoutLine(`\n👀 Docs: ${docsUrl}`);
+  }
+
+  return true;
+};
+
+const configure = (repoDir: string, docsUrl: string): boolean => {
+  const configPath = configPathFor(repoDir);
+  const defaultConfigPath = path.join(repoDir, 'config', '.defaultConfig.json');
+
+  if (!fs.existsSync(configPath)) {
+    try {
+      fs.copyFileSync(defaultConfigPath, configPath);
+    } catch {
+      return false;
+    }
+    writeStdoutLine("\n🧠 Created 'ballin.config.json' file in root using default settings");
+    return true;
+  }
+
+  return updateConfig(repoDir, docsUrl);
+};
+
+const ballinConfigPath = (repoDir: string): string => path.join(repoDir, 'bin', 'ballin_config');
+
+const runBallinConfigGet = (repoDir: string, key: string): string | null => {
+  const result = runCommand(ballinConfigPath(repoDir), ['get', key], {
+    cwd: repoDir,
+    env: commandEnv(repoDir),
+  });
+
+  if (result.status !== 0 || result.error) {
+    return null;
+  }
+
+  return result.stdout.trimEnd();
+};
+
+const runBallinConfigSet = (repoDir: string, key: string, value: string): boolean => (
+  runVisibleCommand(ballinConfigPath(repoDir), ['set', key, value], {
+    cwd: repoDir,
+    env: commandEnv(repoDir),
+  }) === 0
+);
+
+const runGh = (
+  repoDir: string,
+  host: string,
+  args: string[],
+  options: { quiet?: boolean } = {},
+) => runCommand('gh', args, {
+  cwd: repoDir,
+  env: commandEnv(repoDir, { GH_HOST: host }),
+  stdio: options.quiet ? ['ignore', 'pipe', 'ignore'] : ['ignore', 'pipe', 'inherit'],
+});
+
+const configureGist = (repoDir: string, docsUrl: string, guHostExisted: boolean): boolean => {
+  let guHost = runBallinConfigGet(repoDir, 'gu.host');
+  const guId = runBallinConfigGet(repoDir, 'gu.id');
+
+  if (guHost === null || guId === null) {
+    return false;
+  }
+
+  if (process.env.BALLIN_GU_HOST) {
+    if (!runBallinConfigSet(repoDir, 'gu.host', process.env.BALLIN_GU_HOST)) {
+      return false;
+    }
+    guHost = runBallinConfigGet(repoDir, 'gu.host');
+    if (guHost === null) {
+      return false;
+    }
+  } else if (guId === 'null' || !guHostExisted) {
+    writeStdoutLine();
+    const inputHost = prompt(`🤔 What GitHub host should be used for Gist backups? [${guHost}] `);
+    if (inputHost) {
+      if (!runBallinConfigSet(repoDir, 'gu.host', inputHost)) {
+        return false;
+      }
+      guHost = runBallinConfigGet(repoDir, 'gu.host');
+      if (guHost === null) {
+        return false;
+      }
+    }
+  }
+
+  if (!commandExists('gh')) {
+    writeStdoutLine('\n⚠️  ERROR: GitHub CLI is required for Gist backup setup.');
+    writeStdoutLine('\nInstall gh, authenticate it, then run this installer again.');
+    writeStdoutLine(`\nSetup guide: ${docsUrl}`);
+    writeStdoutLine(`\nRun after installing gh:\n  gh auth login --hostname ${guHost}`);
+    return false;
+  }
+
+  const authResult = runGh(repoDir, guHost, ['auth', 'status', '--hostname', guHost], { quiet: true });
+  if (authResult.status !== 0 || authResult.error) {
+    writeStdoutLine(`\n⚠️  ERROR: gh is not authenticated for ${guHost}.`);
+    writeStdoutLine(`\nRun:\n  gh auth login --hostname ${guHost}`);
+    writeStdoutLine('\nThen run this installer again.');
+    return false;
+  }
+
+  if (guId !== 'null') {
+    return true;
+  }
+
+  const gistDescription = '### Backup of your dev environment\n'
+    + 'Created by [ballin-scripts](https://github.com/JBallin/ballin-scripts)\n';
+
+  writeStdoutLine();
+  const hasBackup = prompt('🤔 Do you already have a ballin-scripts backup gist? [y/N] ');
+  if (hasBackup === 'y' || hasBackup === 'Y') {
+    writeStdoutLine('\nWelcome Back!');
+    let validGistId = false;
+
+    while (!validGistId) {
+      const gistId = prompt('Enter your gist ID: ');
+      const markerResult = runGh(
+        repoDir,
+        guHost,
+        ['gist', 'view', gistId, '--raw', '--filename', '.MyConfig.md'],
+        { quiet: true },
+      );
+
+      if (markerResult.status === 0 && markerResult.stdout === gistDescription) {
+        writeStdoutLine('\n👍 Storing your previous gist ID in your config:');
+        const configPath = configPathFor(repoDir);
+        const previousConfig = fs.readFileSync(configPath, 'utf8');
+        const restoreResult = runGh(
+          repoDir,
+          guHost,
+          ['gist', 'view', gistId, '--raw', '--filename', 'ballin_config'],
+          { quiet: true },
+        );
+
+        if (restoreResult.status === 0 && !restoreResult.error) {
+          fs.writeFileSync(configPath, restoreResult.stdout);
+          if (!updateConfig(repoDir, docsUrl)) {
+            fs.writeFileSync(configPath, previousConfig);
+            return false;
+          }
+          writeStdoutLine('\n♻️  Restored ballin.config.json from your backup gist.');
+        } else {
+          writeStdoutLine('\nℹ️  No ballin_config snapshot was found in that gist; keeping the local config defaults.');
+        }
+
+        if (!runBallinConfigSet(repoDir, 'gu.id', gistId)) {
+          return false;
+        }
+        validGistId = true;
+      } else {
+        writeStdoutLine(`\n⚠️  INVALID: Expected backup marker in gist '${gistId}'.`);
+      }
+    }
+  }
+
+  if (runBallinConfigGet(repoDir, 'gu.id') === 'null') {
+    const markerPath = path.join(repoDir, '.MyConfig.md');
+    fs.writeFileSync(markerPath, gistDescription);
+
+    const createResult = runGh(repoDir, guHost, ['gist', 'create', '.MyConfig.md', '--desc', gistDescription]);
+    if (createResult.status !== 0 || createResult.error) {
+      fs.rmSync(markerPath, { force: true });
+      return false;
+    }
+
+    const gistUrl = createResult.stdout.trimEnd();
+    writeStdoutLine(`\n💥 Created a secret gist titled '.MyConfig' at the following URL:\n${gistUrl}`);
+
+    const gistId = gistUrl.split('/').pop() ?? gistUrl;
+    writeStdoutLine('\n🧳 Storing your new gist ID in your config...');
+    if (!runBallinConfigSet(repoDir, 'gu.id', gistId)) {
+      fs.rmSync(markerPath, { force: true });
+      return false;
+    }
+
+    const guCachePath = path.join(repoDir, '.gu-cache');
+    if (fs.existsSync(guCachePath)) {
+      fs.rmSync(guCachePath, { recursive: true, force: true });
+      writeStdoutLine('\n🗑  Deleted existing .gu-cache folder');
+    }
+
+    fs.rmSync(markerPath, { force: true });
   }
 
   return true;
@@ -104,6 +326,63 @@ const symlinkBinaries = (repoDir: string, binDir: string): boolean => {
   return true;
 };
 
+const resolveBinDir = (): string | null => {
+  if (commandExists('brew')) {
+    const brewPrefix = readCommandOutput('brew', ['--prefix']);
+    if (brewPrefix !== null) {
+      return path.join(brewPrefix.trimEnd(), 'bin');
+    }
+  }
+
+  const homeDir = process.env.HOME;
+  return homeDir ? path.join(homeDir, '.local', 'bin') : null;
+};
+
+const validateBinDirInPath = (binDir: string): boolean => {
+  const envPath = process.env.PATH ?? '';
+  if (envPath.split(path.delimiter).includes(binDir)) {
+    return true;
+  }
+
+  writeStdoutLine(`\n⚠️  ERROR: ${binDir} doesn't seem to be in your path.`);
+  writeStdoutLine(`Add 'export PATH="${binDir}:$PATH"' to your shell profile.`);
+  writeStdoutLine('and open a new terminal window and run this installation again.');
+  return false;
+};
+
+const setup = (repoDir: string, docsUrl: string): boolean => {
+  const binDir = resolveBinDir();
+  if (!binDir || !validateBinDirInPath(binDir)) {
+    return false;
+  }
+
+  const configExisted = fs.existsSync(configPathFor(repoDir));
+  const guHostExisted = configExisted && configHasGuHost(repoDir);
+
+  if (!configure(repoDir, docsUrl)) {
+    writeStdoutLine('\n⚠️  ERROR: Unable to create or update ballin.config.json');
+    return false;
+  }
+
+  if (!configureGist(repoDir, docsUrl, guHostExisted)) {
+    writeStdoutLine('\n⚠️  ERROR: Unable to configure Gist backup');
+    return false;
+  }
+
+  setupAnalytics(repoDir);
+
+  if (!symlinkBinaries(repoDir, binDir)) {
+    return false;
+  }
+
+  if (!configExisted && fs.existsSync(configPathFor(repoDir))) {
+    writeStdoutLine(`\n👀 Docs: ${docsUrl}`);
+  }
+
+  writeStdoutLine('\n😎 ballin!');
+  return true;
+};
+
 const runInstallSetupCli = (): void => {
   const [, , command, repoDir, option] = process.argv;
 
@@ -117,13 +396,18 @@ const runInstallSetupCli = (): void => {
     return;
   }
 
+  if (command === 'setup' && repoDir && option) {
+    process.exitCode = setup(repoDir, option) ? 0 : 1;
+    return;
+  }
+
   if (command === 'setup-analytics' && repoDir) {
     process.exitCode = setupAnalytics(repoDir) ? 0 : 1;
     return;
   }
 
   if (!command || !repoDir || !option) {
-    writeStdoutLine('Usage: install_setup.ts <configure|symlink-binaries|setup-analytics> <repo-dir> [docs-url|bin-dir]');
+    writeStdoutLine('Usage: install_setup.ts <configure|setup|symlink-binaries|setup-analytics> <repo-dir> [docs-url|bin-dir]');
     process.exitCode = 1;
     return;
   }
@@ -138,7 +422,9 @@ if (require.main === module) {
 
 module.exports = {
   configure,
+  configureGist,
   runInstallSetupCli,
+  setup,
   setupAnalytics,
   symlinkBinaries,
 };

--- a/commands/repo_update.ts
+++ b/commands/repo_update.ts
@@ -1,0 +1,130 @@
+const {
+  isDirectory,
+  runCommand,
+  writeStdoutLine,
+} = require('./commandHelpers.ts');
+
+import type { StdioOptions } from 'child_process';
+
+const updateBranch = 'main';
+const updateRemoteRef = `origin/${updateBranch}`;
+
+const commandEnv = (cwd: string): NodeJS.ProcessEnv => ({
+  ...process.env,
+  PWD: cwd,
+});
+
+const runGit = (args: string[], cwd: string, stdio: StdioOptions): number | null => (
+  runCommand('git', args, {
+    cwd,
+    env: commandEnv(cwd),
+    stdio,
+  }).status
+);
+
+const runGitQuiet = (args: string[], cwd: string): number | null => (
+  runGit(args, cwd, 'ignore')
+);
+
+const runFetch = (cwd: string): number | null => (
+  runGit(
+    ['fetch', 'origin', `+${updateBranch}:refs/remotes/origin/${updateBranch}`],
+    cwd,
+    ['inherit', 'ignore', 'inherit'],
+  )
+);
+
+const isMergeInProgress = (cwd: string): boolean => (
+  runGitQuiet(['rev-parse', '-q', '--verify', 'MERGE_HEAD'], cwd) === 0
+);
+
+const stashChanges = (repoDir: string, recoveryContext: string): boolean => {
+  if (isMergeInProgress(repoDir) && runGitQuiet(['merge', '--abort'], repoDir) !== 0) {
+    writeStdoutLine(`git merge abort failed during ${recoveryContext}.`);
+    return false;
+  }
+
+  if (runGitQuiet(['stash', 'push', '--include-untracked'], repoDir) !== 0) {
+    writeStdoutLine(`git stash failed during ${recoveryContext}.`);
+    return false;
+  }
+
+  return true;
+};
+
+const checkoutUpdateBranch = (repoDir: string): boolean => {
+  if (runGitQuiet(['checkout', updateBranch], repoDir) === 0) {
+    return true;
+  }
+
+  writeStdoutLine(`git checkout ${updateBranch} failed. stashing changes and trying again...`);
+
+  if (!stashChanges(repoDir, 'checkout recovery')) {
+    return false;
+  }
+
+  if (runGitQuiet(['checkout', updateBranch], repoDir) !== 0) {
+    writeStdoutLine('git checkout failed during checkout recovery.');
+    return false;
+  }
+
+  return true;
+};
+
+const updateInstalledRepo = (repoDir: string): boolean => {
+  if (!isDirectory(repoDir)) {
+    writeStdoutLine(`install directory not found: ${repoDir}`);
+    return false;
+  }
+
+  if (runFetch(repoDir) !== 0) {
+    writeStdoutLine(`git fetch origin ${updateBranch} failed`);
+    return false;
+  }
+
+  if (!checkoutUpdateBranch(repoDir)) {
+    return false;
+  }
+
+  if (runGitQuiet(['merge', updateRemoteRef], repoDir) !== 0) {
+    writeStdoutLine('git merge failed. stashing changes and trying again...');
+
+    if (!stashChanges(repoDir, 'merge recovery')) {
+      return false;
+    }
+
+    if (runGitQuiet(['checkout', updateBranch], repoDir) !== 0) {
+      writeStdoutLine('git checkout failed during merge recovery.');
+      return false;
+    }
+
+    if (runGitQuiet(['merge', updateRemoteRef], repoDir) !== 0) {
+      writeStdoutLine('git merge failed during merge recovery.');
+      return false;
+    }
+  }
+
+  return true;
+};
+
+const runRepoUpdateCli = (): void => {
+  const [, , repoDir] = process.argv;
+
+  if (!repoDir) {
+    writeStdoutLine('Usage: repo_update.ts <repo-dir>');
+    process.exitCode = 1;
+    return;
+  }
+
+  process.exitCode = updateInstalledRepo(repoDir) ? 0 : 1;
+};
+
+if (require.main === module) {
+  runRepoUpdateCli();
+}
+
+module.exports = {
+  commandEnv,
+  runRepoUpdateCli,
+  updateInstalledRepo,
+};

--- a/install.sh
+++ b/install.sh
@@ -2,15 +2,23 @@
 printf '%s\n' "🏀 let's ball..."
 
 repo_dir="$HOME/.ballin-scripts"
-ballin_config="$repo_dir/bin/ballin_config"
 docs_url='https://github.com/JBallin/ballin-scripts/blob/main/docs/README.md'
 required_node_version='24.12'
+repo_existed=true
+
+print_stale_checkout_guidance() {
+  printf '\n⚠️  ERROR: Unable to update %s before setup.\n' "$repo_dir"
+  printf 'Update or delete %s, then run this installer again.\n' "$repo_dir"
+}
 
 ################################## CLONE REPO ##################################
+if [ ! -d "$repo_dir" ]; then
+  repo_existed=false
+fi
+
 if ! (
   cd "$HOME" || exit
-  # only clone if folder doesn't already exist
-  if [ ! -d '.ballin-scripts' ]; then
+  if [ "$repo_existed" = false ]; then
     echo ''
     if ! git clone https://github.com/JBallin/ballin-scripts.git .ballin-scripts; then
       exit 1
@@ -21,25 +29,8 @@ if ! (
   exit 1
 fi
 
-
-############################## CHECK INITIAL SETUP #############################
-if [ -x "$(command -v brew)" ]; then
-  bin_dir="$(brew --prefix)/bin"
-else
-  # Use a conventional user-owned bin directory when Homebrew is unavailable.
-  bin_dir="$HOME/.local/bin"
-fi
-
-# Check that the directory used for commands is in $PATH
-if [[ ":$PATH:" != *":$bin_dir:"* ]]; then
-  l1="$bin_dir doesn't seem to be in your path."
-  l2="Add 'export PATH=\"$bin_dir:\$PATH\"' to your shell profile."
-  l3='and open a new terminal window and run this installation again.'
-  printf '\n⚠️  ERROR: %s\n%s\n%s\n' "$l1" "$l2" "$l3"
-  unset l1 l2 l3
-  exit 1
-# Check that Node.js is available before running configuration commands
-elif [ ! -x "$(command -v node)" ]; then
+################################## CHECK NODE ##################################
+if [ ! -x "$(command -v node)" ]; then
   printf '\n⚠️  ERROR: Node.js is required.\n'
   printf '\nRecommended: install Node.js %s or newer with nvm.' "$required_node_version"
   printf '\nSetup guide: %s\n' "$docs_url"
@@ -53,175 +44,40 @@ elif [ "$(node -p "const [major, minor] = process.versions.node.split('.').map(N
   printf '\nAlternatively:\n  brew install node\n'
   printf '\nThen run this installer again.\n'
   exit 1
-else
-
-
-########################## CREATE/UPDATE CONFIG FILE #########################
-config_existed=true
-if [ ! -f "$repo_dir/ballin.config.json" ]; then
-  config_existed=false
-fi
-gu_host_existed=false
-if [ "$config_existed" = true ] \
-  && [ "$(node -e "const fs = require('fs'); const config = JSON.parse(fs.readFileSync(process.argv[1], 'utf8')); process.stdout.write(config.gu && Object.prototype.hasOwnProperty.call(config.gu, 'host') ? 'true' : 'false')" "$repo_dir/ballin.config.json" 2>/dev/null)" = 'true' ]; then
-  gu_host_existed=true
 fi
 
-# Configuration must succeed before Gist credentials or command symlinks are touched.
-if [ -f "$repo_dir/commands/install_setup.ts" ] \
-  && node "$repo_dir/commands/install_setup.ts" configure "$repo_dir" "$docs_url"; then
-  :
-else
-  if ! (
-    cd "$repo_dir/config"
-    if [ ! -f '../ballin.config.json' ]; then
-      # create config
-      if ! cp '.defaultConfig.json' '../ballin.config.json'; then
-        exit 1
-      fi
-      printf '\n%s\n' "🧠 Created 'ballin.config.json' file in root using default settings"
-    else
-      # ballin_update reruns this installer after pulling changes; add any new
-      # default options to the existing config without overwriting user settings.
-      if ! UPDATE_RESULT=$(node "$repo_dir/config/updateConfig.ts"); then
-        exit 1
-      fi
-      if [ -n "$UPDATE_RESULT" ]; then
-        printf '\n🙌 %s\n' "$UPDATE_RESULT"
-        printf '\n👀 Docs: %s\n' "$docs_url"
-      fi
+############################ UPDATE EXISTING REPO ##############################
+if [ "$repo_existed" = true ]; then
+  if [ -f "$repo_dir/commands/repo_update.ts" ]; then
+    if ! (
+      cd "$repo_dir" || exit
+      node "$repo_dir/commands/repo_update.ts" "$repo_dir"
+    ); then
+      print_stale_checkout_guidance
+      exit 1
     fi
-  ); then
-    printf '\n⚠️  ERROR: Unable to create or update ballin.config.json\n'
-    exit 1
-  fi
-fi
-
-
-#################################### GIST ####################################
-  if ! (
+  elif ! (
     cd "$repo_dir" || exit
-    gu_host="$("$ballin_config" get gu.host)"
-    gu_id="$("$ballin_config" get gu.id)"
-    if [ -n "${BALLIN_GU_HOST:-}" ]; then
-      "$ballin_config" set gu.host "$BALLIN_GU_HOST"
-      gu_host="$("$ballin_config" get gu.host)"
-    elif [ "$gu_id" = 'null' ] || [ "$gu_host_existed" = false ]; then
-      echo ''
-      read -rp "🤔 What GitHub host should be used for Gist backups? [${gu_host}] " input_host
-      if [ -n "$input_host" ]; then
-        "$ballin_config" set gu.host "$input_host"
-        gu_host="$("$ballin_config" get gu.host)"
-      fi
-    fi
-    export GH_HOST="$gu_host"
-
-    if [ ! -x "$(command -v gh)" ]; then
-      printf '\n⚠️  ERROR: GitHub CLI is required for Gist backup setup.\n'
-      printf '\nInstall gh, authenticate it, then run this installer again.\n'
-      printf '\nSetup guide: %s\n' "$docs_url"
-      printf '\nRun after installing gh:\n  gh auth login --hostname %s\n' "$gu_host"
-      exit 1
-    elif ! gh auth status --hostname "$gu_host" > /dev/null 2>&1; then
-      printf '\n⚠️  ERROR: gh is not authenticated for %s.\n' "$gu_host"
-      printf '\nRun:\n  gh auth login --hostname %s\n' "$gu_host"
-      printf '\nThen run this installer again.\n'
-      exit 1
-    elif [ "$gu_id" = 'null' ]; then
-        l1='### Backup of your dev environment'
-        l2='Created by [ballin-scripts](https://github.com/JBallin/ballin-scripts)'
-        gist_description="$l1\n$l2\n"
-
-        echo ''
-        read -rp '🤔 Do you already have a ballin-scripts backup gist? [y/N] ' YN
-        if [[ $YN == 'y' || $YN == 'Y' ]]; then
-          unset YN
-          valid_gist_id=1
-          printf '\n%s\n' 'Welcome Back!'
-          while [ "$valid_gist_id" = 1 ]; do
-            read -rep 'Enter your gist ID: ' gist_id
-            if [ "$(gh gist view "$gist_id" --raw --filename '.MyConfig.md' 2>/dev/null)" = "$(printf '%b' "$gist_description")" ]; then
-              printf '\n%s\n' '👍 Storing your previous gist ID in your config:'
-              restore_config='.ballin.config.restore.tmp'
-              previous_config='.ballin.config.restore.previous.tmp'
-              cp 'ballin.config.json' "$previous_config"
-              if gh gist view "$gist_id" --raw --filename ballin_config > "$restore_config"; then
-                cp "$restore_config" 'ballin.config.json'
-                if ! update_result=$(node "$repo_dir/config/updateConfig.ts"); then
-                  cp "$previous_config" 'ballin.config.json'
-                  rm -f "$restore_config" "$previous_config"
-                  exit 1
-                fi
-                printf '\n%s\n' '♻️  Restored ballin.config.json from your backup gist.'
-                if [ -n "$update_result" ]; then
-                  printf '\n🙌 %s\n' "$update_result"
-                  printf '\n👀 Docs: %s\n' "$docs_url"
-                fi
-              else
-                printf '\n%s\n' 'ℹ️  No ballin_config snapshot was found in that gist; keeping the local config defaults.'
-              fi
-              rm -f "$restore_config" "$previous_config"
-              "$ballin_config" set gu.id "$gist_id"
-              valid_gist_id=0
-            else
-              printf "\n⚠️  INVALID: Expected backup marker in gist '%s'.\n" "$gist_id"
-            fi
-          done
-        fi
-        unset YN gist_id valid_gist_id
-
-        if [ "$("$ballin_config" get gu.id)" = 'null' ]; then
-          printf '%b' "$gist_description" > '.MyConfig.md'
-
-          gist_url=$(gh gist create '.MyConfig.md' --desc "$gist_description")
-          printf "\n💥 Created a secret gist titled '.MyConfig' at the following URL:\n%s\n" "$gist_url"
-
-          gist_id=${gist_url##*/}
-          printf '\n%s\n' '🧳 Storing your new gist ID in your config...'
-          "$ballin_config" set gu.id "$gist_id"
-
-          if [ -d '.gu-cache' ]; then
-            rm -rf '.gu-cache'
-            printf '\n%s\n' '🗑  Deleted existing .gu-cache folder'
-          fi
-
-          unset gist_url gist_id l1 l2 gist_description
-          rm '.MyConfig.md'
-        fi
-    fi
+    git fetch origin +main:refs/remotes/origin/main \
+      && git checkout main \
+      && git merge origin/main
   ); then
-    printf '\n⚠️  ERROR: Unable to configure Gist backup\n'
+    print_stale_checkout_guidance
     exit 1
   fi
+fi
 
-  ############################## ANALYTICS SETUP ###############################
-  if [ -f "$repo_dir/commands/install_setup.ts" ]; then
-    node "$repo_dir/commands/install_setup.ts" setup-analytics "$repo_dir" || :
-  fi
+################################# TYPED SETUP ##################################
+if [ ! -f "$repo_dir/commands/install_setup.ts" ]; then
+  print_stale_checkout_guidance
+  exit 1
+fi
 
-  ############################## SYMLINK BINARIES ##############################
-  if [ -f "$repo_dir/commands/install_setup.ts" ]; then
-    if ! node "$repo_dir/commands/install_setup.ts" symlink-binaries "$repo_dir" "$bin_dir"; then
-      exit 1
-    fi
-  else
-    if ! mkdir -p "$bin_dir"; then
-      printf '\n⚠️  ERROR: Unable to create %s\n' "$bin_dir"
-      exit 1
-    fi
-
-    for bin in "$repo_dir/bin/"*; do
-      if ! ln -sfn "$bin" "$bin_dir/${bin##*/}"; then
-        printf '\n⚠️  ERROR: Unable to symlink binaries into %s\n' "$bin_dir"
-        exit 1
-      fi
-    done
-    printf '\n💪 symlinked binaries into %s\n' "$bin_dir"
-  fi
-
-  if [ "$config_existed" = false ] && [ -f "$repo_dir/ballin.config.json" ]; then
-    printf '\n👀 Docs: %s\n' "$docs_url"
-  fi
-
-  printf '\n%s\n' '😎 ballin!'
+(
+  cd "$repo_dir" || exit
+  node "$repo_dir/commands/install_setup.ts" setup "$repo_dir" "$docs_url"
+)
+setup_status=$?
+if [ "$setup_status" -ne 0 ]; then
+  exit "$setup_status"
 fi

--- a/test/ballin_update.test.ts
+++ b/test/ballin_update.test.ts
@@ -5,6 +5,7 @@ const os = require('os');
 const path = require('path');
 
 const updatePath = path.join(__dirname, '..', 'bin', 'ballin_update');
+const docsUrl = 'https://github.com/JBallin/ballin-scripts/blob/main/docs/README.md';
 type SpawnUpdateOverrides = Omit<
   import('child_process').SpawnSyncOptionsWithStringEncoding,
   'encoding' | 'env'
@@ -95,11 +96,16 @@ esac
 `);
   };
 
-  const installInstallerStub = () => {
-    writeExecutable('install.sh', `#!/usr/bin/env bash
-printf '%s|install.sh:%s\\n' "$PWD" "$*" >> "$BALLIN_UPDATE_TEST_LOG"
-exit "$FAKE_INSTALL_STATUS"
-`, repoDir);
+  const installSetupStub = () => {
+    const commandsDir = path.join(repoDir, 'commands');
+    fs.mkdirSync(commandsDir, { recursive: true });
+    fs.writeFileSync(path.join(commandsDir, 'install_setup.ts'), `const fs = require('fs');
+fs.appendFileSync(process.env.BALLIN_UPDATE_TEST_LOG, process.cwd() + '|install_setup:' + process.argv.slice(2).join(' ') + '\\n');
+if (process.env.FAKE_SETUP_SIGNAL) {
+  process.kill(process.pid, process.env.FAKE_SETUP_SIGNAL);
+}
+process.exit(Number(process.env.FAKE_SETUP_STATUS || '0'));
+`);
   };
 
   const runUpdate = (
@@ -123,7 +129,7 @@ exit "$FAKE_INSTALL_STATUS"
       FAKE_GIT_STASH_STATUS: '0',
       FAKE_GIT_FIRST_CHECKOUT_STATUS: '0',
       FAKE_GIT_RETRY_CHECKOUT_STATUS: '0',
-      FAKE_INSTALL_STATUS: '0',
+      FAKE_SETUP_STATUS: '0',
       ...env,
     },
   });
@@ -133,6 +139,8 @@ exit "$FAKE_INSTALL_STATUS"
       ? fs.readFileSync(commandLogPath, 'utf8').trim().split('\n').filter(Boolean)
       : []
   );
+
+  const setupLog = () => `${fs.realpathSync(repoDir)}|install_setup:setup ${repoDir} ${docsUrl}`;
 
   beforeEach(() => {
     testDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ballin-update-'));
@@ -149,14 +157,14 @@ exit "$FAKE_INSTALL_STATUS"
     linkCommand('cat');
     fs.symlinkSync(process.execPath, path.join(toolDir, 'node'));
     installGitStub();
-    installInstallerStub();
+    installSetupStub();
   });
 
   afterEach(() => {
     fs.rmSync(testDir, { recursive: true, force: true });
   });
 
-  it('fetches, merges, then runs the installer from the installed repository', () => {
+  it('fetches, merges, then runs the setup from the installed repository', () => {
     const result = runUpdate();
 
     assert.equal(result.status, 0, result.stderr);
@@ -166,7 +174,7 @@ exit "$FAKE_INSTALL_STATUS"
       `${repoDir}|git:fetch origin +main:refs/remotes/origin/main`,
       `${repoDir}|git:checkout main`,
       `${repoDir}|git:merge origin/main`,
-      `${repoDir}|install.sh:`,
+      setupLog(),
     ]);
   });
 
@@ -185,7 +193,7 @@ exit "$FAKE_INSTALL_STATUS"
       'fetch-stdin:secret-token',
       `${repoDir}|git:checkout main`,
       `${repoDir}|git:merge origin/main`,
-      `${repoDir}|install.sh:`,
+      setupLog(),
     ]);
   });
 
@@ -204,12 +212,12 @@ exit "$FAKE_INSTALL_STATUS"
       `${repoDir}|git:fetch origin +main:refs/remotes/origin/main`,
       `${repoDir}|git:checkout main`,
       `${repoDir}|git:merge origin/main`,
-      `${repoDir}|install.sh:`,
+      setupLog(),
     ]);
   });
 
-  it('returns the installer status when install fails after a successful merge', () => {
-    const result = runUpdate({ FAKE_INSTALL_STATUS: '27' });
+  it('returns the setup status when setup fails after a successful merge', () => {
+    const result = runUpdate({ FAKE_SETUP_STATUS: '27' });
 
     assert.equal(result.status, 27);
     assert.equal(result.stdout, '👟 getting fresh kicks...\n\n');
@@ -218,18 +226,18 @@ exit "$FAKE_INSTALL_STATUS"
       `${repoDir}|git:fetch origin +main:refs/remotes/origin/main`,
       `${repoDir}|git:checkout main`,
       `${repoDir}|git:merge origin/main`,
-      `${repoDir}|install.sh:`,
+      setupLog(),
     ]);
   });
 
-  it('reports a missing installer with the shared command error format', () => {
-    fs.rmSync(path.join(repoDir, 'install.sh'));
+  it('reports a missing setup through Node when the typed setup file is unavailable', () => {
+    fs.rmSync(path.join(repoDir, 'commands', 'install_setup.ts'));
 
     const result = runUpdate();
 
-    assert.equal(result.status, 127);
+    assert.equal(result.status, 1);
     assert.equal(result.stdout, '👟 getting fresh kicks...\n\n');
-    assert.include(result.stderr, './install.sh: command not found');
+    assert.include(result.stderr, 'Cannot find module');
     assert.deepEqual(commandLog(), [
       `${repoDir}|git:fetch origin +main:refs/remotes/origin/main`,
       `${repoDir}|git:checkout main`,
@@ -237,13 +245,8 @@ exit "$FAKE_INSTALL_STATUS"
     ]);
   });
 
-  it('uses a shell-style signal exit status when the installer is signaled', () => {
-    writeExecutable('install.sh', `#!/usr/bin/env bash
-printf '%s|install.sh:%s\\n' "$PWD" "$*" >> "$BALLIN_UPDATE_TEST_LOG"
-kill -TERM "$$"
-`, repoDir);
-
-    const result = runUpdate();
+  it('uses a shell-style signal exit status when the setup is signaled', () => {
+    const result = runUpdate({ FAKE_SETUP_SIGNAL: 'SIGTERM' });
 
     assert.equal(result.status, 143);
     assert.equal(result.stdout, '👟 getting fresh kicks...\n\n');
@@ -252,11 +255,11 @@ kill -TERM "$$"
       `${repoDir}|git:fetch origin +main:refs/remotes/origin/main`,
       `${repoDir}|git:checkout main`,
       `${repoDir}|git:merge origin/main`,
-      `${repoDir}|install.sh:`,
+      setupLog(),
     ]);
   });
 
-  it('stops before merge and install when fetch fails', () => {
+  it('stops before merge and setup when fetch fails', () => {
     const result = runUpdate({ FAKE_GIT_FETCH_STATUS: '23' });
 
     assert.equal(result.status, 1);
@@ -290,7 +293,7 @@ kill -TERM "$$"
     assert.deepEqual(commandLog(), []);
   });
 
-  it('stashes, retries checkout main, merges, and installs when initial checkout is blocked', () => {
+  it('stashes, retries checkout main, merges, and runs setup when initial checkout is blocked', () => {
     const result = runUpdate({ FAKE_GIT_FIRST_CHECKOUT_STATUS: '27' });
 
     assert.equal(result.status, 0, result.stderr);
@@ -307,11 +310,11 @@ kill -TERM "$$"
       `${repoDir}|git:stash push --include-untracked`,
       `${repoDir}|git:checkout main`,
       `${repoDir}|git:merge origin/main`,
-      `${repoDir}|install.sh:`,
+      setupLog(),
     ]);
   });
 
-  it('stops before merge and install when checkout recovery cannot stash changes', () => {
+  it('stops before merge and setup when checkout recovery cannot stash changes', () => {
     const result = runUpdate({
       FAKE_GIT_FIRST_CHECKOUT_STATUS: '27',
       FAKE_GIT_STASH_STATUS: '28',
@@ -333,7 +336,7 @@ kill -TERM "$$"
     ]);
   });
 
-  it('stops before merge and install when checkout still fails after stashing', () => {
+  it('stops before merge and setup when checkout still fails after stashing', () => {
     const result = runUpdate({
       FAKE_GIT_FIRST_CHECKOUT_STATUS: '27',
       FAKE_GIT_RETRY_CHECKOUT_STATUS: '28',
@@ -356,7 +359,7 @@ kill -TERM "$$"
     ]);
   });
 
-  it('stashes, checks out main, retries merge, and installs after an initial merge failure', () => {
+  it('stashes, checks out main, retries merge, and runs setup after an initial merge failure', () => {
     const result = runUpdate({ FAKE_GIT_FIRST_MERGE_STATUS: '24' });
 
     assert.equal(result.status, 0, result.stderr);
@@ -373,7 +376,7 @@ kill -TERM "$$"
       `${repoDir}|git:stash push --include-untracked`,
       `${repoDir}|git:checkout main`,
       `${repoDir}|git:merge origin/main`,
-      `${repoDir}|install.sh:`,
+      setupLog(),
     ]);
   });
 
@@ -398,7 +401,7 @@ kill -TERM "$$"
       `${repoDir}|git:stash push --include-untracked`,
       `${repoDir}|git:checkout main`,
       `${repoDir}|git:merge origin/main`,
-      `${repoDir}|install.sh:`,
+      setupLog(),
     ]);
   });
 
@@ -426,7 +429,7 @@ kill -TERM "$$"
     ]);
   });
 
-  it('stops before install when the retry merge fails', () => {
+  it('stops before setup when the retry merge fails', () => {
     const result = runUpdate({
       FAKE_GIT_FIRST_MERGE_STATUS: '24',
       FAKE_GIT_RETRY_MERGE_STATUS: '25',
@@ -451,7 +454,7 @@ kill -TERM "$$"
     ]);
   });
 
-  it('stops before retry merge and install when the fallback stash path fails', () => {
+  it('stops before retry merge and setup when the fallback stash path fails', () => {
     const result = runUpdate({
       FAKE_GIT_FIRST_MERGE_STATUS: '24',
       FAKE_GIT_STASH_STATUS: '26',
@@ -474,7 +477,7 @@ kill -TERM "$$"
     ]);
   });
 
-  it('stops before retry merge and install when the fallback checkout fails', () => {
+  it('stops before retry merge and setup when the fallback checkout fails', () => {
     const result = runUpdate({
       FAKE_GIT_FIRST_MERGE_STATUS: '24',
       FAKE_GIT_RETRY_CHECKOUT_STATUS: '27',

--- a/test/install.test.ts
+++ b/test/install.test.ts
@@ -5,231 +5,205 @@ const os = require('os');
 const path = require('path');
 
 const installPath = path.join(__dirname, '..', 'install.sh');
+const docsUrl = 'https://github.com/JBallin/ballin-scripts/blob/main/docs/README.md';
+
 type RunInstallOptions = {
   env?: NodeJS.ProcessEnv;
-  input?: string;
 };
 
 describe('install', () => {
   let homeDir: string;
-  let binDir: string;
+  let toolDir: string;
   let repoDir: string;
   let commandLogPath: string;
 
-  const writeExecutable = (name: string, contents: string, directory = binDir) => {
+  const writeExecutable = (name: string, contents: string, directory = toolDir) => {
     const executablePath = path.join(directory, name);
     fs.writeFileSync(executablePath, contents, { mode: 0o755 });
     return executablePath;
   };
 
-  const linkCommand = (name: string, directory = binDir) => {
+  const linkCommand = (name: string) => {
     const commandPath = (process.env.PATH ?? '')
       .split(path.delimiter)
       .map((commandDirectory) => path.join(commandDirectory, name))
       .find((candidate) => fs.existsSync(candidate));
 
     assert.exists(commandPath, `${name} is required to run the install test harness`);
-    fs.symlinkSync(commandPath, path.join(directory, name));
+    fs.symlinkSync(commandPath, path.join(toolDir, name));
   };
 
-  const installBaseCommands = () => {
-    ['chmod', 'cp', 'ln', 'mkdir', 'rm'].forEach((command) => linkCommand(command));
+  const writeCurrentCheckout = ({ repoUpdate = true, installSetup = true } = {}) => {
+    fs.mkdirSync(path.join(repoDir, 'commands'), { recursive: true });
+    fs.mkdirSync(path.join(repoDir, 'bin'), { recursive: true });
+    if (repoUpdate) {
+      fs.writeFileSync(path.join(repoDir, 'commands', 'repo_update.ts'), '');
+    }
+    if (installSetup) {
+      fs.writeFileSync(path.join(repoDir, 'commands', 'install_setup.ts'), '');
+    }
+  };
+
+  const installGitStub = () => {
+    writeExecutable('git', `#!/usr/bin/env bash
+printf 'git:%s\\n' "$*" >> "$FAKE_COMMAND_LOG"
+case "$1" in
+  clone)
+    if [ "$2:$3" != 'https://github.com/JBallin/ballin-scripts.git:.ballin-scripts' ]; then
+      exit 2
+    fi
+    mkdir -p "$HOME/.ballin-scripts/commands" "$HOME/.ballin-scripts/bin"
+    : > "$HOME/.ballin-scripts/commands/repo_update.ts"
+    : > "$HOME/.ballin-scripts/commands/install_setup.ts"
+    exit "$FAKE_GIT_CLONE_STATUS"
+    ;;
+  fetch)
+    exit "$FAKE_GIT_FETCH_STATUS"
+    ;;
+  checkout)
+    exit "$FAKE_GIT_CHECKOUT_STATUS"
+    ;;
+  merge)
+    if [ "$FAKE_GIT_MERGE_STATUS" = '0' ]; then
+      mkdir -p "$HOME/.ballin-scripts/commands"
+      : > "$HOME/.ballin-scripts/commands/repo_update.ts"
+      : > "$HOME/.ballin-scripts/commands/install_setup.ts"
+    fi
+    exit "$FAKE_GIT_MERGE_STATUS"
+    ;;
+  *)
+    exit 2
+    ;;
+esac
+`);
+  };
+
+  const installNodeStub = () => {
     writeExecutable('node', `#!/usr/bin/env bash
 if [ "$1" = '-p' ]; then
   printf '%s\\n' "$FAKE_NODE_SUPPORTED"
   exit 0
 fi
-if [ "$1" = "$HOME/.ballin-scripts/commands/install_setup.ts" ]; then
-  printf 'node:install_setup %s\\n' "$*" >> "$FAKE_COMMAND_LOG"
-  shift
-  if [ "$1" = 'configure' ]; then
-    repo_dir="$2"
-    docs_url="$3"
-    if [ ! -f "$repo_dir/ballin.config.json" ]; then
-      if ! cp "$repo_dir/config/.defaultConfig.json" "$repo_dir/ballin.config.json"; then
-        exit 1
-      fi
-      printf "\\n🧠 Created 'ballin.config.json' file in root using default settings\\n"
-      exit 0
-    fi
-    printf '%s' "$FAKE_UPDATE_OUTPUT"
-    if [ -n "$FAKE_UPDATE_OUTPUT" ]; then
-      printf '\\n👀 Docs: %s\\n' "$docs_url"
-    fi
-    exit "$FAKE_NODE_STATUS"
-  fi
-  if [ "$1" = 'setup-analytics' ]; then
-    repo_dir="$2"
-    config_json=$(<"$repo_dir/ballin.config.json")
-    case "$config_json" in
-      *'"enabled":"false"'*) exit 0 ;;
-    esac
-    if [ "$BALLIN_NO_ANALYTICS" = '1' ] || [ -n "$CI" ]; then
-      exit 0
-    fi
-    mkdir -p "$repo_dir/.analytics"
-    printf '%s\\n' '826f9faa-9995-4f66-a01b-73b4f7aebdf1' > "$repo_dir/.analytics/install-id"
-    printf '%s\\n' 'ballin-scripts collects minimal anonymous command analytics.'
-    exit 0
-  fi
-  if [ "$1" != 'symlink-binaries' ]; then
-    exit 2
-  fi
-  repo_dir="$2"
-  bin_dir="$3"
-  if ! mkdir -p "$bin_dir"; then
-    printf '\\n⚠️  ERROR: Unable to create %s\\n' "$bin_dir"
-    exit 1
-  fi
-  for bin in "$repo_dir/bin/"*; do
-    if ! ln -sfn "$bin" "$bin_dir/\${bin##*/}"; then
-      printf '\\n⚠️  ERROR: Unable to symlink binaries into %s\\n' "$bin_dir"
-      exit 1
-    fi
-  done
-  printf '\\n💪 symlinked binaries into %s\\n' "$bin_dir"
-  exit 0
-fi
-printf '%s' "$FAKE_UPDATE_OUTPUT"
-exit "$FAKE_NODE_STATUS"
-`);
-  };
-
-  const installConfigCommand = () => {
-    writeExecutable('ballin_config', `#!/usr/bin/env bash
-printf 'ballin_config:%s\\n' "$*" >> "$FAKE_COMMAND_LOG"
-case "$1:$2" in
-  get:gu.host) printf '%s\\n' 'github.example.test' ;;
-  get:gu.id) printf '%s\\n' 'existing-gist-id' ;;
-esac
-`, path.join(repoDir, 'bin'));
-  };
-
-  const installAdoptableConfigCommand = () => {
-    writeExecutable('ballin_config', `#!/usr/bin/env bash
-printf 'ballin_config:%s\\n' "$*" >> "$FAKE_COMMAND_LOG"
-gist_id_file="$HOME/.configured-gist-id"
-host_file="$HOME/.configured-gu-host"
-configured_host='github.example.test'
-if [ -f "$host_file" ]; then
-  while IFS= read -r stored_host; do
-    configured_host="$stored_host"
-  done < "$host_file"
-fi
-case "$1:$2" in
-  get:gu.host) printf '%s\\n' "$configured_host" ;;
-  get:gu.id)
-    if [ -f "$gist_id_file" ]; then
-      while IFS= read -r gist_id; do
-        printf '%s\\n' "$gist_id"
-      done < "$gist_id_file"
-    else
-      printf '%s\\n' 'null'
-    fi
+case "$1" in
+  "$HOME/.ballin-scripts/commands/repo_update.ts")
+    printf 'node:repo_update %s\\n' "$*" >> "$FAKE_COMMAND_LOG"
+    exit "$FAKE_REPO_UPDATE_STATUS"
     ;;
-  set:gu.host)
-    printf '%s\\n' "$3" > "$host_file"
-    printf '%s\\n' "\\"gu.host\\" set to: \\"$3\\""
+  "$HOME/.ballin-scripts/commands/install_setup.ts")
+    printf 'node:install_setup %s\\n' "$*" >> "$FAKE_COMMAND_LOG"
+    exit "$FAKE_SETUP_STATUS"
     ;;
-  set:gu.id)
-    printf '%s\\n' "$3" > "$gist_id_file"
-    analytics_json=''
-    if [ -f "$HOME/.ballin-scripts/ballin.config.json" ]; then
-      config_json=$(<"$HOME/.ballin-scripts/ballin.config.json")
-      case "$config_json" in
-        *'"analytics":{"enabled":"false"}'*) analytics_json=',"analytics":{"enabled":"false"}' ;;
-      esac
-    fi
-    printf '{"up":{"cleanup":"false","ballin":"true","gu":"true","softwareupdate":"false","npm":"true","nvm":"true"},"gu":{"id":"%s","host":"%s"}%s}\\n' "$3" "$configured_host" "$analytics_json" > "$HOME/.ballin-scripts/ballin.config.json"
-    printf '%s\\n' "\\"gu.id\\" set to: \\"$3\\""
-    ;;
-esac
-`, path.join(repoDir, 'bin'));
-  };
-
-  const installFakeGhCommand = () => {
-    writeExecutable('gh', `#!/usr/bin/env bash
-printf 'gh:%s\\n' "$*" >> "$FAKE_COMMAND_LOG"
-expected_host="\${FAKE_GH_HOST:-github.example.test}"
-case "$1:$2" in
-  auth:status)
-    if [ "$*" != "auth status --hostname $expected_host" ]; then exit 2; fi
-    exit "$FAKE_GH_AUTH_STATUS"
-    ;;
-  gist:view)
-    if [ "$GH_HOST" != "$expected_host" ]; then
-      printf '%s\\n' 'Unexpected GH_HOST' >&2
-      exit 2
-    fi
-    if [ "$3" = 'returning-gist-id' ] && [ "$4:$5:$6" = '--raw:--filename:.MyConfig.md' ]; then
-      printf '%s\\n' '### Backup of your dev environment'
-      printf '%s\\n' 'Created by [ballin-scripts](https://github.com/JBallin/ballin-scripts)'
-      printf '\\n'
-      exit 0
-    fi
-    if [ "$3" = 'wrong-gist-id' ] && [ "$4:$5:$6" = '--raw:--filename:.MyConfig.md' ]; then
-      printf '%s\\n' 'not a ballin backup'
-      exit 0
-    fi
-    if [ "$3" = 'returning-gist-id' ] && [ "$4:$5:$6" = '--raw:--filename:ballin_config' ]; then
-      printf '%s\\n' '{"up":{"cleanup":"false","ballin":"true","gu":"true","softwareupdate":"false","npm":"true","nvm":"true"},"gu":{"id":null,"host":"github.example.test"},"analytics":{"enabled":"false"}}'
-      exit 0
-    fi
+  *)
+    printf 'unexpected node command: %s\\n' "$*" >&2
     exit 2
     ;;
-  gist:create)
-    if [ "$GH_HOST" != "$expected_host" ]; then
-      printf '%s\\n' 'Unexpected GH_HOST' >&2
-      exit 2
-    fi
-    if [ "$3:$4" != '.MyConfig.md:--desc' ]; then exit 2; fi
-    printf '%s\\n' 'https://gist.github.com/new-gist-id'
-    ;;
-  *) exit 2 ;;
 esac
 `);
   };
 
-  const runInstall = ({ env = {}, input }: RunInstallOptions = {}) => spawnSync(installPath, [], {
+  const installBaseCommands = () => {
+    linkCommand('bash');
+    linkCommand('mkdir');
+    installGitStub();
+    installNodeStub();
+  };
+
+  const runInstall = ({ env = {} }: RunInstallOptions = {}) => spawnSync(installPath, [], {
     encoding: 'utf8',
-    input,
     env: {
       HOME: homeDir,
-      PATH: binDir,
+      PATH: toolDir,
       FAKE_COMMAND_LOG: commandLogPath,
+      FAKE_GIT_CLONE_STATUS: '0',
+      FAKE_GIT_FETCH_STATUS: '0',
+      FAKE_GIT_CHECKOUT_STATUS: '0',
+      FAKE_GIT_MERGE_STATUS: '0',
       FAKE_NODE_SUPPORTED: 'true',
-      FAKE_NODE_STATUS: '0',
-      FAKE_GH_AUTH_STATUS: '0',
+      FAKE_REPO_UPDATE_STATUS: '0',
+      FAKE_SETUP_STATUS: '0',
       ...env,
     },
   });
 
   const commandLog = () => (fs.existsSync(commandLogPath)
-    ? fs.readFileSync(commandLogPath, 'utf8')
-    : '');
+    ? fs.readFileSync(commandLogPath, 'utf8').trim().split('\n').filter(Boolean)
+    : []);
+
+  const setupCommand = () => `node:install_setup ${repoDir}/commands/install_setup.ts setup ${repoDir} ${docsUrl}`;
 
   beforeEach(() => {
     homeDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ballin-install-'));
-    binDir = path.join(homeDir, '.local', 'bin');
+    toolDir = path.join(homeDir, 'tools');
     repoDir = path.join(homeDir, '.ballin-scripts');
-    fs.mkdirSync(binDir, { recursive: true });
-    fs.mkdirSync(path.join(repoDir, 'bin'), { recursive: true });
-    fs.mkdirSync(path.join(repoDir, 'commands'));
-    fs.writeFileSync(path.join(repoDir, 'commands', 'install_setup.ts'), '');
-    fs.mkdirSync(path.join(repoDir, 'config'));
-    fs.copyFileSync(
-      path.join(__dirname, '..', 'config', '.defaultConfig.json'),
-      path.join(repoDir, 'config', '.defaultConfig.json'),
-    );
     commandLogPath = path.join(homeDir, 'commands.log');
-    linkCommand('bash');
+    fs.mkdirSync(toolDir);
   });
 
   afterEach(() => {
     fs.rmSync(homeDir, { recursive: true, force: true });
   });
 
+  it('clones a missing checkout and delegates fresh setup to typed code', () => {
+    installBaseCommands();
+
+    const result = runInstall();
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.include(result.stdout, "🏀 let's ball...");
+    assert.deepEqual(commandLog(), [
+      'git:clone https://github.com/JBallin/ballin-scripts.git .ballin-scripts',
+      setupCommand(),
+    ]);
+  });
+
+  it('updates an existing current checkout through the typed repo updater before setup', () => {
+    installBaseCommands();
+    writeCurrentCheckout();
+
+    const result = runInstall();
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.deepEqual(commandLog(), [
+      `node:repo_update ${repoDir}/commands/repo_update.ts ${repoDir}`,
+      setupCommand(),
+    ]);
+  });
+
+  it('uses the minimal Bash update bridge for stale checkouts without typed repo update', () => {
+    installBaseCommands();
+    writeCurrentCheckout({ repoUpdate: false, installSetup: false });
+
+    const result = runInstall();
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.deepEqual(commandLog(), [
+      'git:fetch origin +main:refs/remotes/origin/main',
+      'git:checkout main',
+      'git:merge origin/main',
+      setupCommand(),
+    ]);
+  });
+
+  it('fails clearly when the stale checkout bridge cannot update', () => {
+    installBaseCommands();
+    writeCurrentCheckout({ repoUpdate: false, installSetup: false });
+
+    const result = runInstall({ env: { FAKE_GIT_MERGE_STATUS: '24' } });
+
+    assert.equal(result.status, 1);
+    assert.include(result.stdout, `Unable to update ${repoDir} before setup`);
+    assert.include(result.stdout, `Update or delete ${repoDir}`);
+    assert.deepEqual(commandLog(), [
+      'git:fetch origin +main:refs/remotes/origin/main',
+      'git:checkout main',
+      'git:merge origin/main',
+    ]);
+  });
+
   it('stops with guidance when Node.js is unavailable', () => {
+    linkCommand('bash');
+    writeCurrentCheckout();
+
     const result = runInstall();
 
     assert.equal(result.status, 1);
@@ -238,11 +212,12 @@ esac
     assert.include(result.stdout, 'docs/README.md');
     assert.include(result.stdout, 'brew install node');
     assert.include(result.stdout, 'run this installer again');
-    assert.isFalse(fs.existsSync(path.join(repoDir, 'ballin.config.json')));
+    assert.deepEqual(commandLog(), []);
   });
 
   it('stops with guidance when Node.js is below the supported version', () => {
     installBaseCommands();
+    writeCurrentCheckout();
 
     const result = runInstall({ env: { FAKE_NODE_SUPPORTED: 'false' } });
 
@@ -252,308 +227,19 @@ esac
     assert.include(result.stdout, 'docs/README.md');
     assert.include(result.stdout, 'brew install node');
     assert.include(result.stdout, 'run this installer again');
-    assert.isFalse(fs.existsSync(path.join(repoDir, 'ballin.config.json')));
-    assert.equal(commandLog(), '');
+    assert.deepEqual(commandLog(), []);
   });
 
-  it('stops before configuration and Gist work when the command directory is missing from PATH', () => {
-    const pathDir = path.join(homeDir, 'test-path');
-    fs.mkdirSync(pathDir);
-    ['bash'].forEach((command) => linkCommand(command, pathDir));
-    writeExecutable('node', '#!/usr/bin/env bash\nexit 0\n', pathDir);
-
-    const result = runInstall({ env: { PATH: pathDir } });
-
-    assert.equal(result.status, 1);
-    assert.include(result.stdout, `${binDir} doesn't seem to be in your path.`);
-    assert.include(result.stdout, `export PATH="${binDir}:$PATH"`);
-    assert.isFalse(fs.existsSync(path.join(repoDir, 'ballin.config.json')));
-    assert.equal(commandLog(), '');
-  });
-
-  it('stops with guidance when GitHub CLI is unavailable', () => {
+  it('returns the typed setup status when setup fails', () => {
     installBaseCommands();
-    installAdoptableConfigCommand();
+    writeCurrentCheckout();
 
-    const result = runInstall();
+    const result = runInstall({ env: { FAKE_SETUP_STATUS: '27' } });
 
-    assert.equal(result.status, 1);
-    assert.include(result.stdout, 'GitHub CLI is required for Gist backup setup');
-    assert.include(result.stdout, 'Install gh, authenticate it, then run this installer again');
-    assert.include(result.stdout, 'gh auth login --hostname github.example.test');
-    assert.include(result.stdout, 'docs/README.md');
-    assert.notInclude(commandLog(), 'gh:');
-    assert.notInclude(result.stdout, 'symlinked binaries');
-    assert.notInclude(result.stdout, '😎 ballin!');
-    assert.isFalse(fs.existsSync(path.join(binDir, 'ballin_config')));
-  });
-
-  it('stops with guidance when GitHub CLI is not authenticated', () => {
-    installBaseCommands();
-    installAdoptableConfigCommand();
-    installFakeGhCommand();
-
-    const result = runInstall({ env: { FAKE_GH_AUTH_STATUS: '4' } });
-
-    assert.equal(result.status, 1);
-    assert.include(result.stdout, 'gh is not authenticated for github.example.test');
-    assert.include(result.stdout, 'gh auth login --hostname github.example.test');
-    assert.include(result.stdout, 'Then run this installer again');
-    assert.include(commandLog(), 'gh:auth status --hostname github.example.test');
-    assert.notInclude(commandLog(), 'gh:gist');
-    assert.notInclude(result.stdout, 'symlinked binaries');
-    assert.notInclude(result.stdout, '😎 ballin!');
-    assert.isFalse(fs.existsSync(path.join(binDir, 'ballin_config')));
-  });
-
-  it('performs an isolated initial setup and shows docs once', () => {
-    installBaseCommands();
-    installConfigCommand();
-    installFakeGhCommand();
-
-    const result = runInstall();
-
-    assert.equal(result.status, 0, result.stderr);
-    assert.include(result.stdout, "Created 'ballin.config.json'");
-    assert.equal(result.stdout.match(/👀 Docs:/g).length, 1);
-    assert.include(result.stdout, `symlinked binaries into ${binDir}`);
-    assert.include(result.stdout, '😎 ballin!');
-    assert.deepEqual(
-      JSON.parse(fs.readFileSync(path.join(repoDir, 'ballin.config.json'), 'utf8')),
-      JSON.parse(fs.readFileSync(path.join(repoDir, 'config', '.defaultConfig.json'), 'utf8')),
-    );
-    assert.isTrue(fs.lstatSync(path.join(binDir, 'ballin_config')).isSymbolicLink());
-    assert.include(commandLog(), 'node:install_setup');
-    assert.include(commandLog(), 'symlink-binaries');
-    assert.notInclude(commandLog(), 'gist:');
-    assert.include(commandLog(), 'gh:auth status --hostname github.example.test');
-    assert.notInclude(commandLog(), 'gh:gist');
-  });
-
-  it('falls back to Bash symlinking when the typed setup entrypoint is missing from an existing checkout', () => {
-    installBaseCommands();
-    installConfigCommand();
-    installFakeGhCommand();
-    fs.unlinkSync(path.join(repoDir, 'commands', 'install_setup.ts'));
-
-    const result = runInstall();
-
-    assert.equal(result.status, 0, result.stderr);
-    assert.include(result.stdout, `symlinked binaries into ${binDir}`);
-    assert.isTrue(fs.lstatSync(path.join(binDir, 'ballin_config')).isSymbolicLink());
-    assert.notInclude(commandLog(), 'node:install_setup');
-  });
-
-  it('falls back to Bash config setup when the typed setup entrypoint does not support configure yet', () => {
-    installBaseCommands();
-    installConfigCommand();
-    installFakeGhCommand();
-    writeExecutable('node', `#!/usr/bin/env bash
-if [ "$1" = '-p' ]; then
-  printf '%s\\n' "$FAKE_NODE_SUPPORTED"
-  exit 0
-fi
-if [ "$1" = "$HOME/.ballin-scripts/commands/install_setup.ts" ]; then
-  printf 'node:install_setup %s\\n' "$*" >> "$FAKE_COMMAND_LOG"
-  shift
-  if [ "$1" = 'symlink-binaries' ]; then
-    repo_dir="$2"
-    bin_dir="$3"
-    mkdir -p "$bin_dir"
-    for bin in "$repo_dir/bin/"*; do
-      ln -sfn "$bin" "$bin_dir/\${bin##*/}"
-    done
-    printf '\\n💪 symlinked binaries into %s\\n' "$bin_dir"
-    exit 0
-  fi
-  exit 1
-fi
-printf '%s' "$FAKE_UPDATE_OUTPUT"
-exit "$FAKE_NODE_STATUS"
-`);
-
-    const result = runInstall();
-
-    assert.equal(result.status, 0, result.stderr);
-    assert.include(result.stdout, "Created 'ballin.config.json'");
-    assert.deepEqual(
-      JSON.parse(fs.readFileSync(path.join(repoDir, 'ballin.config.json'), 'utf8')),
-      JSON.parse(fs.readFileSync(path.join(repoDir, 'config', '.defaultConfig.json'), 'utf8')),
-    );
-    assert.include(commandLog(), 'node:install_setup');
-  });
-
-  it('does not repeat unchanged setup guidance during an ordinary update', () => {
-    installBaseCommands();
-    installConfigCommand();
-    installFakeGhCommand();
-    fs.copyFileSync(
-      path.join(repoDir, 'config', '.defaultConfig.json'),
-      path.join(repoDir, 'ballin.config.json'),
-    );
-
-    const result = runInstall();
-
-    assert.equal(result.status, 0, result.stderr);
-    assert.notInclude(result.stdout, '👀 Docs:');
-    assert.notInclude(result.stdout, "Created 'ballin.config.json'");
-    assert.notInclude(result.stdout, 'What GitHub host should be used for Gist backups?');
-    assert.include(result.stdout, '😎 ballin!');
-  });
-
-  it('prompts once when migration adds gu.host to an existing Gist config', () => {
-    installBaseCommands();
-    installAdoptableConfigCommand();
-    installFakeGhCommand();
-    fs.writeFileSync(path.join(homeDir, '.configured-gist-id'), 'existing-gist-id\n');
-    fs.writeFileSync(path.join(repoDir, 'ballin.config.json'), '{"gu":{"id":"existing-gist-id"}}\n');
-
-    const result = runInstall({
-      env: {
-        FAKE_GH_HOST: 'github.enterprise.test',
-        FAKE_UPDATE_OUTPUT: 'New configuration options have been added!\ngu.host: github.example.test\n',
-      },
-      input: 'github.enterprise.test\n',
-    });
-
-    assert.equal(result.status, 0, result.stderr);
-    assert.include(commandLog(), 'ballin_config:set gu.host github.enterprise.test\n');
-    assert.include(commandLog(), 'gh:auth status --hostname github.enterprise.test');
-    assert.notInclude(commandLog(), 'gh:gist');
-  });
-
-  it('reports newly added configuration and links to the guide', () => {
-    installBaseCommands();
-    installConfigCommand();
-    installFakeGhCommand();
-    fs.writeFileSync(path.join(repoDir, 'ballin.config.json'), '{}\n');
-
-    const updateOutput = 'New configuration options have been added!\nup.nvm: false\n';
-    const result = runInstall({ env: { FAKE_UPDATE_OUTPUT: updateOutput } });
-
-    assert.equal(result.status, 0, result.stderr);
-    assert.include(result.stdout, updateOutput.trim());
-    assert.equal(result.stdout.match(/👀 Docs:/g).length, 1);
-    assert.include(result.stdout, 'docs/README.md');
-    assert.include(commandLog(), 'configure');
-  });
-
-  it('restores config values from an adopted backup gist', () => {
-    installBaseCommands();
-    installAdoptableConfigCommand();
-    installFakeGhCommand();
-
-    const result = runInstall({ input: '\ny\nreturning-gist-id\n' });
-
-    assert.equal(result.status, 0, result.stderr);
-    assert.include(result.stdout, 'Storing your previous gist ID in your config');
-    assert.include(result.stdout, 'Restored ballin.config.json from your backup gist');
-    assert.include(commandLog(), 'gh:gist view returning-gist-id --raw --filename ballin_config');
-    assert.include(commandLog(), 'ballin_config:set gu.id returning-gist-id\n');
-    const restoredConfig = JSON.parse(fs.readFileSync(path.join(repoDir, 'ballin.config.json'), 'utf8'));
-    assert.equal(restoredConfig.up.cleanup, 'false');
-    assert.equal(restoredConfig.up.gu, 'true');
-    assert.equal(restoredConfig.gu.id, 'returning-gist-id');
-    assert.equal(restoredConfig.gu.host, 'github.example.test');
-    assert.equal(restoredConfig.analytics.enabled, 'false');
-    assert.isFalse(fs.existsSync(path.join(repoDir, '.analytics', 'install-id')));
-  });
-
-  it('rejects readable returning Gists without the backup marker', () => {
-    installBaseCommands();
-    installAdoptableConfigCommand();
-    installFakeGhCommand();
-
-    const result = runInstall({ input: '\ny\nwrong-gist-id\nreturning-gist-id\n' });
-
-    assert.equal(result.status, 0, result.stderr);
-    assert.include(result.stdout, "INVALID: Expected backup marker in gist 'wrong-gist-id'");
-    assert.include(commandLog(), 'gh:gist view wrong-gist-id --raw --filename .MyConfig.md');
-    assert.notInclude(commandLog(), 'ballin_config:set gu.id wrong-gist-id');
-    assert.include(commandLog(), 'ballin_config:set gu.id returning-gist-id\n');
-  });
-
-  it('stops before Gist and success output when config creation fails', () => {
-    installBaseCommands();
-    installConfigCommand();
-    fs.unlinkSync(path.join(binDir, 'cp'));
-    writeExecutable('cp', '#!/usr/bin/env bash\nexit 9\n');
-
-    const result = runInstall();
-
-    assert.equal(result.status, 1);
-    assert.include(result.stdout, 'Unable to create or update ballin.config.json');
-    assert.notInclude(commandLog(), 'ballin_config:');
-    assert.notInclude(commandLog(), 'gist:');
-    assert.notInclude(result.stdout, 'symlinked binaries');
-    assert.notInclude(result.stdout, '😎 ballin!');
-  });
-
-  it('stops before Gist and success output when config migration fails', () => {
-    installBaseCommands();
-    installConfigCommand();
-    fs.writeFileSync(path.join(repoDir, 'ballin.config.json'), '{}\n');
-
-    const result = runInstall({ env: { FAKE_NODE_STATUS: '7' } });
-
-    assert.equal(result.status, 1);
-    assert.include(result.stdout, 'Unable to create or update ballin.config.json');
-    assert.notInclude(commandLog(), 'ballin_config:');
-    assert.notInclude(commandLog(), 'gist:');
-    assert.notInclude(result.stdout, 'symlinked binaries');
-    assert.notInclude(result.stdout, '😎 ballin!');
-  });
-
-  it('uses the Homebrew prefix as the command directory when brew is present', () => {
-    installBaseCommands();
-    installConfigCommand();
-    installFakeGhCommand();
-    writeExecutable('brew', `#!/usr/bin/env bash
-if [ "$1" = '--prefix' ]; then
-  printf '%s\\n' "$HOME/.local"
-  exit 0
-fi
-exit 2
-`);
-
-    const result = runInstall();
-
-    assert.equal(result.status, 0, result.stderr);
-    assert.include(result.stdout, `symlinked binaries into ${binDir}`);
-  });
-
-  it('creates a new secret Gist when gh is authenticated and no backup is configured', () => {
-    installBaseCommands();
-    installAdoptableConfigCommand();
-    installFakeGhCommand();
-
-    const result = runInstall({ input: '\nn\n' });
-
-    assert.equal(result.status, 0, result.stderr);
-    assert.include(result.stdout, "Created a secret gist titled '.MyConfig'");
-    assert.include(commandLog(), 'gh:gist create .MyConfig.md --desc ');
-    assert.include(commandLog(), 'ballin_config:set gu.id new-gist-id\n');
-    assert.isFalse(fs.existsSync(path.join(repoDir, '.MyConfig.md')));
-  });
-
-  it('uses an install-time custom Gist host from user input', () => {
-    installBaseCommands();
-    installAdoptableConfigCommand();
-    installFakeGhCommand();
-
-    const result = runInstall({
-      env: { FAKE_GH_HOST: 'github.enterprise.test' },
-      input: 'github.enterprise.test\nn\n',
-    });
-
-    assert.equal(result.status, 0, result.stderr);
-    assert.include(commandLog(), 'ballin_config:set gu.host github.enterprise.test\n');
-    assert.include(commandLog(), 'gh:auth status --hostname github.enterprise.test');
-    assert.include(commandLog(), 'gh:gist create .MyConfig.md --desc ');
-    const configuredHost = fs.readFileSync(path.join(homeDir, '.configured-gu-host'), 'utf8').trim();
-    assert.equal(configuredHost, 'github.enterprise.test');
-    const createdConfig = JSON.parse(fs.readFileSync(path.join(repoDir, 'ballin.config.json'), 'utf8'));
-    assert.equal(createdConfig.gu.host, 'github.enterprise.test');
-    assert.equal(createdConfig.gu.id, 'new-gist-id');
+    assert.equal(result.status, 27);
+    assert.deepEqual(commandLog(), [
+      `node:repo_update ${repoDir}/commands/repo_update.ts ${repoDir}`,
+      setupCommand(),
+    ]);
   });
 });

--- a/test/install_setup.test.ts
+++ b/test/install_setup.test.ts
@@ -8,6 +8,7 @@ const {
 } = require('../commands/analytics.ts');
 const {
   configure,
+  setup,
   setupAnalytics,
   symlinkBinaries,
 } = require('../commands/install_setup.ts');
@@ -20,6 +21,8 @@ describe('install setup', () => {
   let repoDir: string;
   let sourceBinDir: string;
   let binDir: string;
+  let toolDir: string;
+  let commandLogPath: string;
   const docsUrl = 'https://example.test/docs';
   const fixedInstallId = '826f9faa-9995-4f66-a01b-73b4f7aebdf1';
 
@@ -51,6 +54,95 @@ describe('install setup', () => {
   const installIdPath = () => path.join(repoDir, '.analytics', 'install-id');
 
   const readInstallId = () => fs.readFileSync(installIdPath(), 'utf8');
+
+  const commandPath = (name: string) => (process.env.PATH ?? '')
+    .split(path.delimiter)
+    .map((directory) => path.join(directory, name))
+    .find((candidate) => fs.existsSync(candidate));
+
+  const linkCommand = (name: string) => {
+    const sourcePath = commandPath(name);
+    assert.exists(sourcePath, `${name} is required to run the install setup test harness`);
+    fs.symlinkSync(sourcePath, path.join(toolDir, name));
+  };
+
+  const writeExecutable = (name: string, contents: string, directory = toolDir) => {
+    const executablePath = path.join(directory, name);
+    fs.writeFileSync(executablePath, contents, { mode: 0o755 });
+    return executablePath;
+  };
+
+  const commandLog = () => (fs.existsSync(commandLogPath)
+    ? fs.readFileSync(commandLogPath, 'utf8')
+    : '');
+
+  const installStaticConfigCommand = (id = 'existing-gist-id', host = 'github.example.test') => {
+    writeExecutable('ballin_config', `#!/usr/bin/env bash
+printf 'ballin_config:%s\\n' "$*" >> "$FAKE_COMMAND_LOG"
+case "$1:$2" in
+  get:gu.host) printf '%s\\n' '${host}' ;;
+  get:gu.id) printf '%s\\n' '${id}' ;;
+  set:gu.host|set:gu.id) printf '%s\\n' "\\"$2\\" set to: \\"$3\\"" ;;
+esac
+`, sourceBinDir);
+  };
+
+  const installAdoptableConfigCommand = () => {
+    writeExecutable('ballin_config', `#!/usr/bin/env bash
+printf 'ballin_config:%s\\n' "$*" >> "$FAKE_COMMAND_LOG"
+gist_id_file="$HOME/.configured-gist-id"
+host_file="$HOME/.configured-gu-host"
+configured_host='github.example.test'
+if [ -f "$host_file" ]; then
+  while IFS= read -r stored_host; do
+    configured_host="$stored_host"
+  done < "$host_file"
+fi
+case "$1:$2" in
+  get:gu.host) printf '%s\\n' "$configured_host" ;;
+  get:gu.id)
+    if [ -f "$gist_id_file" ]; then
+      while IFS= read -r gist_id; do
+        printf '%s\\n' "$gist_id"
+      done < "$gist_id_file"
+    else
+      printf '%s\\n' 'null'
+    fi
+    ;;
+  set:gu.host)
+    printf '%s\\n' "$3" > "$host_file"
+    printf '%s\\n' "\\"gu.host\\" set to: \\"$3\\""
+    ;;
+  set:gu.id)
+    printf '%s\\n' "$3" > "$gist_id_file"
+    printf '{"up":{"cleanup":"false","ballin":"true","gu":"true","softwareupdate":"false","npm":"true","nvm":"true"},"gu":{"id":"%s","host":"%s"},"analytics":{"enabled":"false"}}\\n' "$3" "$configured_host" > "$BALLIN_TEST_REPO_DIR/ballin.config.json"
+    printf '%s\\n' "\\"gu.id\\" set to: \\"$3\\""
+    ;;
+esac
+`, sourceBinDir);
+  };
+
+  const installFakeGhCommand = () => {
+    writeExecutable('gh', `#!/usr/bin/env bash
+printf 'gh:%s\\n' "$*" >> "$FAKE_COMMAND_LOG"
+expected_host="\${FAKE_GH_HOST:-github.example.test}"
+case "$1:$2" in
+  auth:status)
+    if [ "$*" != "auth status --hostname $expected_host" ]; then exit 2; fi
+    exit "$FAKE_GH_AUTH_STATUS"
+    ;;
+  gist:create)
+    if [ "$GH_HOST" != "$expected_host" ]; then
+      printf '%s\\n' 'Unexpected GH_HOST' >&2
+      exit 2
+    fi
+    if [ "$3:$4" != '.MyConfig.md:--desc' ]; then exit 2; fi
+    printf '%s\\n' 'https://gist.github.com/new-gist-id'
+    ;;
+  *) exit 2 ;;
+esac
+`);
+  };
 
   const withEnv = (env: NodeJS.ProcessEnv, action: () => { output: string; result: boolean }) => {
     const previousValues = new Map<string, string | undefined>();
@@ -107,8 +199,11 @@ describe('install setup', () => {
     repoDir = path.join(testDir, 'repo');
     sourceBinDir = path.join(repoDir, 'bin');
     binDir = path.join(testDir, 'home', '.local', 'bin');
+    toolDir = path.join(testDir, 'tools');
+    commandLogPath = path.join(testDir, 'commands.log');
 
     fs.mkdirSync(sourceBinDir, { recursive: true });
+    fs.mkdirSync(toolDir);
     fs.writeFileSync(path.join(sourceBinDir, 'ballin'), '#!/usr/bin/env node\n');
     fs.writeFileSync(path.join(sourceBinDir, 'gu'), '#!/usr/bin/env node\n');
   });
@@ -323,5 +418,73 @@ describe('install setup', () => {
 
     assert.isFalse(result);
     assert.isTrue(fs.statSync(path.join(binDir, 'ballin')).isDirectory());
+  });
+
+  it('runs full setup with existing Gist settings through typed orchestration', () => {
+    installConfigSources();
+    installStaticConfigCommand();
+    installFakeGhCommand();
+    fs.writeFileSync(path.join(repoDir, 'ballin.config.json'), JSON.stringify({
+      gu: { id: 'existing-gist-id', host: 'github.example.test' },
+      analytics: { enabled: 'false' },
+    }));
+    linkCommand('bash');
+
+    const result = withEnv({
+      HOME: path.join(testDir, 'home'),
+      PATH: `${toolDir}${path.delimiter}${binDir}`,
+      FAKE_COMMAND_LOG: commandLogPath,
+      FAKE_GH_AUTH_STATUS: '0',
+    }, () => captureStdout(() => setup(repoDir, docsUrl)));
+
+    assert.isTrue(result.result);
+    assert.include(result.output, `symlinked binaries into ${binDir}`);
+    assert.include(result.output, '😎 ballin!');
+    assert.include(commandLog(), 'gh:auth status --hostname github.example.test');
+    assert.isTrue(fs.lstatSync(path.join(binDir, 'ballin')).isSymbolicLink());
+  });
+
+  it('stops before setup work when the command directory is missing from PATH', () => {
+    installConfigSources();
+
+    const result = withEnv({
+      HOME: path.join(testDir, 'home'),
+      PATH: toolDir,
+    }, () => captureStdout(() => setup(repoDir, docsUrl)));
+
+    assert.isFalse(result.result);
+    assert.include(result.output, `${binDir} doesn't seem to be in your path.`);
+    assert.include(result.output, `export PATH="${binDir}:$PATH"`);
+  });
+
+  it('creates a new secret Gist through the setup CLI when no backup is configured', () => {
+    installConfigSources();
+    installAdoptableConfigCommand();
+    installFakeGhCommand();
+    linkCommand('bash');
+
+    const result = spawnSync(process.execPath, [
+      installSetupPath,
+      'setup',
+      repoDir,
+      docsUrl,
+    ], {
+      encoding: 'utf8',
+      input: '\nn\n',
+      env: {
+        ...process.env,
+        HOME: path.join(testDir, 'home'),
+        PATH: `${toolDir}${path.delimiter}${binDir}`,
+        FAKE_COMMAND_LOG: commandLogPath,
+        FAKE_GH_AUTH_STATUS: '0',
+        BALLIN_TEST_REPO_DIR: repoDir,
+      },
+    });
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.include(result.stdout, "Created a secret gist titled '.MyConfig'");
+    assert.include(commandLog(), 'gh:gist create .MyConfig.md --desc ');
+    assert.include(commandLog(), 'ballin_config:set gu.id new-gist-id\n');
+    assert.isFalse(fs.existsSync(path.join(repoDir, '.MyConfig.md')));
   });
 });


### PR DESCRIPTION
## Summary

Closes #177.

This makes install and update converge around shared setup behavior while keeping `install.sh` as a thin bootstrap:

- extracts the existing `ballin_update` git fetch/checkout/merge recovery into `commands/repo_update.ts`
- changes `ballin_update` to update the repo and invoke typed setup directly instead of rerunning `./install.sh`
- moves post-bootstrap install orchestration into `commands/install_setup.ts setup`, including config, Gist setup, analytics setup, bin directory validation, and symlink creation
- slims `install.sh` to clone if missing, require Node early, update existing checkouts, and delegate to typed setup
- keeps a minimal stale-checkout bridge in Bash that tries to pull latest when the typed repo updater is unavailable, then fails clearly if that repair does not work
- updates README wording for `ballin_update`

## Review notes

I agree with the self-healing direction here: it avoids preserving parallel Bash setup logic while still giving stale checkouts a simple path to become current enough for typed setup. The Bash fallback remains intentionally narrow: repo update only, not config/Gist/analytics/symlink setup.

## Validation

- `npm test`