### PR TITLE
[codex] Polish README positioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,11 +48,10 @@ and tradeoffs.
 
 ## Fresh Mac setup
 
-On a new Mac, install `ballin-scripts` and point it at an existing backup Gist.
-The installer can adopt that Gist and restore saved `ballin_config` values,
-while the Gist snapshots provide the reference for recreating shell files, Git
-settings, package lists, editor settings, and other development-environment
-state.
+On a new Mac, install `ballin-scripts` and let the installer create the private
+backup Gist used by `gu`. Future snapshots provide the reference for recreating
+shell files, Git settings, package lists, editor settings, and other
+development-environment state.
 
 This is currently a backup and maintenance toolkit, not a full one-command
 machine restore system. The backed-up snapshots make rebuilds more repeatable

--- a/README.md
+++ b/README.md
@@ -48,9 +48,9 @@ and tradeoffs.
 
 ## Fresh Mac setup
 
-On a new Mac, install `ballin-scripts` and let the installer create the private
-backup Gist used by `gu`. Future snapshots provide the reference for recreating
-shell files, Git settings, package lists, editor settings, and other
+On a new Mac, install `ballin-scripts` and let the installer create or adopt the
+private backup Gist used by `gu`. Future snapshots provide the reference for
+recreating shell files, Git settings, package lists, editor settings, and other
 development-environment state.
 
 This is currently a backup and update toolkit, not a full one-command

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ with minimal manual setup. It backs up the files, package lists, editor settings
 and local configuration that define your setup, then automates routine updates.
 
 It is built for people who want a repeatable macOS development environment with
-low-friction maintenance.
+low-friction routine updates.
 
 Core commands:
 
@@ -30,13 +30,13 @@ when moving between Macs or rebuilding a development machine:
 See the [supported capabilities reference](docs/capabilities.md) for the exact
 snapshot files and update integrations.
 
-## Backup and maintenance behavior
+## Backup and update behavior
 
-The tools split backup from broader system maintenance:
+The tools split backup from broader system updates:
 
 - `gu` reads local development-environment state and uploads changed snapshots
   to the configured private Gist.
-- `up` runs maintenance tasks such as Homebrew upgrades, optional Node.js/npm
+- `up` runs update tasks such as Homebrew upgrades, optional Node.js/npm
   updates, optional macOS and App Store updates, optional `ballin-scripts`
   updates, and optional `gu` backups.
 - Installation adds the command shims to your shell path and configures the
@@ -53,7 +53,7 @@ backup Gist used by `gu`. Future snapshots provide the reference for recreating
 shell files, Git settings, package lists, editor settings, and other
 development-environment state.
 
-This is currently a backup and maintenance toolkit, not a full one-command
+This is currently a backup and update toolkit, not a full one-command
 machine restore system. The backed-up snapshots make rebuilds more repeatable
 and auditable.
 
@@ -117,8 +117,8 @@ No updates are available.
 
 ### Update with `up`
 
-`up` automates common maintenance tasks for a macOS development machine,
-including Homebrew maintenance, App Store and macOS updates, `ballin-scripts`
+`up` automates common update tasks for a macOS development machine,
+including Homebrew upgrades, App Store and macOS updates, `ballin-scripts`
 updates, optional Node.js/npm updates, and optional `gu` backups.
 
 ```shell

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ with minimal manual setup. It backs up the files, package lists, editor settings
 and local configuration that define your setup, then automates routine updates.
 
 It is built for people who want a repeatable macOS development environment with
-low-friction routine updates.
+low-friction updates.
 
 Core commands:
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ low-friction maintenance.
 
 Core commands:
 
-- `up` updates and maintains the development environment.
+- `up` updates the development environment.
 - `gu` snapshots the development environment to a private Gist.
 
 ## What it manages

--- a/README.md
+++ b/README.md
@@ -3,23 +3,21 @@
 *Back up your dotfiles and update your macOS development environment.*
 
 `ballin-scripts` helps you recreate and maintain a macOS development environment
-with minimal manual setup. It backs up dotfiles, editor settings, Homebrew
-state, npm globals, and related configuration to a private Gist, then automates
-routine updates.
+with minimal manual setup. It backs up the files, package lists, editor settings,
+and local configuration that define your setup, then automates routine updates.
 
-It is built for people who want their Mac setup to be repeatable: the files and
-package lists that define the environment are captured in one place, and the
-routine update path is available as a single command.
+It is built for people who want a repeatable macOS development environment with
+low-friction maintenance.
 
 Core commands:
 
-- `up` updates the development environment.
-- `gu` snapshots it to a private Gist.
+- `up` updates and maintains the development environment.
+- `gu` snapshots the development environment to a private Gist.
 
 ## What it manages
 
-`ballin-scripts` focuses on the state that is easy to lose when moving between
-Macs or rebuilding a development machine:
+`ballin-scripts` backs up development-environment state that is easy to lose
+when moving between Macs or rebuilding a development machine:
 
 - shell startup files and common editor config files
 - Git config and global ignore files
@@ -32,7 +30,7 @@ Macs or rebuilding a development machine:
 See the [supported capabilities reference](docs/capabilities.md) for the exact
 snapshot files and update integrations.
 
-## What it changes
+## Backup and maintenance behavior
 
 The tools split backup from broader system maintenance:
 
@@ -50,11 +48,11 @@ and tradeoffs.
 
 ## Fresh Mac setup
 
-On a new Mac, install `ballin-scripts` and point it at an existing backup Gist
-when prompted. The installer can adopt that Gist and restore saved
-`ballin_config` values, while the Gist snapshots provide the reference for
-recreating shell files, Git settings, package lists, editor settings, and other
-development-environment state.
+On a new Mac, install `ballin-scripts` and point it at an existing backup Gist.
+The installer can adopt that Gist and restore saved `ballin_config` values,
+while the Gist snapshots provide the reference for recreating shell files, Git
+settings, package lists, editor settings, and other development-environment
+state.
 
 This is currently a backup and maintenance toolkit, not a full one-command
 machine restore system. The backed-up snapshots make rebuilds more repeatable


### PR DESCRIPTION
## Summary
- Refine the README opening so `ballin-scripts` is positioned around backing up development-environment state and maintaining a repeatable macOS development environment.
- Clarify the core `up` and `gu` commands and rename the behavior section around backup and maintenance.
- Tighten the fresh Mac setup wording while preserving the existing structure and technical scope.

## Follow-up issues
- #192
- #193
- #194

## Tests
- Not run; README-only docs update.