### PR TITLE
[codex] Make ballin doctor quiet by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ gu read zshrc.sh
 | Command | Purpose |
 | --- | --- |
 | `ballin` | Shows available commands and common usage. |
-| `ballin doctor` | Advanced readiness check for the Ballin-managed environment. |
+| `ballin doctor` | Checks whether the Ballin-managed environment looks ready. |
 | `up` | Updates Homebrew, macOS, App Store apps, optional Node.js/npm tools, `ballin-scripts`, and optional backups. |
 | `gu` | Backs up dotfiles, editor settings, package lists, and tool state to a private Gist. |
 | `ballin_config` | Reads and updates local `ballin-scripts` settings. |

--- a/README.md
+++ b/README.md
@@ -172,10 +172,14 @@ backup readiness.
 ballin doctor
 ```
 
-Healthy and warning-only runs exit `0`; warnings are concise next steps, not
-script-blocking failures. Runs with required check errors exit `1`. This command
-does not run `brew doctor`; Homebrew-specific readiness stays separate from the
-Ballin health check.
+Healthy runs print one concise readiness message. Warning-only runs exit `0`
+and show only warnings with next steps, not unrelated healthy checks. Runs with
+required check errors exit `1` and show failed checks with next steps. Use
+`ballin doctor --verbose` to see the full `OK`, `WARN`, `ERROR`, and `INFO`
+check list. Invalid doctor usage exits `2`.
+
+This command does not run `brew doctor`; Homebrew-specific readiness stays
+separate from the Ballin health check.
 
 ## Commands
 

--- a/README.md
+++ b/README.md
@@ -162,31 +162,12 @@ Read one backed-up file from the Gist:
 gu read zshrc.sh
 ```
 
-### Check health with `ballin doctor`
-
-`ballin doctor` checks whether the Ballin-managed development environment is
-ready: supported Node.js, installed command shims, readable config, and Gist
-backup readiness.
-
-```shell
-ballin doctor
-```
-
-Healthy runs print one concise readiness message. Warning-only runs exit `0`
-and show only warnings with next steps, not unrelated healthy checks. Runs with
-required check errors exit `1` and show failed checks with next steps. Use
-`ballin doctor --verbose` to see the full `OK`, `WARN`, `ERROR`, and `INFO`
-check list. Invalid doctor usage exits `2`.
-
-This command does not run `brew doctor`; Homebrew-specific readiness stays
-separate from the Ballin health check.
-
 ## Commands
 
 | Command | Purpose |
 | --- | --- |
 | `ballin` | Shows available commands and common usage. |
-| `ballin doctor` | Checks Ballin-managed environment health. |
+| `ballin doctor` | Advanced readiness check for the Ballin-managed environment. |
 | `up` | Updates Homebrew, macOS, App Store apps, optional Node.js/npm tools, `ballin-scripts`, and optional backups. |
 | `gu` | Backs up dotfiles, editor settings, package lists, and tool state to a private Gist. |
 | `ballin_config` | Reads and updates local `ballin-scripts` settings. |

--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ gu read zshrc.sh
 | Command | Purpose |
 | --- | --- |
 | `ballin` | Shows available commands and common usage. |
-| `ballin doctor` | Checks whether the Ballin-managed environment looks ready. |
+| `ballin doctor` | Checks whether the Ballin-managed environment is healthy. |
 | `up` | Updates Homebrew, macOS, App Store apps, optional Node.js/npm tools, `ballin-scripts`, and optional backups. |
 | `gu` | Backs up dotfiles, editor settings, package lists, and tool state to a private Gist. |
 | `ballin_config` | Reads and updates local `ballin-scripts` settings. |

--- a/commands/ballin.ts
+++ b/commands/ballin.ts
@@ -28,6 +28,7 @@ const format = {
   reset: '\x1b[1mreset\x1b[0m',
   open: '\x1b[1mopen\x1b[0m',
   read: '\x1b[1mread\x1b[0m',
+  verbose: '\x1b[1m--verbose\x1b[0m',
 };
 
 const examples = {
@@ -48,6 +49,7 @@ Commands:
                           ${format.reset} (to defaults)
     ballin_uninstall      remove ballin-scripts
     ballin doctor         check Ballin-managed environment health
+                          ${format.verbose} show full readiness details
 
 Scripts:
 

--- a/commands/ballin.ts
+++ b/commands/ballin.ts
@@ -90,7 +90,7 @@ const formatDoctorCheck = (check: DoctorCheck): string => {
   return lines.join('\n');
 };
 
-const formatDoctorReport = (report: DoctorReport): string => {
+const formatVerboseDoctorReport = (report: DoctorReport): string => {
   const statusSummary = report.status === 'pass'
     ? 'Ballin-managed environment health looks good.'
     : report.status === 'warn'
@@ -107,9 +107,20 @@ const formatDoctorReport = (report: DoctorReport): string => {
   ].join('\n');
 };
 
+const formatDefaultDoctorReport = (report: DoctorReport): string => {
+  if (report.status === 'pass') {
+    return 'Your Ballin-managed environment looks ready.\n';
+  }
+
+  const visibleStatus = report.status === 'fail' ? 'fail' : 'warn';
+  const visibleChecks = report.checks.filter(({ status }) => status === visibleStatus);
+  return `${visibleChecks.map(formatDoctorCheck).join('\n')}\n`;
+};
+
 const runDoctorCommand = (args: string[]): void => {
-  if (args.length) {
-    writeStderr('Usage: ballin doctor\n');
+  const verbose = args.length === 1 && args[0] === '--verbose';
+  if (args.length > 0 && !verbose) {
+    writeStderr('Usage: ballin doctor [--verbose]\n');
     process.exitCode = 2;
     return;
   }
@@ -121,7 +132,7 @@ const runDoctorCommand = (args: string[]): void => {
     env: process.env,
   }) as DoctorReport;
 
-  writeStdout(formatDoctorReport(report));
+  writeStdout(verbose ? formatVerboseDoctorReport(report) : formatDefaultDoctorReport(report));
   process.exitCode = report.status === 'fail' ? 1 : 0;
 };
 

--- a/commands/ballin.ts
+++ b/commands/ballin.ts
@@ -111,7 +111,7 @@ const formatVerboseDoctorReport = (report: DoctorReport): string => {
 
 const formatDefaultDoctorReport = (report: DoctorReport): string => {
   if (report.status === 'pass') {
-    return 'Your Ballin-managed environment looks ready.\n';
+    return 'Your Ballin-managed environment is healthy.\n';
   }
 
   const visibleStatus = report.status === 'fail' ? 'fail' : 'warn';

--- a/commands/ballin.ts
+++ b/commands/ballin.ts
@@ -82,12 +82,12 @@ const writeStderr = (text: string): void => {
   process.stderr.write(text);
 };
 
-const formatDoctorCheck = (check: DoctorCheck): string => {
+const formatDoctorCheck = (check: DoctorCheck, nextPrefix = '      Next: '): string => {
   const lines = [
     `${statusLabels[check.status].padEnd(5)} ${check.label}: ${check.summary}`,
   ];
   if (check.status === 'warn' || check.status === 'fail') {
-    lines.push(`      Next: ${nextSteps[check.id] ?? 'Review the check output above.'}`);
+    lines.push(`${nextPrefix}${nextSteps[check.id] ?? 'Review the check output above.'}`);
   }
   return lines.join('\n');
 };
@@ -102,7 +102,7 @@ const formatVerboseDoctorReport = (report: DoctorReport): string => {
   return [
     'Ballin doctor',
     '',
-    ...report.checks.map(formatDoctorCheck),
+    ...report.checks.map((check) => formatDoctorCheck(check)),
     '',
     `Result: ${statusSummary}`,
     '',
@@ -116,7 +116,7 @@ const formatDefaultDoctorReport = (report: DoctorReport): string => {
 
   const visibleStatus = report.status === 'fail' ? 'fail' : 'warn';
   const visibleChecks = report.checks.filter(({ status }) => status === visibleStatus);
-  return `${visibleChecks.map(formatDoctorCheck).join('\n')}\n`;
+  return `${visibleChecks.map((check) => formatDoctorCheck(check, 'Next: ')).join('\n')}\n`;
 };
 
 const runDoctorCommand = (args: string[]): void => {

--- a/docs/optional-capabilities.md
+++ b/docs/optional-capabilities.md
@@ -89,14 +89,11 @@ including Node.js, installed commands, settings, and Gist backup setup.
 ballin doctor
 ```
 
-The default output stays quiet unless something needs attention. Use
-`--verbose` for details:
+The default output is concise. Use `--verbose` for details:
 
 ```shell
 ballin doctor --verbose
 ```
-
-`ballin doctor` does not run `brew doctor`.
 
 ## Analytics
 

--- a/docs/optional-capabilities.md
+++ b/docs/optional-capabilities.md
@@ -82,26 +82,22 @@ them before continuing.
 
 ## Readiness checks
 
-Use `ballin doctor` when you want to check whether the Ballin-managed
-environment looks ready: supported Node.js, installed command shims, readable
-config, and Gist backup readiness.
+Use `ballin doctor` to check Ballin-managed readiness, including Node.js,
+command shims, config, and Gist backup setup.
 
 ```shell
 ballin doctor
 ```
 
-Healthy runs print one concise readiness message. Warning-only runs exit `0`
-and show only warnings with next steps, not unrelated healthy checks. Runs with
-required check errors exit `1` and show failed checks with next steps.
-
-Use `--verbose` to see the full `OK`, `WARN`, `ERROR`, and `INFO` check list:
+The default output stays quiet unless something needs attention. Use
+`--verbose` to see every check:
 
 ```shell
 ballin doctor --verbose
 ```
 
-Invalid doctor usage exits `2`. `ballin doctor` does not run `brew doctor`;
-Homebrew-specific readiness stays separate from the Ballin health check.
+Healthy and warning-only runs exit `0`; required failures exit `1`; invalid
+usage exits `2`. `ballin doctor` does not run `brew doctor`.
 
 ## Analytics
 

--- a/docs/optional-capabilities.md
+++ b/docs/optional-capabilities.md
@@ -82,7 +82,7 @@ them before continuing.
 
 ## Readiness checks
 
-Use `ballin doctor` to check whether the Ballin-managed environment looks ready,
+Use `ballin doctor` to check whether the Ballin-managed environment is healthy,
 including Node.js, installed commands, settings, and Gist backup setup. Add
 `--verbose` when you want the full check list.
 

--- a/docs/optional-capabilities.md
+++ b/docs/optional-capabilities.md
@@ -80,6 +80,29 @@ host, and either adopts an existing backup Gist or creates a new one. When an
 adopted backup includes saved `ballin_config` values, the installer restores
 them before continuing.
 
+## Readiness checks
+
+Use `ballin doctor` when you want to check whether the Ballin-managed
+environment looks ready: supported Node.js, installed command shims, readable
+config, and Gist backup readiness.
+
+```shell
+ballin doctor
+```
+
+Healthy runs print one concise readiness message. Warning-only runs exit `0`
+and show only warnings with next steps, not unrelated healthy checks. Runs with
+required check errors exit `1` and show failed checks with next steps.
+
+Use `--verbose` to see the full `OK`, `WARN`, `ERROR`, and `INFO` check list:
+
+```shell
+ballin doctor --verbose
+```
+
+Invalid doctor usage exits `2`. `ballin doctor` does not run `brew doctor`;
+Homebrew-specific readiness stays separate from the Ballin health check.
+
 ## Analytics
 
 `ballin-scripts` can send minimal anonymous usage analytics after a first-run

--- a/docs/optional-capabilities.md
+++ b/docs/optional-capabilities.md
@@ -83,16 +83,11 @@ them before continuing.
 ## Readiness checks
 
 Use `ballin doctor` to check whether the Ballin-managed environment looks ready,
-including Node.js, installed commands, settings, and Gist backup setup.
+including Node.js, installed commands, settings, and Gist backup setup. Add
+`--verbose` when you want the full check list.
 
 ```shell
 ballin doctor
-```
-
-The default output is concise. Use `--verbose` for details:
-
-```shell
-ballin doctor --verbose
 ```
 
 ## Analytics

--- a/docs/optional-capabilities.md
+++ b/docs/optional-capabilities.md
@@ -82,22 +82,21 @@ them before continuing.
 
 ## Readiness checks
 
-Use `ballin doctor` to check Ballin-managed readiness, including Node.js,
-command shims, config, and Gist backup setup.
+Use `ballin doctor` to check whether the Ballin-managed environment looks ready,
+including Node.js, installed commands, settings, and Gist backup setup.
 
 ```shell
 ballin doctor
 ```
 
 The default output stays quiet unless something needs attention. Use
-`--verbose` to see every check:
+`--verbose` for details:
 
 ```shell
 ballin doctor --verbose
 ```
 
-Healthy and warning-only runs exit `0`; required failures exit `1`; invalid
-usage exits `2`. `ballin doctor` does not run `brew doctor`.
+`ballin doctor` does not run `brew doctor`.
 
 ## Analytics
 

--- a/test/ballin.test.ts
+++ b/test/ballin.test.ts
@@ -106,8 +106,17 @@ esac
     }
   });
 
-  it('reports healthy Ballin-managed environment checks through doctor', () => {
+  it('reports a concise healthy doctor result by default', () => {
     const result = runBallin(['doctor']);
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(result.stdout, 'Your Ballin-managed environment looks ready.\n');
+    assert.equal(result.stderr, '');
+    assert.equal(fs.readFileSync(commandLogPath, 'utf8'), 'auth status --hostname example.test\n');
+  });
+
+  it('reports full Ballin-managed environment checks through verbose doctor', () => {
+    const result = runBallin(['doctor', '--verbose']);
 
     assert.equal(result.status, 0, result.stderr);
     assert.include(result.stdout, 'Ballin doctor');
@@ -143,10 +152,22 @@ esac
     assert.include(result.stdout, 'Next: Run the installer to create or adopt a backup Gist.');
     assert.include(result.stdout, 'WARN  GitHub CLI: GitHub CLI is not discoverable on PATH.');
     assert.include(result.stdout, 'Next: Install GitHub CLI and authenticate it for your backup host.');
-    assert.include(result.stdout, 'INFO  GitHub CLI authentication: Skipping GitHub CLI authentication check because gh is not on PATH.');
-    assert.include(result.stdout, 'Result: Ballin-managed environment has warnings. Warnings do not fail this command.');
+    assert.notInclude(result.stdout, 'OK    Node.js runtime:');
+    assert.notInclude(result.stdout, 'OK    Command shims on PATH:');
+    assert.notInclude(result.stdout, 'OK    Config readability:');
+    assert.notInclude(result.stdout, 'OK    Gist host:');
+    assert.notInclude(result.stdout, 'INFO  GitHub CLI authentication: Skipping GitHub CLI authentication check because gh is not on PATH.');
+    assert.notInclude(result.stdout, 'Result: Ballin-managed environment has warnings. Warnings do not fail this command.');
     assert.equal(result.stderr, '');
     assert.isFalse(fs.existsSync(commandLogPath));
+
+    const verboseResult = runBallin(['doctor', '--verbose']);
+
+    assert.equal(verboseResult.status, 0, verboseResult.stderr);
+    assert.include(verboseResult.stdout, 'OK    Node.js runtime:');
+    assert.include(verboseResult.stdout, 'WARN  Gist ID: Backup Gist ID is not configured yet.');
+    assert.include(verboseResult.stdout, 'INFO  GitHub CLI authentication: Skipping GitHub CLI authentication check because gh is not on PATH.');
+    assert.include(verboseResult.stdout, 'Result: Ballin-managed environment has warnings. Warnings do not fail this command.');
   });
 
   it('fails doctor when a required health check fails', () => {
@@ -157,6 +178,11 @@ esac
     assert.equal(missingShim.status, 1);
     assert.include(missingShim.stdout, 'ERROR Command shims on PATH: Missing command shims on PATH: up.');
     assert.include(missingShim.stdout, 'Next: Run the installer again or add the Ballin command directory to PATH.');
+    assert.notInclude(missingShim.stdout, 'OK    Node.js runtime:');
+    assert.notInclude(missingShim.stdout, 'OK    Config readability:');
+    assert.notInclude(missingShim.stdout, 'WARN');
+    assert.notInclude(missingShim.stdout, 'INFO');
+    assert.notInclude(missingShim.stdout, 'Result: Ballin-managed environment has errors.');
 
     fs.rmSync(configPath);
     const missingConfig = runBallin(['doctor']);
@@ -168,9 +194,13 @@ esac
 
   it('rejects invalid doctor usage', () => {
     const result = runBallin(['doctor', 'extra']);
+    const verboseWithExtra = runBallin(['doctor', '--verbose', 'extra']);
 
     assert.equal(result.status, 2);
     assert.equal(result.stdout, '');
-    assert.equal(result.stderr, 'Usage: ballin doctor\n');
+    assert.equal(result.stderr, 'Usage: ballin doctor [--verbose]\n');
+    assert.equal(verboseWithExtra.status, 2);
+    assert.equal(verboseWithExtra.stdout, '');
+    assert.equal(verboseWithExtra.stderr, 'Usage: ballin doctor [--verbose]\n');
   });
 });

--- a/test/ballin.test.ts
+++ b/test/ballin.test.ts
@@ -150,9 +150,10 @@ esac
 
     assert.equal(result.status, 0, result.stderr);
     assert.include(result.stdout, 'WARN  Gist ID: Backup Gist ID is not configured yet.');
-    assert.include(result.stdout, 'Next: Run the installer to create or adopt a backup Gist.');
+    assert.include(result.stdout, '\nNext: Run the installer to create or adopt a backup Gist.');
     assert.include(result.stdout, 'WARN  GitHub CLI: GitHub CLI is not discoverable on PATH.');
-    assert.include(result.stdout, 'Next: Install GitHub CLI and authenticate it for your backup host.');
+    assert.include(result.stdout, '\nNext: Install GitHub CLI and authenticate it for your backup host.');
+    assert.notInclude(result.stdout, '      Next:');
     assert.notInclude(result.stdout, 'OK    Node.js runtime:');
     assert.notInclude(result.stdout, 'OK    Command shims on PATH:');
     assert.notInclude(result.stdout, 'OK    Config readability:');
@@ -167,6 +168,7 @@ esac
     assert.equal(verboseResult.status, 0, verboseResult.stderr);
     assert.include(verboseResult.stdout, 'OK    Node.js runtime:');
     assert.include(verboseResult.stdout, 'WARN  Gist ID: Backup Gist ID is not configured yet.');
+    assert.include(verboseResult.stdout, '      Next: Run the installer to create or adopt a backup Gist.');
     assert.include(verboseResult.stdout, 'INFO  GitHub CLI authentication: Skipping GitHub CLI authentication check because gh is not on PATH.');
     assert.include(verboseResult.stdout, 'Result: Ballin-managed environment has warnings. Warnings do not fail this command.');
   });
@@ -178,7 +180,8 @@ esac
 
     assert.equal(missingShim.status, 1);
     assert.include(missingShim.stdout, 'ERROR Command shims on PATH: Missing command shims on PATH: up.');
-    assert.include(missingShim.stdout, 'Next: Run the installer again or add the Ballin command directory to PATH.');
+    assert.include(missingShim.stdout, '\nNext: Run the installer again or add the Ballin command directory to PATH.');
+    assert.notInclude(missingShim.stdout, '      Next:');
     assert.notInclude(missingShim.stdout, 'OK    Node.js runtime:');
     assert.notInclude(missingShim.stdout, 'OK    Config readability:');
     assert.notInclude(missingShim.stdout, 'WARN');

--- a/test/ballin.test.ts
+++ b/test/ballin.test.ts
@@ -111,7 +111,7 @@ esac
     const result = runBallin(['doctor']);
 
     assert.equal(result.status, 0, result.stderr);
-    assert.equal(result.stdout, 'Your Ballin-managed environment looks ready.\n');
+    assert.equal(result.stdout, 'Your Ballin-managed environment is healthy.\n');
     assert.equal(result.stderr, '');
     assert.equal(fs.readFileSync(commandLogPath, 'utf8'), 'auth status --hostname example.test\n');
   });

--- a/test/ballin.test.ts
+++ b/test/ballin.test.ts
@@ -20,6 +20,7 @@ describe('ballin', () => {
     assert.equal(result.status, 0);
     assert.include(result.stdout, 'A Collection of Ballin Scripts!');
     assert.include(result.stdout, 'ballin doctor');
+    assert.include(result.stdout, '--verbose');
     assert.include(result.stdout, 'ballin_update');
     assert.include(result.stdout, 'ballin_config');
     assert.include(result.stdout, 'ballin_uninstall');


### PR DESCRIPTION
## Summary

Closes #204.

Makes `ballin doctor` quiet by default while preserving the first implementation's full readiness checklist behind `ballin doctor --verbose`.

## What changed

- Default healthy output is now a single confidence-oriented readiness message.
- Warning-only and error default output now shows only the actionable warning/error checks and next steps.
- `ballin doctor --verbose` keeps the full `OK`, `WARN`, `ERROR`, and `INFO` checklist and result summary.
- The top-level `ballin` overview mentions `--verbose` so the detailed mode is discoverable.
- README keeps `doctor` as a concise command-table entry, while `docs/optional-capabilities.md` carries a short readiness-check note.

## Validation

- `npm test` (`241 passing`)