### PR TITLE
[codex] Add analytics worker rate limiting

### DIFF
--- a/analytics-worker/README.md
+++ b/analytics-worker/README.md
@@ -86,9 +86,8 @@ process request metadata operationally before the worker runs; the application
 schema does not read or persist it.
 
 The ingest token is a deployment gate for the backend skeleton, not a permanent
-abuse solution for a distributed CLI. Before production traffic is enabled,
-configure Cloudflare-side rate limiting or equivalent edge protection for
-`POST /v1/events`.
+abuse solution for a distributed CLI. The Worker also uses a Cloudflare Workers
+rate limiting binding for `POST /v1/events`.
 
 ## Local Setup
 
@@ -114,14 +113,13 @@ This repository does not require a live Cloudflare project yet. When ready:
    wrangler secret put INGEST_TOKEN
    ```
 
-6. Configure Cloudflare-side rate limiting for `POST /v1/events`.
-7. Apply migrations:
+6. Apply migrations:
 
    ```shell
    wrangler d1 migrations apply ballin-scripts-analytics
    ```
 
-8. Deploy:
+7. Deploy:
 
    ```shell
    wrangler deploy

--- a/analytics-worker/README.md
+++ b/analytics-worker/README.md
@@ -91,7 +91,9 @@ rate limiting binding for `POST /v1/events`.
 
 ## Local Setup
 
-This repository does not require a live Cloudflare project yet. When ready:
+This repository does not require a live Cloudflare project yet. When ready, run
+these commands from `analytics-worker/`. If Wrangler is not installed globally,
+use `npx wrangler` in place of `wrangler`.
 
 1. Copy `wrangler.toml.example` to `wrangler.toml`.
 2. Create a D1 database:

--- a/analytics-worker/src/index.ts
+++ b/analytics-worker/src/index.ts
@@ -8,6 +8,10 @@ type D1PreparedStatement = {
   run: () => Promise<unknown>;
 };
 
+type RateLimit = {
+  limit: (options: { key: string }) => Promise<{ success: boolean }>;
+};
+
 type ExecutionContext = {
   waitUntil: (promise: Promise<unknown>) => void;
 };
@@ -19,6 +23,7 @@ type ScheduledController = {
 
 type Env = {
   ANALYTICS_DB: D1Database;
+  ANALYTICS_RATE_LIMITER: RateLimit;
   INSTALL_ID_HASH_SECRET: string;
   INGEST_TOKEN: string;
 };
@@ -72,6 +77,7 @@ const ingestTokenHeader = 'x-ballin-analytics-token';
 const maxBodyBytes = 2048;
 const retentionDays = 395;
 const allowedDateSkewDays = 1;
+const eventRateLimitKey = 'v1-events';
 
 const jsonResponse = (status: number, body: { error: string }): Response => (
   new Response(JSON.stringify(body), {
@@ -239,9 +245,18 @@ const storeAnalyticsEvent = async (env: Env, event: AnalyticsEvent): Promise<voi
   ]);
 };
 
+const rateLimitEventRequest = async (env: Env): Promise<Response | null> => {
+  const { success } = await env.ANALYTICS_RATE_LIMITER.limit({ key: eventRateLimitKey });
+  return success ? null : emptyResponse(429);
+};
+
 const handleEventRequest = async (request: Request, env: Env): Promise<Response> => {
   if (request.method !== 'POST') {
     return emptyResponse(405);
+  }
+  const rateLimitedResponse = await rateLimitEventRequest(env);
+  if (rateLimitedResponse) {
+    return rateLimitedResponse;
   }
   if (!request.headers.get('content-type')?.toLowerCase().includes('application/json')) {
     return jsonResponse(400, { error: 'content-type must be application/json' });

--- a/analytics-worker/src/index.ts
+++ b/analytics-worker/src/index.ts
@@ -254,10 +254,6 @@ const handleEventRequest = async (request: Request, env: Env): Promise<Response>
   if (request.method !== 'POST') {
     return emptyResponse(405);
   }
-  const rateLimitedResponse = await rateLimitEventRequest(env);
-  if (rateLimitedResponse) {
-    return rateLimitedResponse;
-  }
   if (!request.headers.get('content-type')?.toLowerCase().includes('application/json')) {
     return jsonResponse(400, { error: 'content-type must be application/json' });
   }
@@ -269,6 +265,10 @@ const handleEventRequest = async (request: Request, env: Env): Promise<Response>
   }
   if (request.headers.get(ingestTokenHeader) !== env.INGEST_TOKEN) {
     return emptyResponse(401);
+  }
+  const rateLimitedResponse = await rateLimitEventRequest(env);
+  if (rateLimitedResponse) {
+    return rateLimitedResponse;
   }
   const body = await request.text();
   if (new TextEncoder().encode(body).byteLength > maxBodyBytes) {

--- a/analytics-worker/wrangler.toml.example
+++ b/analytics-worker/wrangler.toml.example
@@ -7,5 +7,13 @@ binding = "ANALYTICS_DB"
 database_name = "ballin-scripts-analytics"
 database_id = "replace-with-cloudflare-d1-database-id"
 
+[[ratelimits]]
+name = "ANALYTICS_RATE_LIMITER"
+namespace_id = "1001"
+
+  [ratelimits.simple]
+  limit = 1_500
+  period = 60
+
 [triggers]
 crons = ["17 3 * * *"]

--- a/docs/analytics-backend.md
+++ b/docs/analytics-backend.md
@@ -4,9 +4,9 @@
 analytics. The backend records only the minimal signals needed for active
 installs, top-level command usage, and command success or failure.
 
-The backend skeleton lives in [`analytics-worker/`](../analytics-worker/). It is
-not deployed by default and does not require a Cloudflare account to work on the
-CLI.
+The backend skeleton lives in [`analytics-worker/`](../analytics-worker/). Its
+package README covers Worker setup commands. It is not deployed by default and
+does not require a Cloudflare account to work on the CLI.
 
 ## Production Setup
 

--- a/docs/analytics-backend.md
+++ b/docs/analytics-backend.md
@@ -22,7 +22,8 @@ notice and [Analytics](analytics.md).
 - D1 can count active installs from daily buckets and server-hashed install IDs.
 - The CLI does not need a runtime analytics SDK.
 - Retention is controlled by the Worker and D1 schema.
-- The deployment can stay tiny: one Worker, one D1 database, and two secrets.
+- The deployment can stay tiny: one Worker, one D1 database, one rate-limit
+  binding, and two secrets.
 
 ## Alternatives Considered
 
@@ -40,11 +41,10 @@ daily install and command-count data.
 
 ## Abuse Controls
 
-The skeleton requires an ingest token before accepting events and rejects
-oversized payloads. A distributed CLI cannot keep a token truly secret, so this
-is a deployment gate rather than the complete production abuse story. Before
-real production traffic is enabled, configure Cloudflare-side rate limiting or
-equivalent edge protection for `POST /v1/events`.
+The skeleton requires an ingest token before accepting events, rejects oversized
+payloads, and applies a Workers rate-limit binding to `POST /v1/events`. A
+distributed CLI cannot keep a token truly secret, so the token is only one part
+of the production abuse story.
 
 ## Production Checklist
 
@@ -55,7 +55,7 @@ Before enabling the CLI to send production events:
 - apply `analytics-worker/migrations/0001_initial.sql`
 - set `INSTALL_ID_HASH_SECRET`
 - set `INGEST_TOKEN`
-- configure Cloudflare-side rate limiting or equivalent edge protection
+- confirm the `ANALYTICS_RATE_LIMITER` binding is deployed
 - deploy the Worker
 - configure the CLI endpoint in the client implementation
 - re-check that the client payload, first-run notice, and `docs/analytics.md`


### PR DESCRIPTION
Refs #185

## Summary

- add a Cloudflare Workers rate-limit binding to the analytics Worker
- return `429` for rate-limited `POST /v1/events` requests before parsing/storing payloads
- document the binding in the Worker setup checklist, including running Wrangler from `analytics-worker/`

## Notes

This is a prerequisite for enabling production analytics sends, not the final CLI production wiring. The endpoint/token should still remain disabled until the Worker/D1 deployment is created, migrations and secrets are applied, the rate-limit binding is confirmed, and synthetic requests verify the payload/storage behavior.

## Validation

- `npm test` (216 passing)
