### PR TITLE
[codex] Fix analytics command flush before exit

### DIFF
--- a/commands/analytics.ts
+++ b/commands/analytics.ts
@@ -220,21 +220,32 @@ const requestOptions = (endpoint: string, ingestToken: string): RequestOptions =
 };
 
 const sendAnalyticsPayload: AnalyticsSender = (payload, options) => new Promise((resolve) => {
+  let wallClockTimeout: NodeJS.Timeout | undefined;
+  let settled = false;
+  const settle = (): void => {
+    if (!settled) {
+      settled = true;
+      if (wallClockTimeout) {
+        clearTimeout(wallClockTimeout);
+      }
+      resolve();
+    }
+  };
+
   if (!options.endpoint || !options.ingestToken) {
-    resolve();
+    settle();
     return;
   }
 
   try {
     const body = JSON.stringify(payload);
     const optionsWithHeaders = requestOptions(options.endpoint, options.ingestToken);
-    let settled = false;
-    const settle = (): void => {
-      if (!settled) {
-        settled = true;
-        resolve();
-      }
-    };
+    const timeoutMs = options.timeoutMs ?? defaultTimeoutMs;
+    let destroyRequest = () => {};
+    wallClockTimeout = setTimeout(() => {
+      destroyRequest();
+      settle();
+    }, timeoutMs);
     const request = https.request({
       ...optionsWithHeaders,
       headers: {
@@ -246,17 +257,20 @@ const sendAnalyticsPayload: AnalyticsSender = (payload, options) => new Promise(
       response.on('close', settle);
       response.resume();
     });
+    destroyRequest = () => {
+      request.destroy();
+    };
 
     request.on('error', settle);
     request.on('close', settle);
-    request.setTimeout(options.timeoutMs ?? defaultTimeoutMs, () => {
+    request.setTimeout(timeoutMs, () => {
       request.destroy();
       settle();
     });
     request.end(body);
   } catch {
     // Analytics must never affect command behavior.
-    resolve();
+    settle();
   }
 });
 
@@ -325,13 +339,12 @@ const runWithCommandAnalytics = (
       durationBucket: durationBucketFromMs(Math.max(0, nowMs() - startedAt)),
     }, runtime);
   } catch (error) {
-    return recordAnalyticsEvent({
+    void recordAnalyticsEvent({
       command,
       status: 'failure',
       durationBucket: durationBucketFromMs(Math.max(0, nowMs() - startedAt)),
-    }, runtime).then(() => {
-      throw error;
-    });
+    }, runtime);
+    throw error;
   }
 };
 

--- a/commands/analytics.ts
+++ b/commands/analytics.ts
@@ -5,9 +5,8 @@ const os = require('os');
 const path = require('path');
 const { fetchConfig } = require('../config/index.ts');
 
-import type { ClientRequest, IncomingMessage } from 'http';
+import type { IncomingMessage } from 'http';
 import type { RequestOptions } from 'https';
-import type { Socket } from 'net';
 
 type AnalyticsConfig = {
   enabled?: string;
@@ -39,7 +38,7 @@ type SenderOptions = {
   timeoutMs?: number;
 };
 
-type AnalyticsSender = (payload: AnalyticsPayload, options: SenderOptions) => void;
+type AnalyticsSender = (payload: AnalyticsPayload, options: SenderOptions) => Promise<void>;
 
 type AnalyticsRuntime = SenderOptions & {
   env?: NodeJS.ProcessEnv;
@@ -220,24 +219,22 @@ const requestOptions = (endpoint: string, ingestToken: string): RequestOptions =
   };
 };
 
-const ignoreRequestFailure = (request: ClientRequest): void => {
-  request.on('error', () => {});
-};
-
-const unrefRequestSocket = (request: ClientRequest): void => {
-  request.on('socket', (socket: Socket) => {
-    socket.unref();
-  });
-};
-
-const sendAnalyticsPayload: AnalyticsSender = (payload, options) => {
+const sendAnalyticsPayload: AnalyticsSender = (payload, options) => new Promise((resolve) => {
   if (!options.endpoint || !options.ingestToken) {
+    resolve();
     return;
   }
 
   try {
     const body = JSON.stringify(payload);
     const optionsWithHeaders = requestOptions(options.endpoint, options.ingestToken);
+    let settled = false;
+    const settle = (): void => {
+      if (!settled) {
+        settled = true;
+        resolve();
+      }
+    };
     const request = https.request({
       ...optionsWithHeaders,
       headers: {
@@ -245,21 +242,25 @@ const sendAnalyticsPayload: AnalyticsSender = (payload, options) => {
         'content-length': Buffer.byteLength(body),
       },
     }, (response: IncomingMessage) => {
+      response.on('end', settle);
+      response.on('close', settle);
       response.resume();
     });
 
-    ignoreRequestFailure(request);
-    unrefRequestSocket(request);
+    request.on('error', settle);
+    request.on('close', settle);
     request.setTimeout(options.timeoutMs ?? defaultTimeoutMs, () => {
       request.destroy();
+      settle();
     });
     request.end(body);
   } catch {
     // Analytics must never affect command behavior.
+    resolve();
   }
-};
+});
 
-const recordAnalyticsEvent = (input: AnalyticsRecordInput, runtime: AnalyticsRuntime = {}): void => {
+const recordAnalyticsEvent = async (input: AnalyticsRecordInput, runtime: AnalyticsRuntime = {}): Promise<void> => {
   try {
     const env = runtime.env ?? process.env;
     if (analyticsDisabledByEnv(env)) {
@@ -291,7 +292,7 @@ const recordAnalyticsEvent = (input: AnalyticsRecordInput, runtime: AnalyticsRun
       durationBucket,
       now: input.now ?? new Date(),
     }, installId);
-    (runtime.sender ?? sendAnalyticsPayload)(payload, {
+    await (runtime.sender ?? sendAnalyticsPayload)(payload, {
       endpoint: runtime.endpoint ?? productionAnalyticsEndpoint,
       ingestToken: runtime.ingestToken ?? productionAnalyticsIngestToken,
       timeoutMs: runtime.timeoutMs ?? defaultTimeoutMs,
@@ -312,24 +313,25 @@ const runWithCommandAnalytics = (
   command: string,
   runCommand: () => void,
   runtime: CommandAnalyticsRuntime = {},
-): void => {
+): Promise<void> => {
   const nowMs = runtime.nowMs ?? Date.now;
   const startedAt = nowMs();
   process.exitCode = undefined;
   try {
     runCommand();
-    recordAnalyticsEvent({
+    return recordAnalyticsEvent({
       command,
       status: analyticsStatusFromExitCode(process.exitCode),
       durationBucket: durationBucketFromMs(Math.max(0, nowMs() - startedAt)),
     }, runtime);
   } catch (error) {
-    recordAnalyticsEvent({
+    return recordAnalyticsEvent({
       command,
       status: 'failure',
       durationBucket: durationBucketFromMs(Math.max(0, nowMs() - startedAt)),
-    }, runtime);
-    throw error;
+    }, runtime).then(() => {
+      throw error;
+    });
   }
 };
 

--- a/commands/analytics.ts
+++ b/commands/analytics.ts
@@ -339,13 +339,20 @@ const runWithCommandAnalytics = (
       durationBucket: durationBucketFromMs(Math.max(0, nowMs() - startedAt)),
     }, runtime);
   } catch (error) {
-    void recordAnalyticsEvent({
+    return recordAnalyticsEvent({
       command,
       status: 'failure',
       durationBucket: durationBucketFromMs(Math.max(0, nowMs() - startedAt)),
-    }, runtime);
-    throw error;
+    }, runtime).then(() => {
+      throw error;
+    });
   }
+};
+
+const rethrowCommandError = (error: unknown): void => {
+  setImmediate(() => {
+    throw error;
+  });
 };
 
 module.exports = {
@@ -358,6 +365,7 @@ module.exports = {
   installIdPathForRepo,
   readLocalInstallId,
   recordAnalyticsEvent,
+  rethrowCommandError,
   runWithCommandAnalytics,
   sendAnalyticsPayload,
 };

--- a/commands/ballin.ts
+++ b/commands/ballin.ts
@@ -1,4 +1,5 @@
 const {
+  rethrowCommandError,
   runWithCommandAnalytics,
 } = require('./analytics.ts');
 const path = require('path');
@@ -148,7 +149,7 @@ function runBallinCommand(args = process.argv.slice(2)): void {
 }
 
 const runBallinCli = (): void => {
-  void runWithCommandAnalytics('ballin', runBallinCommand);
+  void runWithCommandAnalytics('ballin', runBallinCommand).catch(rethrowCommandError);
 };
 
 module.exports = {

--- a/commands/ballin.ts
+++ b/commands/ballin.ts
@@ -148,7 +148,7 @@ function runBallinCommand(args = process.argv.slice(2)): void {
 }
 
 const runBallinCli = (): void => {
-  runWithCommandAnalytics('ballin', runBallinCommand);
+  void runWithCommandAnalytics('ballin', runBallinCommand);
 };
 
 module.exports = {

--- a/commands/ballin_update.ts
+++ b/commands/ballin_update.ts
@@ -1,5 +1,6 @@
 const path = require('path');
 const {
+  rethrowCommandError,
   runWithCommandAnalytics,
 } = require('./analytics.ts');
 const {
@@ -35,7 +36,7 @@ function runBallinUpdateCommand(): void {
 }
 
 const runBallinUpdateCli = (): void => {
-  void runWithCommandAnalytics('ballin_update', runBallinUpdateCommand);
+  void runWithCommandAnalytics('ballin_update', runBallinUpdateCommand).catch(rethrowCommandError);
 };
 
 module.exports = {

--- a/commands/ballin_update.ts
+++ b/commands/ballin_update.ts
@@ -35,7 +35,7 @@ function runBallinUpdateCommand(): void {
 }
 
 const runBallinUpdateCli = (): void => {
-  runWithCommandAnalytics('ballin_update', runBallinUpdateCommand);
+  void runWithCommandAnalytics('ballin_update', runBallinUpdateCommand);
 };
 
 module.exports = {

--- a/commands/gu.ts
+++ b/commands/gu.ts
@@ -2,6 +2,7 @@ const fs = require('fs');
 const os = require('os');
 const path = require('path');
 const {
+  rethrowCommandError,
   runWithCommandAnalytics,
 } = require('./analytics.ts');
 const {
@@ -714,7 +715,7 @@ function runGuCommand(args = process.argv.slice(2)): void {
 }
 
 const runGuCli = (args = process.argv.slice(2)): void => {
-  void runWithCommandAnalytics('gu', () => runGuCommand(args));
+  void runWithCommandAnalytics('gu', () => runGuCommand(args)).catch(rethrowCommandError);
 };
 
 module.exports = {

--- a/commands/gu.ts
+++ b/commands/gu.ts
@@ -714,7 +714,7 @@ function runGuCommand(args = process.argv.slice(2)): void {
 }
 
 const runGuCli = (args = process.argv.slice(2)): void => {
-  runWithCommandAnalytics('gu', () => runGuCommand(args));
+  void runWithCommandAnalytics('gu', () => runGuCommand(args));
 };
 
 module.exports = {

--- a/commands/up.ts
+++ b/commands/up.ts
@@ -136,7 +136,7 @@ function runUpCommand(): void {
 }
 
 const runUpCli = (): void => {
-  runWithCommandAnalytics('up', runUpCommand);
+  void runWithCommandAnalytics('up', runUpCommand);
 };
 
 module.exports = {

--- a/commands/up.ts
+++ b/commands/up.ts
@@ -1,6 +1,7 @@
 const fs = require('fs');
 const path = require('path');
 const {
+  rethrowCommandError,
   runWithCommandAnalytics,
 } = require('./analytics.ts');
 const {
@@ -136,7 +137,7 @@ function runUpCommand(): void {
 }
 
 const runUpCli = (): void => {
-  void runWithCommandAnalytics('up', runUpCommand);
+  void runWithCommandAnalytics('up', runUpCommand).catch(rethrowCommandError);
 };
 
 module.exports = {

--- a/test/analytics.test.ts
+++ b/test/analytics.test.ts
@@ -443,17 +443,16 @@ describe('analytics client', () => {
     });
   });
 
-  it('records command-level failures when the command throws and rethrows', async () => {
+  it('records command-level failures when the command throws and rethrows synchronously', () => {
     setAnalyticsConfig({
       enabled: 'true',
     });
     writeInstallId();
     const payloads: AnalyticsPayload[] = [];
     let currentNow = 0;
-    let thrown: Error | undefined;
 
-    try {
-      await runWithCommandAnalytics('up', () => {
+    assert.throws(() => {
+      runWithCommandAnalytics('up', () => {
         currentNow = 60_000;
         throw new Error('simulated command failure');
       }, {
@@ -466,11 +465,8 @@ describe('analytics client', () => {
           payloads.push(payload);
         },
       });
-    } catch (error) {
-      thrown = error as Error;
-    }
+    }, 'simulated command failure');
 
-    assert.equal(thrown?.message, 'simulated command failure');
     assert.deepInclude(payloads[0], {
       command: 'up',
       status: 'failure',
@@ -544,19 +540,16 @@ describe('analytics client', () => {
     });
   });
 
-  it('bounds https sends with a short timeout and swallows request failures', async () => {
+  it('bounds https sends with a wall-clock timeout and swallows request failures', async () => {
     const originalRequest = https.request;
-    const timeoutHandler: { current?: () => void } = {};
     let destroyed = false;
+    let socketTimeoutRegistered = false;
 
-    https.request = (_options: RequestOptions, callback: (response: IncomingMessage) => void): ClientRequest => {
+    https.request = (): ClientRequest => {
       const request = new EventEmitter() as ClientRequest;
-      const response = new EventEmitter() as IncomingMessage;
-      response.resume = () => response;
-      callback(response);
 
       request.setTimeout = (_milliseconds: number, handler?: () => void) => {
-        timeoutHandler.current = handler;
+        socketTimeoutRegistered = Boolean(handler);
         return request;
       };
       request.end = (() => request) as ClientRequest['end'];
@@ -583,14 +576,14 @@ describe('analytics client', () => {
       }, {
         endpoint: 'https://analytics.example.test/v1/events',
         ingestToken: 'test-token',
-        timeoutMs: 25,
+        timeoutMs: 1,
       });
-      timeoutHandler.current?.();
       await analyticsDone;
     } finally {
       https.request = originalRequest;
     }
 
+    assert.isTrue(socketTimeoutRegistered);
     assert.isTrue(destroyed);
   });
 });

--- a/test/analytics.test.ts
+++ b/test/analytics.test.ts
@@ -6,6 +6,7 @@ const {
   analyticsDisabledByEnv,
   durationBucketFromMs,
   recordAnalyticsEvent,
+  rethrowCommandError,
   runWithCommandAnalytics,
   sendAnalyticsPayload,
 } = require('../commands/analytics.ts');
@@ -443,35 +444,74 @@ describe('analytics client', () => {
     });
   });
 
-  it('records command-level failures when the command throws and rethrows synchronously', () => {
+  it('records command-level failures when the command throws and rejects after flushing', async () => {
     setAnalyticsConfig({
       enabled: 'true',
     });
     writeInstallId();
     const payloads: AnalyticsPayload[] = [];
     let currentNow = 0;
+    let releaseSender = () => {};
+    let analyticsSettled = false;
+    let rejection: Error | undefined;
 
-    assert.throws(() => {
-      runWithCommandAnalytics('up', () => {
-        currentNow = 60_000;
-        throw new Error('simulated command failure');
-      }, {
-        endpoint: 'https://analytics.example.test/v1/events',
-        ingestToken: 'test-token',
-        env: {},
-        installIdPath: testInstallIdPath,
-        nowMs: () => currentNow,
-        sender: async (payload: AnalyticsPayload) => {
-          payloads.push(payload);
-        },
+    const analyticsDone = runWithCommandAnalytics('up', () => {
+      currentNow = 60_000;
+      throw new Error('simulated command failure');
+    }, {
+      endpoint: 'https://analytics.example.test/v1/events',
+      ingestToken: 'test-token',
+      env: {},
+      installIdPath: testInstallIdPath,
+      nowMs: () => currentNow,
+      sender: (payload: AnalyticsPayload) => new Promise<void>((resolve) => {
+        payloads.push(payload);
+        releaseSender = () => resolve();
+      }),
+    });
+
+    void analyticsDone
+      .then(() => {
+        analyticsSettled = true;
+      })
+      .catch((error: Error) => {
+        analyticsSettled = true;
+        rejection = error;
       });
-    }, 'simulated command failure');
 
+    await Promise.resolve();
+    assert.isFalse(analyticsSettled);
     assert.deepInclude(payloads[0], {
       command: 'up',
       status: 'failure',
       durationBucket: '1-10m',
     });
+    releaseSender();
+    await analyticsDone.catch(() => {});
+
+    assert.isTrue(analyticsSettled);
+    assert.equal(rejection?.message, 'simulated command failure');
+  });
+
+  it('rethrows command errors through the event loop', () => {
+    const originalSetImmediate = global.setImmediate;
+    let scheduled: (() => void) | undefined;
+    const error = new Error('simulated command failure');
+
+    global.setImmediate = ((callback: () => void) => {
+      scheduled = callback;
+      return {} as NodeJS.Immediate;
+    }) as typeof setImmediate;
+
+    try {
+      rethrowCommandError(error);
+      assert.isFunction(scheduled);
+      assert.throws(() => {
+        scheduled?.();
+      }, 'simulated command failure');
+    } finally {
+      global.setImmediate = originalSetImmediate;
+    }
   });
 
   it('sends through https and resolves after the response ends', async () => {

--- a/test/analytics.test.ts
+++ b/test/analytics.test.ts
@@ -12,7 +12,6 @@ const {
 
 import type { ClientRequest, IncomingMessage } from 'http';
 import type { RequestOptions } from 'https';
-import type { Socket } from 'net';
 
 type AnalyticsPayload = {
   schemaVersion: 1;
@@ -77,17 +76,17 @@ const writeRawInstallId = (installId: string): void => {
 const recordWithSender = (
   input: Record<string, unknown>,
   runtime: Record<string, unknown> = {},
-): { payloads: AnalyticsPayload[]; notices: string[]; order: string[] } => {
+): Promise<{ payloads: AnalyticsPayload[]; notices: string[]; order: string[] }> => {
   const payloads: AnalyticsPayload[] = [];
   const notices: string[] = [];
   const order: string[] = [];
 
-  recordAnalyticsEvent(input, {
+  return recordAnalyticsEvent(input, {
     endpoint: 'https://analytics.example.test/v1/events',
     ingestToken: 'test-token',
     env: {},
     installIdPath: testInstallIdPath,
-    sender: (payload: AnalyticsPayload) => {
+    sender: async (payload: AnalyticsPayload) => {
       order.push('send');
       payloads.push(payload);
     },
@@ -96,9 +95,9 @@ const recordWithSender = (
       notices.push(message);
     },
     ...runtime,
+  }).then(() => {
+    return { payloads, notices, order };
   });
-
-  return { payloads, notices, order };
 };
 
 describe('analytics client', () => {
@@ -122,13 +121,13 @@ describe('analytics client', () => {
     assert.isFalse(analyticsDisabledByEnv({ BALLIN_NO_ANALYTICS: '0' }));
   });
 
-  it('does not send when analytics are disabled in config', () => {
+  it('does not send when analytics are disabled in config', async () => {
     setAnalyticsConfig({
       enabled: 'false',
     });
     writeInstallId();
 
-    const { payloads, notices } = recordWithSender({
+    const { payloads, notices } = await recordWithSender({
       command: 'up',
       now: fixedNow,
     });
@@ -137,34 +136,34 @@ describe('analytics client', () => {
     assert.deepEqual(notices, []);
   });
 
-  it('does not send when environment opt-outs are set', () => {
+  it('does not send when environment opt-outs are set', async () => {
     const optOuts = [
       { BALLIN_NO_ANALYTICS: '1' },
       { CI: 'true' },
     ];
 
-    optOuts.forEach((env) => {
+    for (const env of optOuts) {
       setAnalyticsConfig({
         enabled: 'true',
       });
       writeInstallId();
 
-      const { payloads } = recordWithSender({
+      const { payloads } = await recordWithSender({
         command: 'up',
         now: fixedNow,
       }, { env });
 
       assert.deepEqual(payloads, []);
-    });
+    }
   });
 
-  it('reads the local install ID and includes it in the payload', () => {
+  it('reads the local install ID and includes it in the payload', async () => {
     setAnalyticsConfig({
       enabled: 'true',
     });
     writeInstallId();
 
-    const { payloads, notices, order } = recordWithSender({
+    const { payloads, notices, order } = await recordWithSender({
       command: 'up',
       status: 'success',
       durationBucket: '<1s',
@@ -181,20 +180,20 @@ describe('analytics client', () => {
     });
   });
 
-  it('uses production endpoint and token defaults when runtime overrides are absent', () => {
+  it('uses production endpoint and token defaults when runtime overrides are absent', async () => {
     setAnalyticsConfig({
       enabled: 'true',
     });
     writeInstallId();
     const senderOptions: SenderOptions[] = [];
 
-    recordAnalyticsEvent({
+    await recordAnalyticsEvent({
       command: 'up',
       now: fixedNow,
     }, {
       env: {},
       installIdPath: testInstallIdPath,
-      sender: (_payload: AnalyticsPayload, options: SenderOptions) => {
+      sender: async (_payload: AnalyticsPayload, options: SenderOptions) => {
         senderOptions.push(options);
       },
     });
@@ -205,12 +204,12 @@ describe('analytics client', () => {
     });
   });
 
-  it('skips sending when the local install ID is missing', () => {
+  it('skips sending when the local install ID is missing', async () => {
     setAnalyticsConfig({
       enabled: 'true',
     });
 
-    const { payloads, notices } = recordWithSender({
+    const { payloads, notices } = await recordWithSender({
       command: 'up',
       now: fixedNow,
     });
@@ -219,13 +218,13 @@ describe('analytics client', () => {
     assert.deepEqual(notices, []);
   });
 
-  it('skips sending and does not rewrite an invalid local install ID', () => {
+  it('skips sending and does not rewrite an invalid local install ID', async () => {
     setAnalyticsConfig({
       enabled: 'true',
     });
     writeRawInstallId('not-a-uuid\n');
 
-    const { payloads, notices } = recordWithSender({
+    const { payloads, notices } = await recordWithSender({
       command: 'up',
       now: fixedNow,
     });
@@ -235,32 +234,30 @@ describe('analytics client', () => {
     assert.equal(fs.readFileSync(testInstallIdPath, 'utf8'), 'not-a-uuid\n');
   });
 
-  it('never throws when analytics config or sender behavior fails', () => {
+  it('never throws when analytics config or sender behavior fails', async () => {
     setAnalyticsConfig({
       enabled: 'true',
     });
     writeInstallId();
 
-    assert.doesNotThrow(() => {
-      recordAnalyticsEvent({
-        command: 'up',
-        now: fixedNow,
-      }, {
-        installIdPath: testInstallIdPath,
-        sender: () => {
-          throw new Error('network unavailable');
-        },
-      });
+    await recordAnalyticsEvent({
+      command: 'up',
+      now: fixedNow,
+    }, {
+      installIdPath: testInstallIdPath,
+      sender: async () => {
+        throw new Error('network unavailable');
+      },
     });
   });
 
-  it('sends only the allowlisted payload fields', () => {
+  it('sends only the allowlisted payload fields', async () => {
     setAnalyticsConfig({
       enabled: 'true',
     });
     writeInstallId();
 
-    const { payloads } = recordWithSender({
+    const { payloads } = await recordWithSender({
       command: 'ballin_config',
       status: 'failure',
       durationBucket: '1-10s',
@@ -286,22 +283,22 @@ describe('analytics client', () => {
     assert.match(payload.osVersion, /^[0-9]+(?:\.[0-9]+)?$|^unknown$/);
   });
 
-  it('skips unsupported commands and invalid enum values', () => {
+  it('skips unsupported commands and invalid enum values', async () => {
     setAnalyticsConfig({
       enabled: 'true',
     });
     writeInstallId();
 
-    const unsupportedCommand = recordWithSender({
+    const unsupportedCommand = await recordWithSender({
       command: 'git',
       now: fixedNow,
     });
-    const unsupportedStatus = recordWithSender({
+    const unsupportedStatus = await recordWithSender({
       command: 'up',
       status: 'maybe',
       now: fixedNow,
     });
-    const unsupportedDuration = recordWithSender({
+    const unsupportedDuration = await recordWithSender({
       command: 'up',
       durationBucket: '42s',
       now: fixedNow,
@@ -324,7 +321,7 @@ describe('analytics client', () => {
     assert.equal(durationBucketFromMs(600_000), '10m+');
   });
 
-  it('records one command-level success event after the command finishes', () => {
+  it('records one command-level success event after the command finishes and flushes', async () => {
     setAnalyticsConfig({
       enabled: 'true',
     });
@@ -332,11 +329,13 @@ describe('analytics client', () => {
     const events: string[] = [];
     const payloads: AnalyticsPayload[] = [];
     let currentNow = 10_000;
+    let releaseSender = () => {};
+    let analyticsSettled = false;
     const previousExitCode = process.exitCode;
     process.exitCode = undefined;
 
     try {
-      runWithCommandAnalytics('ballin', () => {
+      const analyticsDone = runWithCommandAnalytics('ballin', () => {
         events.push('command');
         currentNow = 10_800;
       }, {
@@ -345,16 +344,28 @@ describe('analytics client', () => {
         env: {},
         installIdPath: testInstallIdPath,
         nowMs: () => currentNow,
-        sender: (payload: AnalyticsPayload) => {
-          events.push('send');
+        sender: (payload: AnalyticsPayload) => new Promise<void>((resolve) => {
+          events.push('send-start');
           payloads.push(payload);
-        },
+          releaseSender = () => resolve();
+        }),
       });
+
+      void analyticsDone.then(() => {
+        analyticsSettled = true;
+      });
+
+      assert.deepEqual(events, ['command', 'send-start']);
+      await Promise.resolve();
+      assert.isFalse(analyticsSettled);
+      releaseSender();
+      await analyticsDone;
+      assert.isTrue(analyticsSettled);
     } finally {
       process.exitCode = previousExitCode;
     }
 
-    assert.deepEqual(events, ['command', 'send']);
+    assert.deepEqual(events, ['command', 'send-start']);
     assert.deepInclude(payloads[0], {
       command: 'ballin',
       status: 'success',
@@ -362,7 +373,7 @@ describe('analytics client', () => {
     });
   });
 
-  it('records command-level failures from exitCode without changing it', () => {
+  it('records command-level failures from exitCode without changing it', async () => {
     setAnalyticsConfig({
       enabled: 'true',
     });
@@ -373,7 +384,7 @@ describe('analytics client', () => {
     process.exitCode = undefined;
 
     try {
-      runWithCommandAnalytics('gu', () => {
+      await runWithCommandAnalytics('gu', () => {
         currentNow = 13_000;
         process.exitCode = 17;
       }, {
@@ -382,7 +393,7 @@ describe('analytics client', () => {
         env: {},
         installIdPath: testInstallIdPath,
         nowMs: () => currentNow,
-        sender: (payload: AnalyticsPayload) => {
+        sender: async (payload: AnalyticsPayload) => {
           payloads.push(payload);
         },
       });
@@ -399,7 +410,7 @@ describe('analytics client', () => {
     });
   });
 
-  it('isolates command-level status from a stale process exitCode', () => {
+  it('isolates command-level status from a stale process exitCode', async () => {
     setAnalyticsConfig({
       enabled: 'true',
     });
@@ -409,13 +420,13 @@ describe('analytics client', () => {
     process.exitCode = 17;
 
     try {
-      runWithCommandAnalytics('ballin_update', () => {}, {
+      await runWithCommandAnalytics('ballin_update', () => {}, {
         endpoint: 'https://analytics.example.test/v1/events',
         ingestToken: 'test-token',
         env: {},
         installIdPath: testInstallIdPath,
         nowMs: () => 1000,
-        sender: (payload: AnalyticsPayload) => {
+        sender: async (payload: AnalyticsPayload) => {
           payloads.push(payload);
         },
       });
@@ -432,16 +443,17 @@ describe('analytics client', () => {
     });
   });
 
-  it('records command-level failures when the command throws and rethrows', () => {
+  it('records command-level failures when the command throws and rethrows', async () => {
     setAnalyticsConfig({
       enabled: 'true',
     });
     writeInstallId();
     const payloads: AnalyticsPayload[] = [];
     let currentNow = 0;
+    let thrown: Error | undefined;
 
-    assert.throws(() => {
-      runWithCommandAnalytics('up', () => {
+    try {
+      await runWithCommandAnalytics('up', () => {
         currentNow = 60_000;
         throw new Error('simulated command failure');
       }, {
@@ -450,12 +462,15 @@ describe('analytics client', () => {
         env: {},
         installIdPath: testInstallIdPath,
         nowMs: () => currentNow,
-        sender: (payload: AnalyticsPayload) => {
+        sender: async (payload: AnalyticsPayload) => {
           payloads.push(payload);
         },
       });
-    }, 'simulated command failure');
+    } catch (error) {
+      thrown = error as Error;
+    }
 
+    assert.equal(thrown?.message, 'simulated command failure');
     assert.deepInclude(payloads[0], {
       command: 'up',
       status: 'failure',
@@ -463,47 +478,37 @@ describe('analytics client', () => {
     });
   });
 
-  it('sends through https with a short timeout and swallows request failures', () => {
+  it('sends through https and resolves after the response ends', async () => {
     const originalRequest = https.request;
     let capturedOptions: RequestOptions | null = null;
     let capturedBody = '';
     let timeoutMs = 0;
-    const timeoutHandler: { current?: () => void } = {};
-    let destroyed = false;
-    let socketUnrefCalled = false;
 
     https.request = (options: RequestOptions, callback: (response: IncomingMessage) => void): ClientRequest => {
       capturedOptions = options;
+      const request = new EventEmitter() as ClientRequest;
       const response = new EventEmitter() as IncomingMessage;
       response.resume = () => response;
       callback(response);
 
-      const request = new EventEmitter() as ClientRequest;
       request.setTimeout = (milliseconds: number, handler?: () => void) => {
         timeoutMs = milliseconds;
-        timeoutHandler.current = handler;
+        assert.isFunction(handler);
         return request;
       };
       request.end = ((body?: unknown) => {
         capturedBody = typeof body === 'string' || Buffer.isBuffer(body) ? body.toString() : '';
-        const socket = {
-          unref: () => {
-            socketUnrefCalled = true;
-            return socket;
-          },
-        } as Socket;
-        request.emit('socket', socket);
+        response.emit('end');
         return request;
       }) as ClientRequest['end'];
       request.destroy = () => {
-        destroyed = true;
         return request;
       };
       return request;
     };
 
     try {
-      sendAnalyticsPayload({
+      await sendAnalyticsPayload({
         schemaVersion: 1,
         installId: fixedInstallId,
         dateBucket: '2026-06-27',
@@ -519,16 +524,11 @@ describe('analytics client', () => {
         ingestToken: 'test-token',
         timeoutMs: 25,
       });
-      if (timeoutHandler.current) {
-        timeoutHandler.current();
-      }
     } finally {
       https.request = originalRequest;
     }
 
     assert.equal(timeoutMs, 25);
-    assert.isTrue(destroyed);
-    assert.isTrue(socketUnrefCalled);
     assert.include(capturedBody, '"command":"up"');
     assert.isNotNull(capturedOptions);
     const options = capturedOptions as unknown as RequestOptions;
@@ -542,5 +542,55 @@ describe('analytics client', () => {
       'content-type': 'application/json',
       'x-ballin-analytics-token': 'test-token',
     });
+  });
+
+  it('bounds https sends with a short timeout and swallows request failures', async () => {
+    const originalRequest = https.request;
+    const timeoutHandler: { current?: () => void } = {};
+    let destroyed = false;
+
+    https.request = (_options: RequestOptions, callback: (response: IncomingMessage) => void): ClientRequest => {
+      const request = new EventEmitter() as ClientRequest;
+      const response = new EventEmitter() as IncomingMessage;
+      response.resume = () => response;
+      callback(response);
+
+      request.setTimeout = (_milliseconds: number, handler?: () => void) => {
+        timeoutHandler.current = handler;
+        return request;
+      };
+      request.end = (() => request) as ClientRequest['end'];
+      request.destroy = () => {
+        destroyed = true;
+        request.emit('error', new Error('simulated request failure'));
+        return request;
+      };
+      return request;
+    };
+
+    try {
+      const analyticsDone = sendAnalyticsPayload({
+        schemaVersion: 1,
+        installId: fixedInstallId,
+        dateBucket: '2026-06-27',
+        command: 'up',
+        status: 'success',
+        durationBucket: '<1s',
+        appVersion: '1.0.0',
+        nodeMajor: '24',
+        os: 'darwin',
+        osVersion: '15',
+      }, {
+        endpoint: 'https://analytics.example.test/v1/events',
+        ingestToken: 'test-token',
+        timeoutMs: 25,
+      });
+      timeoutHandler.current?.();
+      await analyticsDone;
+    } finally {
+      https.request = originalRequest;
+    }
+
+    assert.isTrue(destroyed);
   });
 });


### PR DESCRIPTION
## Summary
- make command analytics sends awaitable so short-lived CLI processes stay alive until the bounded send settles
- remove the unref'd HTTPS socket path that could let real `up`/`gu` runs exit before command events reached the Worker
- keep the existing timeout boundary and swallow send failures so analytics still cannot affect command output or exit status

## Privacy and scope
- no telemetry fields were added or changed
- command analytics remains limited to the existing top-level command events
- no command args, paths, Gist details, package/editor data, raw errors, env vars, arbitrary config values, IP storage, or feature-level events are collected

## Tests
- updated analytics tests to await the new sender contract
- covered successful response completion, timeout/error swallowing, command-failure rethrow behavior, exit-code preservation, and payload allowlisting

## Validation
- `npm test` passed locally with 244 passing

Fixes #210