### PR TITLE
[codex] Add analytics D1 reporting script

### DIFF
--- a/analytics-worker/README.md
+++ b/analytics-worker/README.md
@@ -146,3 +146,40 @@ indefinite install history.
 ## Queries
 
 Example D1 queries for the key maintenance questions live in `queries/`.
+
+## Reporting
+
+Run the read-only production report from the repository root:
+
+```shell
+npm run analytics:report
+```
+
+By default, the report covers the last 30 UTC days ending today. To choose an
+inclusive date range:
+
+```shell
+npm run analytics:report -- --from 2026-06-01 --to 2026-06-30
+```
+
+The report uses local Wrangler authentication and
+`analytics-worker/wrangler.toml` to run remote D1 `SELECT` queries. It prints:
+
+- active installs by day
+- top-level command usage
+- command success, failure, and unknown counts
+- runtime/version trends from existing aggregate rows
+
+The report does not read or print Cloudflare secrets. Do not paste secret
+values into the report command. If Wrangler is not installed globally, the
+script falls back to `npx wrangler`.
+
+Reporting stays within the existing aggregate schema:
+
+- `install_days`
+- `command_events_daily`
+- `version_events_daily`
+
+It does not add telemetry fields or expose feature-level events, command
+arguments, local paths, Gist details, package/editor data, raw errors,
+environment variables, arbitrary config values, IP storage, or raw install IDs.

--- a/analytics-worker/queries/report-active-installs.sql
+++ b/analytics-worker/queries/report-active-installs.sql
@@ -1,0 +1,5 @@
+SELECT date_bucket, count(*) AS active_installs
+FROM install_days
+WHERE date_bucket BETWEEN '__FROM_DATE__' AND '__TO_DATE__'
+GROUP BY date_bucket
+ORDER BY date_bucket;

--- a/analytics-worker/queries/report-command-status.sql
+++ b/analytics-worker/queries/report-command-status.sql
@@ -1,0 +1,10 @@
+SELECT
+  command,
+  sum(count) AS total,
+  sum(CASE WHEN status = 'success' THEN count ELSE 0 END) AS successes,
+  sum(CASE WHEN status = 'failure' THEN count ELSE 0 END) AS failures,
+  sum(CASE WHEN status = 'unknown' THEN count ELSE 0 END) AS unknown
+FROM command_events_daily
+WHERE date_bucket BETWEEN '__FROM_DATE__' AND '__TO_DATE__'
+GROUP BY command
+ORDER BY total DESC, command;

--- a/analytics-worker/queries/report-runtime-trends.sql
+++ b/analytics-worker/queries/report-runtime-trends.sql
@@ -1,0 +1,11 @@
+SELECT
+  date_bucket,
+  app_version,
+  node_major,
+  os,
+  os_version,
+  sum(count) AS events
+FROM version_events_daily
+WHERE date_bucket BETWEEN '__FROM_DATE__' AND '__TO_DATE__'
+GROUP BY date_bucket, app_version, node_major, os, os_version
+ORDER BY date_bucket, events DESC, app_version, node_major, os, os_version;

--- a/analytics-worker/report.ts
+++ b/analytics-worker/report.ts
@@ -65,6 +65,13 @@ const isValidDateBucket = (value: string): boolean => {
   return !Number.isNaN(parsed.getTime()) && dateBucket(parsed) === value;
 };
 
+const requiredOptionValue = (value: string | undefined, option: string): string => {
+  if (!value || value.startsWith('--')) {
+    throw new Error(`${option} requires a value`);
+  }
+  return value;
+};
+
 const parseArgs = (args: string[]): ParsedArgs => {
   const parsed: ParsedArgs = {
     database: defaultDatabase,
@@ -77,13 +84,13 @@ const parseArgs = (args: string[]): ParsedArgs => {
       parsed.help = true;
     } else if (arg === '--from') {
       index += 1;
-      parsed.from = args[index];
+      parsed.from = requiredOptionValue(args[index], arg);
     } else if (arg === '--to') {
       index += 1;
-      parsed.to = args[index];
+      parsed.to = requiredOptionValue(args[index], arg);
     } else if (arg === '--database') {
       index += 1;
-      parsed.database = args[index] ?? '';
+      parsed.database = requiredOptionValue(args[index], arg);
     } else {
       throw new Error(`Unknown analytics report option: ${arg}`);
     }

--- a/analytics-worker/report.ts
+++ b/analytics-worker/report.ts
@@ -1,0 +1,394 @@
+const fs = require('fs');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+import type { SpawnSyncReturns } from 'child_process';
+
+type DateRange = {
+  from: string;
+  to: string;
+};
+
+type ReportOptions = DateRange & {
+  database: string;
+  rootDir?: string;
+};
+
+type ParsedArgs = {
+  database: string;
+  from?: string;
+  help: boolean;
+  to?: string;
+};
+
+type D1Row = Record<string, unknown>;
+type D1Runner = (sql: string, options: ReportOptions) => D1Row[];
+type SpawnRunner = (
+  command: string,
+  args: string[],
+  options: { cwd: string; encoding: 'utf8' },
+) => SpawnSyncReturns<string>;
+
+type ReportRows = {
+  activeInstalls: D1Row[];
+  commandStatus: D1Row[];
+  runtimeTrends: D1Row[];
+};
+
+const defaultDatabase = 'ballin-scripts-analytics';
+const datePattern = /^\d{4}-\d{2}-\d{2}$/;
+const reportQueryFiles = {
+  activeInstalls: 'report-active-installs.sql',
+  commandStatus: 'report-command-status.sql',
+  runtimeTrends: 'report-runtime-trends.sql',
+};
+
+const usage = [
+  'Usage: npm run analytics:report -- [--from YYYY-MM-DD] [--to YYYY-MM-DD] [--database NAME]',
+  '',
+  'Prints a read-only production D1 report from the existing analytics aggregates.',
+].join('\n');
+
+const dateBucket = (date: Date): string => date.toISOString().slice(0, 10);
+
+const addUtcDays = (dateBucketValue: string, days: number): string => {
+  const date = new Date(`${dateBucketValue}T00:00:00.000Z`);
+  date.setUTCDate(date.getUTCDate() + days);
+  return dateBucket(date);
+};
+
+const isValidDateBucket = (value: string): boolean => {
+  if (!datePattern.test(value)) {
+    return false;
+  }
+  const parsed = new Date(`${value}T00:00:00.000Z`);
+  return !Number.isNaN(parsed.getTime()) && dateBucket(parsed) === value;
+};
+
+const parseArgs = (args: string[]): ParsedArgs => {
+  const parsed: ParsedArgs = {
+    database: defaultDatabase,
+    help: false,
+  };
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (arg === '--help' || arg === '-h') {
+      parsed.help = true;
+    } else if (arg === '--from') {
+      index += 1;
+      parsed.from = args[index];
+    } else if (arg === '--to') {
+      index += 1;
+      parsed.to = args[index];
+    } else if (arg === '--database') {
+      index += 1;
+      parsed.database = args[index] ?? '';
+    } else {
+      throw new Error(`Unknown analytics report option: ${arg}`);
+    }
+  }
+
+  return parsed;
+};
+
+const dateRangeFromArgs = (args: ParsedArgs, now = new Date()): DateRange => {
+  const to = args.to ?? dateBucket(now);
+  const from = args.from ?? addUtcDays(to, -29);
+
+  if (!isValidDateBucket(from)) {
+    throw new Error('--from must be a valid YYYY-MM-DD date');
+  }
+  if (!isValidDateBucket(to)) {
+    throw new Error('--to must be a valid YYYY-MM-DD date');
+  }
+  if (from > to) {
+    throw new Error('--from must be on or before --to');
+  }
+
+  return { from, to };
+};
+
+const optionsFromArgs = (args: string[], now = new Date()): ReportOptions & { help: boolean } => {
+  const parsed = parseArgs(args);
+  if (!parsed.database) {
+    throw new Error('--database must not be empty');
+  }
+  if (parsed.help) {
+    return {
+      database: parsed.database,
+      from: '',
+      help: true,
+      to: '',
+    };
+  }
+
+  return {
+    ...dateRangeFromArgs(parsed, now),
+    database: parsed.database,
+    help: false,
+  };
+};
+
+const queryPath = (rootDir: string, filename: string): string => (
+  path.join(rootDir, 'analytics-worker', 'queries', filename)
+);
+
+const buildQuery = (template: string, range: DateRange): string => (
+  template
+    .replaceAll('__FROM_DATE__', range.from)
+    .replaceAll('__TO_DATE__', range.to)
+);
+
+const loadReportQueries = (options: ReportOptions): Record<keyof typeof reportQueryFiles, string> => {
+  const rootDir = options.rootDir ?? path.join(__dirname, '..');
+  return {
+    activeInstalls: buildQuery(
+      fs.readFileSync(queryPath(rootDir, reportQueryFiles.activeInstalls), 'utf8'),
+      options,
+    ),
+    commandStatus: buildQuery(
+      fs.readFileSync(queryPath(rootDir, reportQueryFiles.commandStatus), 'utf8'),
+      options,
+    ),
+    runtimeTrends: buildQuery(
+      fs.readFileSync(queryPath(rootDir, reportQueryFiles.runtimeTrends), 'utf8'),
+      options,
+    ),
+  };
+};
+
+const isObject = (value: unknown): value is Record<string, unknown> => (
+  typeof value === 'object' && value !== null && !Array.isArray(value)
+);
+
+const rowsFromD1Json = (value: unknown): D1Row[] => {
+  if (Array.isArray(value)) {
+    if (
+      value.every(isObject)
+      && value.some((item) => (
+        Array.isArray(item.results)
+        || Array.isArray(item.result)
+        || item.success === false
+      ))
+    ) {
+      return value.flatMap((item) => rowsFromD1Json(item));
+    }
+    return value.filter(isObject);
+  }
+  if (!isObject(value)) {
+    return [];
+  }
+  if (value.success === false) {
+    throw new Error('Wrangler D1 query failed');
+  }
+  if (Array.isArray(value.results)) {
+    return value.results.filter(isObject);
+  }
+  if (Array.isArray(value.result)) {
+    return rowsFromD1Json(value.result);
+  }
+  return [];
+};
+
+const parseD1Json = (stdout: string): D1Row[] => {
+  try {
+    return rowsFromD1Json(JSON.parse(stdout));
+  } catch (error) {
+    if (error instanceof SyntaxError) {
+      throw new Error('Wrangler returned invalid JSON');
+    }
+    throw error;
+  }
+};
+
+const wranglerArgsFor = (sql: string, options: ReportOptions): string[] => {
+  const rootDir = options.rootDir ?? path.join(__dirname, '..');
+  return [
+    '--config',
+    path.join(rootDir, 'analytics-worker', 'wrangler.toml'),
+    'd1',
+    'execute',
+    options.database,
+    '--remote',
+    '--json',
+    '--command',
+    sql,
+  ];
+};
+
+const runWrangler = (
+  sql: string,
+  options: ReportOptions,
+  spawnRunner: SpawnRunner = spawnSync,
+): D1Row[] => {
+  const rootDir = options.rootDir ?? path.join(__dirname, '..');
+  const wranglerArgs = wranglerArgsFor(sql, options);
+  let result = spawnRunner('wrangler', wranglerArgs, {
+    cwd: rootDir,
+    encoding: 'utf8',
+  });
+
+  if (result.error && 'code' in result.error && result.error.code === 'ENOENT') {
+    result = spawnRunner('npx', ['wrangler', ...wranglerArgs], {
+      cwd: rootDir,
+      encoding: 'utf8',
+    });
+  }
+
+  if (result.error) {
+    throw result.error;
+  }
+  if (result.status !== 0) {
+    const message = result.stderr.trim() || result.stdout.trim() || 'Wrangler D1 query failed';
+    throw new Error(message);
+  }
+
+  return parseD1Json(result.stdout);
+};
+
+const numberValue = (value: unknown): number => (
+  typeof value === 'number' && Number.isFinite(value) ? value : Number(value) || 0
+);
+
+const stringValue = (value: unknown): string => (
+  typeof value === 'string' && value.length > 0 ? value : 'unknown'
+);
+
+const dateBucketsBetween = (range: DateRange): string[] => {
+  const dates: string[] = [];
+  for (let current = range.from; current <= range.to; current = addUtcDays(current, 1)) {
+    dates.push(current);
+  }
+  return dates;
+};
+
+const table = (headers: string[], rows: string[][]): string => {
+  const widths = headers.map((header, column) => (
+    Math.max(header.length, ...rows.map((row) => row[column]?.length ?? 0))
+  ));
+  const formatRow = (row: string[]): string => (
+    row.map((cell, column) => cell.padEnd(widths[column])).join('  ').trimEnd()
+  );
+  return [
+    formatRow(headers),
+    formatRow(widths.map((width) => '-'.repeat(width))),
+    ...rows.map(formatRow),
+  ].join('\n');
+};
+
+const formatActiveInstalls = (rows: D1Row[], range: DateRange): string => {
+  const installsByDate = new Map(rows.map((row) => [
+    stringValue(row.date_bucket),
+    numberValue(row.active_installs),
+  ]));
+  const tableRows = dateBucketsBetween(range).map((day) => [
+    day,
+    String(installsByDate.get(day) ?? 0),
+  ]);
+
+  return [
+    'Active installs by day',
+    table(['date', 'active_installs'], tableRows),
+  ].join('\n');
+};
+
+const formatCommandStatus = (rows: D1Row[]): string => {
+  if (rows.length === 0) {
+    return 'Command usage\nNo command events found for this range.';
+  }
+
+  const tableRows = rows.map((row) => {
+    const total = numberValue(row.total);
+    const failures = numberValue(row.failures);
+    const failureRate = total === 0 ? '0.0%' : `${((failures / total) * 100).toFixed(1)}%`;
+    return [
+      stringValue(row.command),
+      String(total),
+      String(numberValue(row.successes)),
+      String(failures),
+      String(numberValue(row.unknown)),
+      failureRate,
+    ];
+  });
+
+  return [
+    'Command usage',
+    table(['command', 'total', 'success', 'failure', 'unknown', 'failure_rate'], tableRows),
+  ].join('\n');
+};
+
+const formatRuntimeTrends = (rows: D1Row[]): string => {
+  if (rows.length === 0) {
+    return 'Runtime/version trends\nNo runtime/version events found for this range.';
+  }
+
+  const tableRows = rows.map((row) => [
+    stringValue(row.date_bucket),
+    stringValue(row.app_version),
+    stringValue(row.node_major),
+    stringValue(row.os),
+    stringValue(row.os_version),
+    String(numberValue(row.events)),
+  ]);
+
+  return [
+    'Runtime/version trends',
+    table(['date', 'app_version', 'node_major', 'os', 'os_version', 'events'], tableRows),
+  ].join('\n');
+};
+
+const renderReport = (rows: ReportRows, options: ReportOptions): string => [
+  `Analytics report (${options.from} to ${options.to})`,
+  '',
+  formatActiveInstalls(rows.activeInstalls, options),
+  '',
+  formatCommandStatus(rows.commandStatus),
+  '',
+  formatRuntimeTrends(rows.runtimeTrends),
+  '',
+].join('\n');
+
+const generateReport = (options: ReportOptions, runner: D1Runner = runWrangler): string => {
+  const queries = loadReportQueries(options);
+  return renderReport({
+    activeInstalls: runner(queries.activeInstalls, options),
+    commandStatus: runner(queries.commandStatus, options),
+    runtimeTrends: runner(queries.runtimeTrends, options),
+  }, options);
+};
+
+const runCli = (args = process.argv.slice(2)): number => {
+  try {
+    const options = optionsFromArgs(args);
+    if (options.help) {
+      process.stdout.write(`${usage}\n`);
+      return 0;
+    }
+    process.stdout.write(generateReport(options));
+    return 0;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    process.stderr.write(`analytics report: ${message}\n`);
+    return 1;
+  }
+};
+
+if (require.main === module) {
+  process.exitCode = runCli();
+}
+
+module.exports = {
+  buildQuery,
+  dateRangeFromArgs,
+  defaultDatabase,
+  generateReport,
+  loadReportQueries,
+  optionsFromArgs,
+  parseD1Json,
+  renderReport,
+  runCli,
+  runWrangler,
+  usage,
+  wranglerArgsFor,
+};

--- a/docs/analytics-backend.md
+++ b/docs/analytics-backend.md
@@ -42,6 +42,32 @@ secrets, and an `ANALYTICS_RATE_LIMITER` binding for `POST /v1/events`.
 The Worker deletes rows older than 395 days. That keeps roughly 13 months of
 daily install and command-count data.
 
+## Reporting
+
+Use the local read-only report for production D1 aggregates:
+
+```shell
+npm run analytics:report
+```
+
+To report on a specific inclusive UTC date range:
+
+```shell
+npm run analytics:report -- --from 2026-06-01 --to 2026-06-30
+```
+
+The report runs Wrangler D1 `SELECT` queries against the remote database using
+local Wrangler authentication and `analytics-worker/wrangler.toml`. It shows
+daily active installs, top-level command usage, command success/failure counts,
+and runtime/version trends. It does not require, accept, or print Cloudflare
+secret values.
+
+The report only reads the existing aggregate tables: `install_days`,
+`command_events_daily`, and `version_events_daily`. It does not introduce new
+telemetry fields or report feature-level events, command arguments, local paths,
+Gist details, package/editor data, raw errors, environment variables,
+arbitrary config values, IPs, or raw install IDs.
+
 ## Abuse Controls
 
 The skeleton requires an ingest token before accepting events, rejects oversized

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -11,7 +11,7 @@ const jsRules = {
   ...js.configs.recommended.rules,
   'no-console': 'error',
 };
-const tsFiles = ['commands/**/*.ts', 'config/**/*.ts', 'test/**/*.ts'];
+const tsFiles = ['analytics-worker/report.ts', 'commands/**/*.ts', 'config/**/*.ts', 'test/**/*.ts'];
 
 export default tseslint.config(
   {

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Useful scripts to save time",
   "scripts": {
     "lint": "eslint .",
+    "analytics:report": "node analytics-worker/report.ts",
     "typecheck": "tsc --noEmit",
     "typecheck:analytics-worker": "tsc --noEmit --strict --target ES2023 --module ESNext --lib ES2023,WebWorker --ignoreConfig analytics-worker/src/index.ts",
     "test:unit": "mocha",

--- a/test/analytics_report.test.ts
+++ b/test/analytics_report.test.ts
@@ -1,0 +1,237 @@
+const { assert } = require('chai');
+const {
+  dateRangeFromArgs,
+  defaultDatabase,
+  generateReport,
+  loadReportQueries,
+  optionsFromArgs,
+  parseD1Json,
+  renderReport,
+  runWrangler,
+  wranglerArgsFor,
+} = require('../analytics-worker/report.ts');
+
+type D1Row = Record<string, unknown>;
+type SpawnCall = {
+  args: string[];
+  command: string;
+};
+
+describe('analytics D1 report', () => {
+  it('defaults to the last 30 UTC days ending today', () => {
+    const range = dateRangeFromArgs({
+      database: defaultDatabase,
+      help: false,
+    }, new Date('2026-06-30T23:59:00.000Z'));
+
+    assert.deepEqual(range, {
+      from: '2026-06-01',
+      to: '2026-06-30',
+    });
+  });
+
+  it('validates date arguments before building queries', () => {
+    assert.throws(() => dateRangeFromArgs({
+      database: defaultDatabase,
+      from: '2026-02-30',
+      help: false,
+      to: '2026-03-01',
+    }), '--from must be a valid YYYY-MM-DD date');
+
+    assert.throws(() => dateRangeFromArgs({
+      database: defaultDatabase,
+      from: '2026-06-30',
+      help: false,
+      to: '2026-06-01',
+    }), '--from must be on or before --to');
+  });
+
+  it('loads only read-only aggregate queries with validated date buckets', () => {
+    const queries = loadReportQueries({
+      database: defaultDatabase,
+      from: '2026-06-01',
+      to: '2026-06-30',
+    });
+    const allSql = Object.values(queries).join('\n');
+
+    assert.include(allSql, "FROM install_days");
+    assert.include(allSql, "FROM command_events_daily");
+    assert.include(allSql, "FROM version_events_daily");
+    assert.notInclude(allSql, '__FROM_DATE__');
+    assert.notInclude(allSql, '__TO_DATE__');
+    assert.notMatch(allSql, /\b(?:INSERT|UPDATE|DELETE|DROP|ALTER)\b/i);
+  });
+
+  it('renders active installs, command status, and runtime trends', () => {
+    const output = renderReport({
+      activeInstalls: [
+        { date_bucket: '2026-06-01', active_installs: 2 },
+        { date_bucket: '2026-06-03', active_installs: 1 },
+      ],
+      commandStatus: [
+        {
+          command: 'up',
+          total: 5,
+          successes: 3,
+          failures: 1,
+          unknown: 1,
+        },
+      ],
+      runtimeTrends: [
+        {
+          date_bucket: '2026-06-01',
+          app_version: '1.0.0',
+          node_major: '24',
+          os: 'darwin',
+          os_version: '15',
+          events: 5,
+        },
+      ],
+    }, {
+      database: defaultDatabase,
+      from: '2026-06-01',
+      to: '2026-06-03',
+    });
+
+    assert.include(output, 'Analytics report (2026-06-01 to 2026-06-03)');
+    assert.include(output, '2026-06-02  0');
+    assert.include(output, 'up       5      3        1        1        20.0%');
+    assert.include(output, '2026-06-01  1.0.0        24          darwin  15          5');
+  });
+
+  it('prints clear empty states for sparse aggregate data', () => {
+    const output = renderReport({
+      activeInstalls: [],
+      commandStatus: [],
+      runtimeTrends: [],
+    }, {
+      database: defaultDatabase,
+      from: '2026-06-01',
+      to: '2026-06-01',
+    });
+
+    assert.include(output, '2026-06-01  0');
+    assert.include(output, 'No command events found for this range.');
+    assert.include(output, 'No runtime/version events found for this range.');
+  });
+
+  it('generates the report with an injected D1 runner', () => {
+    const sqlStatements: string[] = [];
+    const report = generateReport({
+      database: defaultDatabase,
+      from: '2026-06-01',
+      to: '2026-06-01',
+    }, (sql: string): D1Row[] => {
+      sqlStatements.push(sql);
+      if (sql.includes('install_days')) {
+        return [{ date_bucket: '2026-06-01', active_installs: 4 }];
+      }
+      if (sql.includes('command_events_daily')) {
+        return [{
+          command: 'gu',
+          failures: 0,
+          successes: 2,
+          total: 2,
+          unknown: 0,
+        }];
+      }
+      return [{
+        app_version: '1.0.0',
+        date_bucket: '2026-06-01',
+        events: 2,
+        node_major: '24',
+        os: 'darwin',
+        os_version: '15',
+      }];
+    });
+
+    assert.lengthOf(sqlStatements, 3);
+    assert.include(report, '2026-06-01  4');
+    assert.include(report, 'gu       2      2        0        0        0.0%');
+  });
+
+  it('parses Wrangler D1 JSON result rows', () => {
+    const rows = parseD1Json(JSON.stringify([
+      {
+        results: [
+          { command: 'up', total: 3 },
+        ],
+        success: true,
+      },
+    ]));
+
+    assert.deepEqual(rows, [{ command: 'up', total: 3 }]);
+  });
+
+  it('rejects unsuccessful Wrangler D1 JSON responses', () => {
+    assert.throws(() => {
+      parseD1Json(JSON.stringify([{ success: false }]));
+    }, 'Wrangler D1 query failed');
+  });
+
+  it('builds remote JSON Wrangler D1 execute arguments', () => {
+    const args = wranglerArgsFor('SELECT 1', {
+      database: 'example-db',
+      from: '2026-06-01',
+      rootDir: '/repo',
+      to: '2026-06-30',
+    });
+
+    assert.deepEqual(args, [
+      '--config',
+      '/repo/analytics-worker/wrangler.toml',
+      'd1',
+      'execute',
+      'example-db',
+      '--remote',
+      '--json',
+      '--command',
+      'SELECT 1',
+    ]);
+  });
+
+  it('surfaces Wrangler failures without running real commands in tests', () => {
+    const calls: SpawnCall[] = [];
+
+    assert.throws(() => {
+      runWrangler('SELECT 1', {
+        database: defaultDatabase,
+        from: '2026-06-01',
+        rootDir: '/repo',
+        to: '2026-06-30',
+      }, (command: string, args: string[]) => {
+        calls.push({ args, command });
+        return {
+          error: undefined,
+          output: [],
+          pid: 1,
+          signal: null,
+          status: 1,
+          stderr: 'D1 unavailable',
+          stdout: '',
+        };
+      });
+    }, 'D1 unavailable');
+
+    assert.deepEqual(calls.map((call) => call.command), ['wrangler']);
+    assert.include(calls[0].args, '--remote');
+  });
+
+  it('parses CLI options for custom date ranges and databases', () => {
+    const options = optionsFromArgs([
+      '--from',
+      '2026-06-01',
+      '--to',
+      '2026-06-30',
+      '--database',
+      'custom-db',
+    ]);
+
+    assert.deepEqual(options, {
+      database: 'custom-db',
+      from: '2026-06-01',
+      help: false,
+      to: '2026-06-30',
+    });
+  });
+});

--- a/test/analytics_report.test.ts
+++ b/test/analytics_report.test.ts
@@ -234,4 +234,10 @@ describe('analytics D1 report', () => {
       to: '2026-06-30',
     });
   });
+
+  it('rejects missing CLI option values', () => {
+    assert.throws(() => optionsFromArgs(['--from']), '--from requires a value');
+    assert.throws(() => optionsFromArgs(['--to', '--database', 'custom-db']), '--to requires a value');
+    assert.throws(() => optionsFromArgs(['--database']), '--database requires a value');
+  });
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,6 +14,7 @@
     "types": ["node", "mocha"]
   },
   "include": [
+    "analytics-worker/report.ts",
     "commands/**/*.ts",
     "config/**/*.ts",
     "test/**/*.ts"


### PR DESCRIPTION
Fixes #202

## Summary
- add a read-only npm analytics:report script for production D1 aggregate reporting
- add approved report query templates for active installs, command status counts, and runtime/version trends
- document safe report usage without accepting or printing Cloudflare secrets

## Validation
- npm test
- npm run analytics:report -- --help