### PR TITLE
[codex] Add ballin doctor health check

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,11 +162,27 @@ Read one backed-up file from the Gist:
 gu read zshrc.sh
 ```
 
+### Check health with `ballin doctor`
+
+`ballin doctor` checks whether the Ballin-managed development environment is
+ready: supported Node.js, installed command shims, readable config, and Gist
+backup readiness.
+
+```shell
+ballin doctor
+```
+
+Healthy and warning-only runs exit `0`; warnings are concise next steps, not
+script-blocking failures. Runs with required check errors exit `1`. This command
+does not run `brew doctor`; Homebrew-specific readiness stays separate from the
+Ballin health check.
+
 ## Commands
 
 | Command | Purpose |
 | --- | --- |
 | `ballin` | Shows available commands and common usage. |
+| `ballin doctor` | Checks Ballin-managed environment health. |
 | `up` | Updates Homebrew, macOS, App Store apps, optional Node.js/npm tools, `ballin-scripts`, and optional backups. |
 | `gu` | Backs up dotfiles, editor settings, package lists, and tool state to a private Gist. |
 | `ballin_config` | Reads and updates local `ballin-scripts` settings. |

--- a/commands/ballin.ts
+++ b/commands/ballin.ts
@@ -1,6 +1,22 @@
 const {
   runWithCommandAnalytics,
 } = require('./analytics.ts');
+const path = require('path');
+const {
+  collectSetupReadiness,
+} = require('./setup_readiness.ts');
+
+type DoctorStatus = 'pass' | 'warn' | 'fail' | 'info';
+type DoctorCheck = {
+  id: string;
+  label: string;
+  status: DoctorStatus;
+  summary: string;
+};
+type DoctorReport = {
+  status: Exclude<DoctorStatus, 'info'>;
+  checks: DoctorCheck[];
+};
 
 const format = {
   fileName: '\x1b[4mfile name\x1b[0m',
@@ -31,6 +47,7 @@ Commands:
                           ${format.set} ${format.key} ${format.value} ${examples.set}
                           ${format.reset} (to defaults)
     ballin_uninstall      remove ballin-scripts
+    ballin doctor         check Ballin-managed environment health
 
 Scripts:
 
@@ -38,12 +55,82 @@ Scripts:
     up                    update brew etc.
 
 `;
+const statusLabels: Record<DoctorStatus, string> = {
+  pass: 'OK',
+  warn: 'WARN',
+  fail: 'ERROR',
+  info: 'INFO',
+};
+
+const nextSteps: Record<string, string> = {
+  'runtime.node': 'Install a supported Node.js version and reopen your shell.',
+  'commands.path': 'Run the installer again or add the Ballin command directory to PATH.',
+  'config.read': 'Recreate ballin.config.json from config/.defaultConfig.json.',
+  'gu.host': 'Set the backup host with ballin_config set gu.host <host>.',
+  'gu.gist': 'Run the installer to create or adopt a backup Gist.',
+  'gu.gh': 'Install GitHub CLI and authenticate it for your backup host.',
+  'gu.auth': 'Run gh auth login for the configured backup host.',
+};
 
 const writeStdout = (text: string): void => {
   process.stdout.write(text);
 };
 
-function runBallinCommand(): void {
+const writeStderr = (text: string): void => {
+  process.stderr.write(text);
+};
+
+const formatDoctorCheck = (check: DoctorCheck): string => {
+  const lines = [
+    `${statusLabels[check.status].padEnd(5)} ${check.label}: ${check.summary}`,
+  ];
+  if (check.status === 'warn' || check.status === 'fail') {
+    lines.push(`      Next: ${nextSteps[check.id] ?? 'Review the check output above.'}`);
+  }
+  return lines.join('\n');
+};
+
+const formatDoctorReport = (report: DoctorReport): string => {
+  const statusSummary = report.status === 'pass'
+    ? 'Ballin-managed environment health looks good.'
+    : report.status === 'warn'
+      ? 'Ballin-managed environment has warnings. Warnings do not fail this command.'
+      : 'Ballin-managed environment has errors.';
+
+  return [
+    'Ballin doctor',
+    '',
+    ...report.checks.map(formatDoctorCheck),
+    '',
+    `Result: ${statusSummary}`,
+    '',
+  ].join('\n');
+};
+
+const runDoctorCommand = (args: string[]): void => {
+  if (args.length) {
+    writeStderr('Usage: ballin doctor\n');
+    process.exitCode = 2;
+    return;
+  }
+
+  const repoDir = path.join(__dirname, '..');
+  const report = collectSetupReadiness({
+    repoDir,
+    configPath: process.env.BALLIN_TEST_CONFIG_PATH || undefined,
+    env: process.env,
+  }) as DoctorReport;
+
+  writeStdout(formatDoctorReport(report));
+  process.exitCode = report.status === 'fail' ? 1 : 0;
+};
+
+function runBallinCommand(args = process.argv.slice(2)): void {
+  if (args[0] === 'doctor') {
+    runDoctorCommand(args.slice(1));
+    return;
+  }
+
   writeStdout(ballinHelp);
 }
 

--- a/test/ballin.test.ts
+++ b/test/ballin.test.ts
@@ -3,14 +3,23 @@ const { spawnSync } = require('child_process');
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
+const {
+  requiredCommandShims,
+} = require('../commands/setup_readiness.ts');
 
 const ballinPath = path.join(__dirname, '..', 'bin', 'ballin');
 type StringSpawnResult = import('child_process').SpawnSyncReturns<string>;
 
 describe('ballin', () => {
+  let tempDir: string;
+  let binDir: string;
+  let configPath: string;
+  let commandLogPath: string;
+
   const assertHelpOutput = (result: StringSpawnResult) => {
     assert.equal(result.status, 0);
     assert.include(result.stdout, 'A Collection of Ballin Scripts!');
+    assert.include(result.stdout, 'ballin doctor');
     assert.include(result.stdout, 'ballin_update');
     assert.include(result.stdout, 'ballin_config');
     assert.include(result.stdout, 'ballin_uninstall');
@@ -18,6 +27,62 @@ describe('ballin', () => {
     assert.include(result.stdout, 'up');
     assert.equal(result.stderr, '');
   };
+
+  const writeExecutable = (name: string, contents = '#!/bin/bash\nexit 0\n') => {
+    fs.writeFileSync(path.join(binDir, name), contents, { mode: 0o755 });
+  };
+
+  const writeConfig = (config: unknown) => {
+    fs.writeFileSync(configPath, `${JSON.stringify(config)}\n`);
+  };
+
+  const runBallin = (args: string[] = []): StringSpawnResult => spawnSync(process.execPath, [
+    ballinPath,
+    ...args,
+  ], {
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      BALLIN_NO_ANALYTICS: '1',
+      BALLIN_TEST_CONFIG_PATH: configPath,
+      FAKE_COMMAND_LOG: commandLogPath,
+      PATH: binDir,
+    },
+  });
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ballin-doctor-'));
+    binDir = path.join(tempDir, 'bin');
+    configPath = path.join(tempDir, 'ballin.config.json');
+    commandLogPath = path.join(tempDir, 'commands.log');
+
+    fs.mkdirSync(binDir, { recursive: true });
+    requiredCommandShims.forEach((command: string) => writeExecutable(command));
+    writeExecutable('gh', `#!/bin/bash
+printf '%s\\n' "$*" >> "$FAKE_COMMAND_LOG"
+case "$1:$2" in
+  auth:status)
+    if [ "$*" != "auth status --hostname example.test" ]; then exit 2; fi
+    exit "\${FAKE_GH_AUTH_STATUS:-0}"
+    ;;
+  *) exit 2 ;;
+esac
+`);
+    writeConfig({
+      up: {},
+      gu: {
+        id: 'test-gist-id',
+        host: 'example.test',
+      },
+      analytics: {
+        enabled: 'false',
+      },
+    });
+  });
+
+  afterEach(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
 
   it('remains executable through its shebang', () => {
     assertHelpOutput(spawnSync(ballinPath, [], {
@@ -39,5 +104,73 @@ describe('ballin', () => {
     } finally {
       fs.rmSync(tempDir, { recursive: true, force: true });
     }
+  });
+
+  it('reports healthy Ballin-managed environment checks through doctor', () => {
+    const result = runBallin(['doctor']);
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.include(result.stdout, 'Ballin doctor');
+    assert.include(result.stdout, 'OK    Node.js runtime:');
+    assert.include(result.stdout, 'OK    Command shims on PATH:');
+    assert.include(result.stdout, 'OK    Config readability:');
+    assert.include(result.stdout, 'OK    Gist host:');
+    assert.include(result.stdout, 'OK    Gist ID:');
+    assert.include(result.stdout, 'OK    GitHub CLI:');
+    assert.include(result.stdout, 'OK    GitHub CLI authentication:');
+    assert.include(result.stdout, 'Result: Ballin-managed environment health looks good.');
+    assert.equal(result.stderr, '');
+    assert.equal(fs.readFileSync(commandLogPath, 'utf8'), 'auth status --hostname example.test\n');
+  });
+
+  it('reports doctor warnings without failing the command', () => {
+    fs.rmSync(path.join(binDir, 'gh'));
+    writeConfig({
+      up: {},
+      gu: {
+        id: null,
+        host: 'example.test',
+      },
+      analytics: {
+        enabled: 'false',
+      },
+    });
+
+    const result = runBallin(['doctor']);
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.include(result.stdout, 'WARN  Gist ID: Backup Gist ID is not configured yet.');
+    assert.include(result.stdout, 'Next: Run the installer to create or adopt a backup Gist.');
+    assert.include(result.stdout, 'WARN  GitHub CLI: GitHub CLI is not discoverable on PATH.');
+    assert.include(result.stdout, 'Next: Install GitHub CLI and authenticate it for your backup host.');
+    assert.include(result.stdout, 'INFO  GitHub CLI authentication: Skipping GitHub CLI authentication check because gh is not on PATH.');
+    assert.include(result.stdout, 'Result: Ballin-managed environment has warnings. Warnings do not fail this command.');
+    assert.equal(result.stderr, '');
+    assert.isFalse(fs.existsSync(commandLogPath));
+  });
+
+  it('fails doctor when a required health check fails', () => {
+    fs.rmSync(path.join(binDir, 'up'));
+
+    const missingShim = runBallin(['doctor']);
+
+    assert.equal(missingShim.status, 1);
+    assert.include(missingShim.stdout, 'ERROR Command shims on PATH: Missing command shims on PATH: up.');
+    assert.include(missingShim.stdout, 'Next: Run the installer again or add the Ballin command directory to PATH.');
+
+    fs.rmSync(configPath);
+    const missingConfig = runBallin(['doctor']);
+
+    assert.equal(missingConfig.status, 1);
+    assert.include(missingConfig.stdout, 'ERROR Config readability: Unable to read');
+    assert.include(missingConfig.stdout, 'Next: Recreate ballin.config.json from config/.defaultConfig.json.');
+  });
+
+  it('rejects invalid doctor usage', () => {
+    const result = runBallin(['doctor', 'extra']);
+
+    assert.equal(result.status, 2);
+    assert.equal(result.stdout, '');
+    assert.equal(result.stderr, 'Usage: ballin doctor\n');
   });
 });


### PR DESCRIPTION
## Summary

Closes #187.

Adds a small `ballin doctor` surface backed by the shared setup readiness helper from #173 / PR #189. The command stays focused on Ballin-managed development environment health and does not expand into broader CLI routing.

## What changed

- Adds `ballin doctor` handling to the existing `ballin` command.
- Formats readiness helper checks as concise `OK`, `WARN`, `ERROR`, and `INFO` lines.
- Treats warning-only doctor output as exit `0`, required check failures as exit `1`, and invalid `ballin doctor` usage as exit `2`.
- Documents the new command and explicitly keeps `brew doctor` out of this slice.
- Adds isolated tests with temp config, temp PATH, and command stubs.

## Scope notes

- Surfaces current helper checks for Node.js runtime, command shims on PATH, config readability, Gist host, Gist ID, `gh` availability, and `gh auth status`.
- Leaves raw helper metadata helper-only.
- Leaves install/update readiness output to #191.
- Leaves Homebrew-specific `brew doctor` readiness to #188.
- Leaves broader `ballin <subcommand>` routing to #194.
- Leaves reliable `ballin_config reset` recovery and future doctor copy polish to #199.

## Validation

- `npm test` (`226 passing`)
- `git diff --check`
