### PR TITLE
[codex] Add setup readiness checks

### DIFF
--- a/commands/install_setup.ts
+++ b/commands/install_setup.ts
@@ -9,6 +9,9 @@ const {
   runCommand,
   writeStdoutLine,
 } = require('./commandHelpers.ts');
+const {
+  collectSetupReadiness,
+} = require('./setup_readiness.ts');
 
 const backupMarker = '### Backup of your dev environment\n'
   + 'Created by [ballin-scripts](https://github.com/JBallin/ballin-scripts)\n'
@@ -36,6 +39,7 @@ const stripTrailingNewlines = (text: string): string => text.replace(/[\r\n]+$/u
 const supportedCommands = new Set([
   'configure',
   'gist',
+  'readiness',
   'setup',
   'setup-analytics',
   'symlink-binaries',
@@ -445,6 +449,11 @@ const runInstallSetupCli = (): void => {
     return;
   }
 
+  if (command === 'readiness' && repoDir) {
+    writeStdoutLine(JSON.stringify(collectSetupReadiness({ repoDir }), null, 2));
+    return;
+  }
+
   if (command === 'setup' && repoDir && option) {
     process.exitCode = setup(repoDir, option, process.argv[5]) ? 0 : 1;
     return;
@@ -461,7 +470,7 @@ const runInstallSetupCli = (): void => {
   }
 
   if (!command || !repoDir || !option) {
-    writeStdoutLine('Usage: install_setup.ts <configure|gist|setup|symlink-binaries|setup-analytics|supports-command> <repo-dir|command> [docs-url|bin-dir] [gu-host-existed]');
+    writeStdoutLine('Usage: install_setup.ts <configure|gist|readiness|setup|symlink-binaries|setup-analytics|supports-command> <repo-dir|command> [docs-url|bin-dir] [gu-host-existed]');
     process.exitCode = 1;
     return;
   }

--- a/commands/install_setup.ts
+++ b/commands/install_setup.ts
@@ -9,9 +9,6 @@ const {
   runCommand,
   writeStdoutLine,
 } = require('./commandHelpers.ts');
-const {
-  collectSetupReadiness,
-} = require('./setup_readiness.ts');
 
 const backupMarker = '### Backup of your dev environment\n'
   + 'Created by [ballin-scripts](https://github.com/JBallin/ballin-scripts)\n'
@@ -39,7 +36,6 @@ const stripTrailingNewlines = (text: string): string => text.replace(/[\r\n]+$/u
 const supportedCommands = new Set([
   'configure',
   'gist',
-  'readiness',
   'setup',
   'setup-analytics',
   'symlink-binaries',
@@ -449,11 +445,6 @@ const runInstallSetupCli = (): void => {
     return;
   }
 
-  if (command === 'readiness' && repoDir) {
-    writeStdoutLine(JSON.stringify(collectSetupReadiness({ repoDir }), null, 2));
-    return;
-  }
-
   if (command === 'setup' && repoDir && option) {
     process.exitCode = setup(repoDir, option, process.argv[5]) ? 0 : 1;
     return;
@@ -470,7 +461,7 @@ const runInstallSetupCli = (): void => {
   }
 
   if (!command || !repoDir || !option) {
-    writeStdoutLine('Usage: install_setup.ts <configure|gist|readiness|setup|symlink-binaries|setup-analytics|supports-command> <repo-dir|command> [docs-url|bin-dir] [gu-host-existed]');
+    writeStdoutLine('Usage: install_setup.ts <configure|gist|setup|symlink-binaries|setup-analytics|supports-command> <repo-dir|command> [docs-url|bin-dir] [gu-host-existed]');
     process.exitCode = 1;
     return;
   }

--- a/commands/setup_readiness.ts
+++ b/commands/setup_readiness.ts
@@ -1,0 +1,363 @@
+const fs = require('fs');
+const path = require('path');
+const {
+  commandExists,
+  runCommand: defaultRunCommand,
+  spawnResultStatus,
+} = require('./commandHelpers.ts');
+
+import type { SpawnSyncOptionsWithStringEncoding } from 'child_process';
+
+type ConfigObject = { [key: string]: unknown };
+type RunCommand = (
+  command: string,
+  args?: string[],
+  options?: Omit<SpawnSyncOptionsWithStringEncoding, 'encoding' | 'shell'>,
+) => {
+  status: number | null;
+  signal: NodeJS.Signals | null;
+  stdout: string;
+  stderr: string;
+  error?: Error;
+};
+
+type SetupReadinessStatus = 'pass' | 'warn' | 'fail' | 'info';
+type SetupReadinessOverallStatus = Exclude<SetupReadinessStatus, 'info'>;
+type SetupReadinessCheck = {
+  id: string;
+  label: string;
+  status: SetupReadinessStatus;
+  summary: string;
+  details?: string;
+  data?: Record<string, unknown>;
+};
+type SetupReadinessReport = {
+  status: SetupReadinessOverallStatus;
+  checks: SetupReadinessCheck[];
+};
+type CollectSetupReadinessOptions = {
+  repoDir: string;
+  configPath?: string;
+  env?: NodeJS.ProcessEnv;
+  nodeVersion?: string;
+  nodeEngine?: string;
+  runCommand?: RunCommand;
+};
+
+const requiredCommandShims = [
+  'ballin',
+  'ballin_config',
+  'ballin_uninstall',
+  'ballin_update',
+  'gu',
+  'up',
+];
+
+const isConfigObject = (value: unknown): value is ConfigObject => (
+  typeof value === 'object' && value !== null && !Array.isArray(value)
+);
+
+const hasOwn = (obj: ConfigObject, key: string): boolean => (
+  Object.prototype.hasOwnProperty.call(obj, key)
+);
+
+const readPackageNodeEngine = (repoDir: string): string | null => {
+  try {
+    const packageJson = JSON.parse(fs.readFileSync(path.join(repoDir, 'package.json'), 'utf8')) as unknown;
+    if (!isConfigObject(packageJson) || !isConfigObject(packageJson.engines)) {
+      return null;
+    }
+    const nodeEngine = packageJson.engines.node;
+    return typeof nodeEngine === 'string' ? nodeEngine : null;
+  } catch {
+    return null;
+  }
+};
+
+const parseVersion = (version: string): number[] | null => {
+  const match = version.trim().replace(/^v/u, '').match(/^(\d+)(?:\.(\d+))?(?:\.(\d+))?/u);
+  if (!match) {
+    return null;
+  }
+  return [1, 2, 3].map((index) => Number.parseInt(match[index] ?? '0', 10));
+};
+
+const parseMinimumEngineVersion = (engine: string): number[] | null => {
+  const match = engine.match(/>=\s*(\d+(?:\.\d+){0,2})/u);
+  return match ? parseVersion(match[1]) : null;
+};
+
+const versionIsAtLeast = (actual: string, minimum: string): boolean | null => {
+  const actualVersion = parseVersion(actual);
+  const minimumVersion = parseMinimumEngineVersion(minimum);
+  if (!actualVersion || !minimumVersion) {
+    return null;
+  }
+
+  for (let index = 0; index < minimumVersion.length; index += 1) {
+    if (actualVersion[index] > minimumVersion[index]) {
+      return true;
+    }
+    if (actualVersion[index] < minimumVersion[index]) {
+      return false;
+    }
+  }
+  return true;
+};
+
+const nodeRuntimeCheck = (
+  repoDir: string,
+  nodeVersion: string,
+  nodeEngine = readPackageNodeEngine(repoDir),
+): SetupReadinessCheck => {
+  if (!nodeEngine) {
+    return {
+      id: 'runtime.node',
+      label: 'Node.js runtime',
+      status: 'warn',
+      summary: 'Unable to determine the supported Node.js version from package.json.',
+      data: { nodeVersion },
+    };
+  }
+
+  const supported = versionIsAtLeast(nodeVersion, nodeEngine);
+  if (supported === null) {
+    return {
+      id: 'runtime.node',
+      label: 'Node.js runtime',
+      status: 'warn',
+      summary: 'Unable to compare the current Node.js version with the configured engine.',
+      data: { nodeVersion, nodeEngine },
+    };
+  }
+
+  return {
+    id: 'runtime.node',
+    label: 'Node.js runtime',
+    status: supported ? 'pass' : 'fail',
+    summary: supported
+      ? `Node.js ${nodeVersion} satisfies ${nodeEngine}.`
+      : `Node.js ${nodeVersion} does not satisfy ${nodeEngine}.`,
+    data: { nodeVersion, nodeEngine },
+  };
+};
+
+const commandShimCheck = (env: NodeJS.ProcessEnv): SetupReadinessCheck => {
+  const commands = requiredCommandShims.map((name) => ({
+    name,
+    found: commandExists(name, { env }),
+  }));
+  const missing = commands.filter(({ found }) => !found).map(({ name }) => name);
+
+  return {
+    id: 'commands.path',
+    label: 'Command shims on PATH',
+    status: missing.length ? 'fail' : 'pass',
+    summary: missing.length
+      ? `Missing command shims on PATH: ${missing.join(', ')}.`
+      : 'All command shims are discoverable on PATH.',
+    data: { commands, missing },
+  };
+};
+
+const readConfig = (configPath: string): {
+  check: SetupReadinessCheck;
+  config: ConfigObject | null;
+} => {
+  let configText = '';
+  try {
+    configText = fs.readFileSync(configPath, 'utf8');
+  } catch {
+    return {
+      config: null,
+      check: {
+        id: 'config.read',
+        label: 'Config readability',
+        status: 'fail',
+        summary: `Unable to read ${configPath}.`,
+        data: { configPath },
+      },
+    };
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(configText);
+  } catch {
+    return {
+      config: null,
+      check: {
+        id: 'config.read',
+        label: 'Config readability',
+        status: 'fail',
+        summary: `${configPath} is not valid JSON.`,
+        data: { configPath },
+      },
+    };
+  }
+
+  if (!isConfigObject(parsed)) {
+    return {
+      config: null,
+      check: {
+        id: 'config.read',
+        label: 'Config readability',
+        status: 'fail',
+        summary: `${configPath} must contain a JSON object.`,
+        data: { configPath },
+      },
+    };
+  }
+
+  const requiredSections = ['up', 'gu', 'analytics'];
+  const missingSections = requiredSections.filter((section) => !hasOwn(parsed, section));
+  return {
+    config: parsed,
+    check: {
+      id: 'config.read',
+      label: 'Config readability',
+      status: missingSections.length ? 'warn' : 'pass',
+      summary: missingSections.length
+        ? `Config is readable but missing sections: ${missingSections.join(', ')}.`
+        : 'Config is readable and has the expected top-level sections.',
+      data: { configPath, missingSections },
+    },
+  };
+};
+
+const guConfigChecks = (
+  config: ConfigObject | null,
+  env: NodeJS.ProcessEnv,
+  runCommand: RunCommand,
+): SetupReadinessCheck[] => {
+  if (!config) {
+    return [{
+      id: 'gu.config',
+      label: 'Gist backup config',
+      status: 'info',
+      summary: 'Skipping Gist backup config checks until config is readable.',
+    }];
+  }
+
+  const guConfig = isConfigObject(config.gu) ? config.gu : null;
+  const host = guConfig && typeof guConfig.host === 'string' ? guConfig.host.trim() : '';
+  const id = guConfig && typeof guConfig.id === 'string' ? guConfig.id.trim() : '';
+  const hasConfiguredId = Boolean(id) && id !== 'null';
+  const checks: SetupReadinessCheck[] = [
+    {
+      id: 'gu.host',
+      label: 'Gist host',
+      status: host ? 'pass' : 'fail',
+      summary: host
+        ? `Gist host is configured as ${host}.`
+        : 'Gist host is not configured.',
+      data: { host: host || null },
+    },
+    {
+      id: 'gu.gist',
+      label: 'Gist ID',
+      status: hasConfiguredId ? 'pass' : 'warn',
+      summary: hasConfiguredId
+        ? 'Backup Gist ID is configured.'
+        : 'Backup Gist ID is not configured yet.',
+      data: { configured: hasConfiguredId },
+    },
+  ];
+
+  const ghAvailable = commandExists('gh', { env });
+  checks.push({
+    id: 'gu.gh',
+    label: 'GitHub CLI',
+    status: ghAvailable ? 'pass' : 'warn',
+    summary: ghAvailable
+      ? 'GitHub CLI is discoverable on PATH.'
+      : 'GitHub CLI is not discoverable on PATH.',
+    data: { command: 'gh', found: ghAvailable },
+  });
+
+  if (!host) {
+    checks.push({
+      id: 'gu.auth',
+      label: 'GitHub CLI authentication',
+      status: 'info',
+      summary: 'Skipping GitHub CLI authentication check until gu.host is configured.',
+    });
+    return checks;
+  }
+
+  if (!ghAvailable) {
+    checks.push({
+      id: 'gu.auth',
+      label: 'GitHub CLI authentication',
+      status: 'info',
+      summary: 'Skipping GitHub CLI authentication check because gh is not on PATH.',
+      data: { host },
+    });
+    return checks;
+  }
+
+  const authResult = runCommand('gh', ['auth', 'status', '--hostname', host], {
+    env: {
+      ...env,
+      GH_HOST: host,
+    },
+    stdio: ['ignore', 'ignore', 'pipe'],
+  });
+  const exitStatus = authResult.error ? 1 : spawnResultStatus(authResult);
+  checks.push({
+    id: 'gu.auth',
+    label: 'GitHub CLI authentication',
+    status: authResult.status === 0 && !authResult.error ? 'pass' : 'warn',
+    summary: authResult.status === 0 && !authResult.error
+      ? `GitHub CLI is authenticated for ${host}.`
+      : `GitHub CLI is not authenticated for ${host}.`,
+    data: { host, exitStatus },
+  });
+
+  return checks;
+};
+
+const overallStatus = (checks: SetupReadinessCheck[]): SetupReadinessOverallStatus => {
+  if (checks.some(({ status }) => status === 'fail')) {
+    return 'fail';
+  }
+  if (checks.some(({ status }) => status === 'warn')) {
+    return 'warn';
+  }
+  return 'pass';
+};
+
+const collectSetupReadiness = ({
+  repoDir,
+  configPath = path.join(repoDir, 'ballin.config.json'),
+  env = process.env,
+  nodeVersion = process.versions.node,
+  nodeEngine,
+  runCommand = defaultRunCommand,
+}: CollectSetupReadinessOptions): SetupReadinessReport => {
+  const checks: SetupReadinessCheck[] = [
+    nodeRuntimeCheck(repoDir, nodeVersion, nodeEngine),
+    commandShimCheck(env),
+  ];
+  const { check: configCheck, config } = readConfig(configPath);
+  checks.push(configCheck);
+  checks.push(...guConfigChecks(config, env, runCommand));
+
+  return {
+    status: overallStatus(checks),
+    checks,
+  };
+};
+
+module.exports = {
+  collectSetupReadiness,
+  requiredCommandShims,
+};
+
+export type {
+  CollectSetupReadinessOptions,
+  SetupReadinessCheck,
+  SetupReadinessOverallStatus,
+  SetupReadinessReport,
+  SetupReadinessStatus,
+};

--- a/test/setup_readiness.test.ts
+++ b/test/setup_readiness.test.ts
@@ -1,0 +1,240 @@
+const { assert } = require('chai');
+const { spawnSync } = require('child_process');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const {
+  collectSetupReadiness,
+  requiredCommandShims,
+} = require('../commands/setup_readiness.ts');
+
+type ReadinessCheck = {
+  id: string;
+  status: string;
+  summary: string;
+  data?: Record<string, unknown>;
+};
+type ReadinessReport = {
+  status: string;
+  checks: ReadinessCheck[];
+};
+type FakeRunResult = {
+  status: number | null;
+  signal: NodeJS.Signals | null;
+  stdout: string;
+  stderr: string;
+  error?: Error;
+};
+
+const installSetupPath = path.join(__dirname, '..', 'commands', 'install_setup.ts');
+
+describe('setup readiness', () => {
+  let tempDir: string;
+  let repoDir: string;
+  let binDir: string;
+  let configPath: string;
+  let commandLog: string[];
+  let authStatus: number;
+
+  const writeExecutable = (name: string, contents = '#!/usr/bin/env bash\nexit 0\n') => {
+    fs.writeFileSync(path.join(binDir, name), contents, { mode: 0o755 });
+  };
+
+  const writeConfig = (config: unknown) => {
+    fs.writeFileSync(configPath, `${JSON.stringify(config)}\n`);
+  };
+
+  const checkById = (report: ReadinessReport, id: string): ReadinessCheck => {
+    const check = report.checks.find((candidate) => candidate.id === id);
+    assert.exists(check, `expected readiness check ${id}`);
+    return check as ReadinessCheck;
+  };
+
+  const fakeRunCommand = (
+    command: string,
+    args: string[] = [],
+  ): FakeRunResult => {
+    commandLog.push([command, ...args].join(' '));
+    return {
+      status: authStatus,
+      signal: null,
+      stdout: '',
+      stderr: authStatus === 0 ? '' : 'simulated auth failure\n',
+    };
+  };
+
+  const collect = (options: {
+    nodeVersion?: string;
+    nodeEngine?: string;
+    runCommand?: typeof fakeRunCommand;
+  } = {}): ReadinessReport => collectSetupReadiness({
+    repoDir,
+    configPath,
+    env: {
+      PATH: binDir,
+    },
+    runCommand: options.runCommand ?? fakeRunCommand,
+    nodeVersion: options.nodeVersion,
+    nodeEngine: options.nodeEngine,
+  });
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ballin-readiness-'));
+    repoDir = path.join(tempDir, 'repo');
+    binDir = path.join(tempDir, 'bin');
+    configPath = path.join(repoDir, 'ballin.config.json');
+    commandLog = [];
+    authStatus = 0;
+
+    fs.mkdirSync(repoDir, { recursive: true });
+    fs.mkdirSync(binDir, { recursive: true });
+    fs.writeFileSync(path.join(repoDir, 'package.json'), JSON.stringify({
+      engines: {
+        node: '>=24.12',
+      },
+    }));
+    requiredCommandShims.forEach((command: string) => writeExecutable(command));
+    writeExecutable('gh');
+    writeConfig({
+      up: {},
+      gu: {
+        id: 'test-gist-id',
+        host: 'example.test',
+      },
+      analytics: {},
+    });
+  });
+
+  afterEach(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('reports supported and unsupported Node.js runtimes', () => {
+    const supported = collect({ nodeVersion: '24.12.0', nodeEngine: '>=24.12' });
+    const unsupported = collect({ nodeVersion: '24.11.9', nodeEngine: '>=24.12' });
+
+    assert.equal(checkById(supported, 'runtime.node').status, 'pass');
+    assert.equal(checkById(unsupported, 'runtime.node').status, 'fail');
+    assert.equal(unsupported.status, 'fail');
+  });
+
+  it('reports missing and non-executable command shims on PATH', () => {
+    fs.rmSync(path.join(binDir, 'up'));
+    fs.writeFileSync(path.join(binDir, 'gu'), 'not executable\n', { mode: 0o644 });
+    fs.chmodSync(path.join(binDir, 'gu'), 0o644);
+
+    const report = collect();
+    const commandCheck = checkById(report, 'commands.path');
+
+    assert.equal(commandCheck.status, 'fail');
+    assert.deepEqual(commandCheck.data?.missing, ['gu', 'up']);
+  });
+
+  it('reports config readability and top-level section availability', () => {
+    const readableConfig = collect();
+    fs.rmSync(configPath);
+    assert.equal(checkById(collect(), 'config.read').status, 'fail');
+
+    fs.writeFileSync(configPath, '{not json\n');
+    assert.include(checkById(collect(), 'config.read').summary, 'not valid JSON');
+
+    writeConfig({ gu: { id: null, host: 'example.test' } });
+    const sectionCheck = checkById(collect(), 'config.read');
+
+    assert.equal(checkById(readableConfig, 'config.read').status, 'pass');
+    assert.equal(sectionCheck.status, 'warn');
+    assert.deepEqual(sectionCheck.data?.missingSections, ['up', 'analytics']);
+  });
+
+  it('reports successful Gist readiness signals without mutating anything', () => {
+    const beforeConfig = fs.readFileSync(configPath, 'utf8');
+
+    const report = collect();
+
+    assert.equal(report.status, 'pass');
+    assert.equal(checkById(report, 'gu.host').status, 'pass');
+    assert.equal(checkById(report, 'gu.gist').status, 'pass');
+    assert.equal(checkById(report, 'gu.gh').status, 'pass');
+    assert.equal(checkById(report, 'gu.auth').status, 'pass');
+    assert.deepEqual(commandLog, ['gh auth status --hostname example.test']);
+    assert.equal(fs.readFileSync(configPath, 'utf8'), beforeConfig);
+    assert.notInclude(commandLog.join('\n'), 'gist create');
+    assert.notInclude(commandLog.join('\n'), 'gist edit');
+    assert.notInclude(commandLog.join('\n'), 'ballin_config set');
+  });
+
+  it('reports unconfigured Gist ID and missing gh as non-mutating warnings', () => {
+    fs.rmSync(path.join(binDir, 'gh'));
+    writeConfig({
+      up: {},
+      gu: {
+        id: null,
+        host: 'example.test',
+      },
+      analytics: {},
+    });
+
+    const report = collect();
+
+    assert.equal(report.status, 'warn');
+    assert.equal(checkById(report, 'gu.gist').status, 'warn');
+    assert.equal(checkById(report, 'gu.gh').status, 'warn');
+    assert.equal(checkById(report, 'gu.auth').status, 'info');
+    assert.deepEqual(commandLog, []);
+  });
+
+  it('reports missing Gist host and failed gh auth', () => {
+    writeConfig({
+      up: {},
+      gu: {
+        id: 'test-gist-id',
+      },
+      analytics: {},
+    });
+
+    const missingHost = collect();
+    assert.equal(checkById(missingHost, 'gu.host').status, 'fail');
+    assert.equal(checkById(missingHost, 'gu.auth').status, 'info');
+    assert.deepEqual(commandLog, []);
+
+    writeConfig({
+      up: {},
+      gu: {
+        id: 'test-gist-id',
+        host: 'example.test',
+      },
+      analytics: {},
+    });
+    authStatus = 4;
+    const authFailed = collect();
+
+    assert.equal(checkById(authFailed, 'gu.auth').status, 'warn');
+    assert.equal(authFailed.status, 'warn');
+    assert.deepEqual(commandLog, ['gh auth status --hostname example.test']);
+  });
+
+  it('exposes readiness JSON through the install setup developer CLI', () => {
+    const result = spawnSync(process.execPath, [
+      installSetupPath,
+      'readiness',
+      repoDir,
+    ], {
+      encoding: 'utf8',
+      env: {
+        PATH: binDir,
+      },
+    });
+    const supportResult = spawnSync(process.execPath, [
+      installSetupPath,
+      'supports-command',
+      'readiness',
+    ], {
+      encoding: 'utf8',
+    });
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(result.stderr, '');
+    assert.equal(JSON.parse(result.stdout).checks[0].id, 'runtime.node');
+    assert.equal(supportResult.status, 0, supportResult.stderr);
+  });
+});

--- a/test/setup_readiness.test.ts
+++ b/test/setup_readiness.test.ts
@@ -1,5 +1,4 @@
 const { assert } = require('chai');
-const { spawnSync } = require('child_process');
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
@@ -25,8 +24,6 @@ type FakeRunResult = {
   stderr: string;
   error?: Error;
 };
-
-const installSetupPath = path.join(__dirname, '..', 'commands', 'install_setup.ts');
 
 describe('setup readiness', () => {
   let tempDir: string;
@@ -211,30 +208,5 @@ describe('setup readiness', () => {
     assert.equal(checkById(authFailed, 'gu.auth').status, 'warn');
     assert.equal(authFailed.status, 'warn');
     assert.deepEqual(commandLog, ['gh auth status --hostname example.test']);
-  });
-
-  it('exposes readiness JSON through the install setup developer CLI', () => {
-    const result = spawnSync(process.execPath, [
-      installSetupPath,
-      'readiness',
-      repoDir,
-    ], {
-      encoding: 'utf8',
-      env: {
-        PATH: binDir,
-      },
-    });
-    const supportResult = spawnSync(process.execPath, [
-      installSetupPath,
-      'supports-command',
-      'readiness',
-    ], {
-      encoding: 'utf8',
-    });
-
-    assert.equal(result.status, 0, result.stderr);
-    assert.equal(result.stderr, '');
-    assert.equal(JSON.parse(result.stdout).checks[0].id, 'runtime.node');
-    assert.equal(supportResult.status, 0, supportResult.stderr);
   });
 });


### PR DESCRIPTION
## Summary

Closes #173.

Adds a focused first slice of shared, read-only setup readiness checks:

- checks the current Node.js runtime against the package engine
- checks whether the installed command shims are discoverable on `PATH`
- checks `ballin.config.json` readability and basic top-level section availability
- reports basic `gu`/Gist readiness signals, including `gu.host`, configured Gist ID, `gh` availability, and `gh auth status --hostname <host>`

## Scope decision

The original direction included reusable setup/readiness state that could eventually be used by installer output, `ballin`, `up`, or a future doctor command. This PR keeps that first slice to the shared helper and tests only.

Normal install and update behavior is intentionally unchanged. The helper is not wired into `install_setup.ts setup`, `ballin_update`, or `up` yet because those surfaces need separate UX and exit-status decisions: when to show readiness, whether warnings are noisy, and whether any readiness state should block setup/update. That follow-up is tracked in #191.

## Why this is separate from `ballin doctor`

This PR intentionally adds the reusable readiness foundation before adding a public UX. The expected future consumer is a `ballin doctor` style command, but keeping this PR to structured helper logic makes the first slice easier to review and avoids deciding command routing, output wording, and exit-status semantics here.

The checks return structured results from `commands/setup_readiness.ts` so future installer output, update flows, `ballin doctor`, `up`, or other surfaces can choose their own display format without reimplementing the underlying checks.

## Surfaces

- Adds the shared helper and isolated tests only.
- Keeps normal install, update, `up`, `gu`, and `ballin` behavior unchanged.
- Does not add an internal `install_setup` readiness subcommand, `ballin doctor`, `ballin update`, or any command-routing changes.

## Follow-ups

- #191 tracks whether install/update should consume readiness output.
- #187 tracks `ballin doctor` health-check design.
- #194 tracks broader `ballin <subcommand>` routing and product/CLI naming.
- #188 tracks Homebrew-specific `brew doctor` readiness integration.

## Validation

- `npm test`