### PR TITLE
[codex] Document config command basics

### DIFF
--- a/docs/optional-capabilities.md
+++ b/docs/optional-capabilities.md
@@ -4,6 +4,21 @@ This guide covers choices for the required Node.js setup, plus optional tools
 and settings that extend `ballin-scripts`. The defaults keep updates predictable
 while letting you opt in to broader automation.
 
+## Working with settings
+
+Use `ballin_config` to read and update local settings. Settings use dot paths,
+such as `up.cleanup` or `analytics.enabled`.
+
+```shell
+ballin_config
+ballin_config get up.cleanup
+ballin_config set up.cleanup false
+ballin_config reset
+```
+
+`ballin_config` prints the full config, `get` prints one value, `set` updates an
+existing setting, and `reset` restores the default config.
+
 ## Node.js
 
 Node.js is required by `ballin-scripts`; install it using whichever method fits


### PR DESCRIPTION
## Summary

Adds a compact settings primer to the optional capabilities guide so readers can see how to inspect, change, and reset `ballin_config` values before the page starts using those examples.

## User impact

Users who follow the README link to optional capabilities can now see the basic `ballin_config`, `get`, `set`, and `reset` forms in one place without needing to infer them from scattered examples.

## Validation

- `git diff --check HEAD~1..HEAD`
- Skipped `npm test` because this is docs-only per repo guidance.