### PR TITLE
[codex] Improve analytics report setup guidance

### DIFF
--- a/analytics-worker/README.md
+++ b/analytics-worker/README.md
@@ -170,7 +170,8 @@ The report uses local Wrangler authentication and
 - command success, failure, and unknown counts
 - runtime/version trends from existing aggregate rows
 
-On a new checkout, create the ignored local config first:
+In a checkout that has not been configured for Worker access, create the ignored
+local config first:
 
 ```shell
 cp analytics-worker/wrangler.toml.example analytics-worker/wrangler.toml

--- a/analytics-worker/README.md
+++ b/analytics-worker/README.md
@@ -170,8 +170,8 @@ The report uses local Wrangler authentication and
 - command success, failure, and unknown counts
 - runtime/version trends from existing aggregate rows
 
-In a checkout that has not been configured for Worker access, create the ignored
-local config first:
+On a machine where this repository has not been configured for Worker access,
+create the ignored local config first:
 
 ```shell
 cp analytics-worker/wrangler.toml.example analytics-worker/wrangler.toml

--- a/analytics-worker/README.md
+++ b/analytics-worker/README.md
@@ -170,6 +170,16 @@ The report uses local Wrangler authentication and
 - command success, failure, and unknown counts
 - runtime/version trends from existing aggregate rows
 
+On a new checkout, create the ignored local config first:
+
+```shell
+cp analytics-worker/wrangler.toml.example analytics-worker/wrangler.toml
+```
+
+Then fill in the D1 `database_id` and make sure Wrangler is authenticated for
+the Cloudflare account. The database ID is not a secret by itself; remote reads
+are still controlled by Wrangler auth.
+
 The report does not read or print Cloudflare secrets. Do not paste secret
 values into the report command. If Wrangler is not installed globally, the
 script falls back to `npx wrangler`.

--- a/analytics-worker/report.ts
+++ b/analytics-worker/report.ts
@@ -224,12 +224,25 @@ const wranglerArgsFor = (sql: string, options: ReportOptions): string[] => {
   ];
 };
 
+const wranglerConfigPath = (rootDir: string): string => (
+  path.join(rootDir, 'analytics-worker', 'wrangler.toml')
+);
+
 const runWrangler = (
   sql: string,
   options: ReportOptions,
   spawnRunner: SpawnRunner = spawnSync,
 ): D1Row[] => {
   const rootDir = options.rootDir ?? path.join(__dirname, '..');
+  const configPath = wranglerConfigPath(rootDir);
+  if (!fs.existsSync(configPath)) {
+    throw new Error([
+      `Missing analytics Worker config: ${configPath}`,
+      'Copy analytics-worker/wrangler.toml.example to analytics-worker/wrangler.toml,',
+      'fill in the D1 database_id, and make sure Wrangler is authenticated.',
+    ].join('\n'));
+  }
+
   const wranglerArgs = wranglerArgsFor(sql, options);
   let result = spawnRunner('wrangler', wranglerArgs, {
     cwd: rootDir,

--- a/docs/analytics-backend.md
+++ b/docs/analytics-backend.md
@@ -57,16 +57,11 @@ npm run analytics:report -- --from 2026-06-01 --to 2026-06-30
 ```
 
 The report runs Wrangler D1 `SELECT` queries against the remote database using
-local Wrangler authentication and `analytics-worker/wrangler.toml`. It shows
-daily active installs, top-level command usage, command success/failure counts,
-and runtime/version trends. It does not require, accept, or print Cloudflare
-secret values.
-
-Before running the report from a new checkout, copy
-`analytics-worker/wrangler.toml.example` to the ignored local
-`analytics-worker/wrangler.toml`, fill in the D1 `database_id`, and authenticate
-Wrangler for the Cloudflare account. The D1 database ID is not a secret by
-itself; Cloudflare still authorizes remote reads through Wrangler auth.
+local Wrangler authentication and the ignored local
+`analytics-worker/wrangler.toml` described in the Worker README. It shows daily
+active installs, top-level command usage, command success/failure counts, and
+runtime/version trends. It does not require, accept, or print Cloudflare secret
+values.
 
 The report only reads the existing aggregate tables: `install_days`,
 `command_events_daily`, and `version_events_daily`. It does not introduce new

--- a/docs/analytics-backend.md
+++ b/docs/analytics-backend.md
@@ -62,6 +62,12 @@ daily active installs, top-level command usage, command success/failure counts,
 and runtime/version trends. It does not require, accept, or print Cloudflare
 secret values.
 
+Before running the report from a new checkout, copy
+`analytics-worker/wrangler.toml.example` to the ignored local
+`analytics-worker/wrangler.toml`, fill in the D1 `database_id`, and authenticate
+Wrangler for the Cloudflare account. The D1 database ID is not a secret by
+itself; Cloudflare still authorizes remote reads through Wrangler auth.
+
 The report only reads the existing aggregate tables: `install_days`,
 `command_events_daily`, and `version_events_daily`. It does not introduce new
 telemetry fields or report feature-level events, command arguments, local paths,

--- a/test/analytics_report.test.ts
+++ b/test/analytics_report.test.ts
@@ -1,4 +1,7 @@
 const { assert } = require('chai');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
 const {
   dateRangeFromArgs,
   defaultDatabase,
@@ -192,12 +195,15 @@ describe('analytics D1 report', () => {
 
   it('surfaces Wrangler failures without running real commands in tests', () => {
     const calls: SpawnCall[] = [];
+    const rootDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ballin-analytics-report-'));
+    fs.mkdirSync(path.join(rootDir, 'analytics-worker'));
+    fs.writeFileSync(path.join(rootDir, 'analytics-worker', 'wrangler.toml'), '');
 
     assert.throws(() => {
       runWrangler('SELECT 1', {
         database: defaultDatabase,
         from: '2026-06-01',
-        rootDir: '/repo',
+        rootDir,
         to: '2026-06-30',
       }, (command: string, args: string[]) => {
         calls.push({ args, command });
@@ -215,6 +221,32 @@ describe('analytics D1 report', () => {
 
     assert.deepEqual(calls.map((call) => call.command), ['wrangler']);
     assert.include(calls[0].args, '--remote');
+  });
+
+  it('explains the required local Wrangler config before running commands', () => {
+    const calls: SpawnCall[] = [];
+
+    assert.throws(() => {
+      runWrangler('SELECT 1', {
+        database: defaultDatabase,
+        from: '2026-06-01',
+        rootDir: '/repo',
+        to: '2026-06-30',
+      }, (command: string, args: string[]) => {
+        calls.push({ args, command });
+        return {
+          error: undefined,
+          output: [],
+          pid: 1,
+          signal: null,
+          status: 0,
+          stderr: '',
+          stdout: '[]',
+        };
+      });
+    }, 'Missing analytics Worker config: /repo/analytics-worker/wrangler.toml');
+
+    assert.deepEqual(calls, []);
   });
 
   it('parses CLI options for custom date ranges and databases', () => {


### PR DESCRIPTION
## Summary
- explain that analytics reporting needs the ignored local Wrangler config, D1 database ID, and Wrangler auth
- add a friendly missing-config preflight before Wrangler's lower-level file error
- cover the new behavior with a focused analytics report test

## Validation
- npm test
- git diff --check
- npm run analytics:report -- --help
- npm run analytics:report (verified the friendly missing-config error in a checkout without analytics-worker/wrangler.toml)