### PR TITLE
[codex] Enable production analytics sends

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 ballin.config.json
 /.gu-cache
 /.analytics
+/analytics-worker/.wrangler/
+/analytics-worker/wrangler.toml

--- a/analytics-worker/README.md
+++ b/analytics-worker/README.md
@@ -1,8 +1,8 @@
 # Analytics Worker
 
-This is the proposed backend for the minimal `ballin-scripts` active-install
-analytics described in issue #166. It is intentionally isolated from the CLI so
-the command package does not gain runtime analytics SDK dependencies.
+This is the backend for the minimal `ballin-scripts` active-install analytics.
+It is intentionally isolated from the CLI so the command package does not gain
+runtime analytics SDK dependencies.
 
 The backend is a Cloudflare Worker with a D1 database binding. It accepts a
 single narrow event shape, hashes the client install ID before storage, and
@@ -85,17 +85,21 @@ The worker should ignore request IP for analytics purposes. Cloudflare may still
 process request metadata operationally before the worker runs; the application
 schema does not read or persist it.
 
-The ingest token is a deployment gate for the backend skeleton, not a permanent
-abuse solution for a distributed CLI. The Worker also uses a Cloudflare Workers
-rate limiting binding for `POST /v1/events`.
+The ingest token is a public client gate once it is shipped in the CLI, not a
+secret abuse solution for a distributed CLI. The Worker also uses a Cloudflare
+Workers rate limiting binding for `POST /v1/events`.
 
-## Local Setup
+## Production Setup
 
-This repository does not require a live Cloudflare project yet. When ready, run
-these commands from `analytics-worker/`. If Wrangler is not installed globally,
-use `npx wrangler` in place of `wrangler`.
+Run these commands from `analytics-worker/`. If Wrangler is not installed
+globally, use `npx wrangler` in place of `wrangler`.
 
-1. Copy `wrangler.toml.example` to `wrangler.toml`.
+1. Copy `wrangler.toml.example` to the ignored local deployment config:
+
+   ```shell
+   cp wrangler.toml.example wrangler.toml
+   ```
+
 2. Create a D1 database:
 
    ```shell
@@ -118,7 +122,7 @@ use `npx wrangler` in place of `wrangler`.
 6. Apply migrations:
 
    ```shell
-   wrangler d1 migrations apply ballin-scripts-analytics
+   wrangler d1 migrations apply ballin-scripts-analytics --remote
    ```
 
 7. Deploy:
@@ -126,6 +130,12 @@ use `npx wrangler` in place of `wrangler`.
    ```shell
    wrangler deploy
    ```
+
+The production endpoint is:
+
+```text
+https://ballin-scripts-analytics.jballin.workers.dev/v1/events
+```
 
 ## Retention
 

--- a/analytics-worker/wrangler.toml.example
+++ b/analytics-worker/wrangler.toml.example
@@ -1,6 +1,7 @@
 name = "ballin-scripts-analytics"
 main = "src/index.ts"
 compatibility_date = "2026-06-27"
+workers_dev = true
 
 [[d1_databases]]
 binding = "ANALYTICS_DB"

--- a/commands/analytics.ts
+++ b/commands/analytics.ts
@@ -78,6 +78,8 @@ const allowedDurations = new Set(['unknown', '<1s', '1-10s', '10-60s', '1-10m', 
 const allowedOs = new Set(['darwin', 'linux', 'win32']);
 const installIdPattern = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
 const defaultAnalyticsDocsUrl = 'https://github.com/JBallin/ballin-scripts/blob/main/docs/analytics.md';
+const productionAnalyticsEndpoint = 'https://ballin-scripts-analytics.jballin.workers.dev/v1/events';
+const productionAnalyticsIngestToken = '6jC_OqsMynyQc3FKXgUN7aP3bbDQ_H_DMhGDrw7t6RE';
 const analyticsNoticeFor = (docsUrl = defaultAnalyticsDocsUrl): string => [
   'ballin-scripts collects minimal anonymous usage analytics after this notice.',
   'Disable: ballin_config set analytics.enabled false',
@@ -290,8 +292,8 @@ const recordAnalyticsEvent = (input: AnalyticsRecordInput, runtime: AnalyticsRun
       now: input.now ?? new Date(),
     }, installId);
     (runtime.sender ?? sendAnalyticsPayload)(payload, {
-      endpoint: runtime.endpoint,
-      ingestToken: runtime.ingestToken,
+      endpoint: runtime.endpoint ?? productionAnalyticsEndpoint,
+      ingestToken: runtime.ingestToken ?? productionAnalyticsIngestToken,
       timeoutMs: runtime.timeoutMs ?? defaultTimeoutMs,
     });
   } catch {

--- a/docs/analytics-backend.md
+++ b/docs/analytics-backend.md
@@ -4,16 +4,19 @@
 analytics. The backend records only the minimal signals needed for active
 installs, top-level command usage, and command success or failure.
 
-The backend skeleton lives in [`analytics-worker/`](../analytics-worker/). Its
-package README covers Worker setup commands. It is not deployed by default and
-does not require a Cloudflare account to work on the CLI.
+The backend lives in [`analytics-worker/`](../analytics-worker/). Its package
+README covers Worker setup and maintenance commands.
 
 ## Production Setup
 
-Production sends stay disabled until the CLI endpoint and token are configured.
-Before enabling them, confirm deployment, D1 binding, migrations, secrets,
-retention cleanup, abuse controls, and payload alignment with the first-run
-notice and [Analytics](analytics.md).
+Production sends use the deployed workers.dev endpoint:
+
+```text
+https://ballin-scripts-analytics.jballin.workers.dev/v1/events
+```
+
+The Worker has a D1 binding, scheduled retention cleanup, two Cloudflare
+secrets, and an `ANALYTICS_RATE_LIMITER` binding for `POST /v1/events`.
 
 ## Why Cloudflare Worker and D1
 
@@ -48,15 +51,17 @@ of the production abuse story.
 
 ## Production Checklist
 
-Before enabling the CLI to send production events:
+For production setup or recreation:
 
-- create the Cloudflare Worker project
 - create the D1 database
-- apply `analytics-worker/migrations/0001_initial.sql`
+- copy `analytics-worker/wrangler.toml.example` to ignored local
+  `analytics-worker/wrangler.toml`
+- set the D1 database ID in local `analytics-worker/wrangler.toml`
 - set `INSTALL_ID_HASH_SECRET`
 - set `INGEST_TOKEN`
-- confirm the `ANALYTICS_RATE_LIMITER` binding is deployed
+- apply `analytics-worker/migrations/0001_initial.sql` with `--remote`
 - deploy the Worker
-- configure the CLI endpoint in the client implementation
-- re-check that the client payload, first-run notice, and `docs/analytics.md`
-  match the documented allowlist
+- confirm the deployed Worker returns `204` for a valid event, `401` for a
+  missing or bad token, and `400` for unsupported fields or invalid enums
+- query D1 to confirm only hashed install/day rows and aggregate counts are
+  stored

--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -62,6 +62,6 @@ backend hashes install IDs before storage, stores daily install rows plus
 aggregate command/version/Node/OS counts, and deletes rows older than 395 days.
 
 Events are sent only when analytics are enabled and the CLI is configured with
-an analytics endpoint and token.
+the production analytics endpoint and public client token.
 
 For deployment details, see [Analytics backend](analytics-backend.md).

--- a/test/analytics.test.ts
+++ b/test/analytics.test.ts
@@ -27,6 +27,12 @@ type AnalyticsPayload = {
   osVersion: string;
 };
 
+type SenderOptions = {
+  endpoint?: string;
+  ingestToken?: string;
+  timeoutMs?: number;
+};
+
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
@@ -172,6 +178,30 @@ describe('analytics client', () => {
     assert.equal(payloads[0].installId, fixedInstallId);
     assert.deepEqual(updatedAnalytics, {
       enabled: 'true',
+    });
+  });
+
+  it('uses production endpoint and token defaults when runtime overrides are absent', () => {
+    setAnalyticsConfig({
+      enabled: 'true',
+    });
+    writeInstallId();
+    const senderOptions: SenderOptions[] = [];
+
+    recordAnalyticsEvent({
+      command: 'up',
+      now: fixedNow,
+    }, {
+      env: {},
+      installIdPath: testInstallIdPath,
+      sender: (_payload: AnalyticsPayload, options: SenderOptions) => {
+        senderOptions.push(options);
+      },
+    });
+
+    assert.deepInclude(senderOptions[0], {
+      endpoint: 'https://ballin-scripts-analytics.jballin.workers.dev/v1/events',
+      ingestToken: '6jC_OqsMynyQc3FKXgUN7aP3bbDQ_H_DMhGDrw7t6RE',
     });
   });
 


### PR DESCRIPTION
## Summary

- deploys and verifies the Cloudflare Worker/D1 analytics backend for issue #185
- enables production analytics sends through the verified workers.dev endpoint and public client token
- updates backend/analytics docs from setup-gated wording to the durable production state

## Deployment and Verification

- Worker URL: https://ballin-scripts-analytics.jballin.workers.dev/v1/events
- D1 migration applied remotely to `ballin-scripts-analytics`
- Worker deploy confirmed `ANALYTICS_DB` and `ANALYTICS_RATE_LIMITER` bindings
- Synthetic checks passed:
  - valid event returned `204`
  - missing token returned `401`
  - unsupported payload field returned `400`
  - invalid command enum returned `400`
- Remote D1 inspection confirmed a 64-character hashed install/day row plus aggregate command/runtime counts only

Local DNS had not propagated yet for the newly registered workers.dev hostname during verification, so the synthetic requests used the real HTTPS hostname with `curl --resolve` pinned to a Cloudflare DNS result.

## Validation

- `npm test` passed: 223 passing

Closes #185.
Updates #82.
