### PR TITLE
[codex] Show readiness after up self-update

### DIFF
--- a/commands/ballin.ts
+++ b/commands/ballin.ts
@@ -5,18 +5,11 @@ const path = require('path');
 const {
   collectSetupReadiness,
 } = require('./setup_readiness.ts');
-
-type DoctorStatus = 'pass' | 'warn' | 'fail' | 'info';
-type DoctorCheck = {
-  id: string;
-  label: string;
-  status: DoctorStatus;
-  summary: string;
-};
-type DoctorReport = {
-  status: Exclude<DoctorStatus, 'info'>;
-  checks: DoctorCheck[];
-};
+const {
+  formatDefaultDoctorReport,
+  formatVerboseDoctorReport,
+} = require('./doctor_report.ts');
+import type { DoctorReport } from './doctor_report.ts';
 
 const format = {
   fileName: '\x1b[4mfile name\x1b[0m',
@@ -57,66 +50,12 @@ Scripts:
     up                    update brew etc.
 
 `;
-const statusLabels: Record<DoctorStatus, string> = {
-  pass: 'OK',
-  warn: 'WARN',
-  fail: 'ERROR',
-  info: 'INFO',
-};
-
-const nextSteps: Record<string, string> = {
-  'runtime.node': 'Install a supported Node.js version and reopen your shell.',
-  'commands.path': 'Run the installer again or add the Ballin command directory to PATH.',
-  'config.read': 'Recreate ballin.config.json from config/.defaultConfig.json.',
-  'gu.host': 'Set the backup host with ballin_config set gu.host <host>.',
-  'gu.gist': 'Run the installer to create or adopt a backup Gist.',
-  'gu.gh': 'Install GitHub CLI and authenticate it for your backup host.',
-  'gu.auth': 'Run gh auth login for the configured backup host.',
-};
-
 const writeStdout = (text: string): void => {
   process.stdout.write(text);
 };
 
 const writeStderr = (text: string): void => {
   process.stderr.write(text);
-};
-
-const formatDoctorCheck = (check: DoctorCheck, nextPrefix = '      Next: '): string => {
-  const lines = [
-    `${statusLabels[check.status].padEnd(5)} ${check.label}: ${check.summary}`,
-  ];
-  if (check.status === 'warn' || check.status === 'fail') {
-    lines.push(`${nextPrefix}${nextSteps[check.id] ?? 'Review the check output above.'}`);
-  }
-  return lines.join('\n');
-};
-
-const formatVerboseDoctorReport = (report: DoctorReport): string => {
-  const statusSummary = report.status === 'pass'
-    ? 'Ballin-managed environment health looks good.'
-    : report.status === 'warn'
-      ? 'Ballin-managed environment has warnings. Warnings do not fail this command.'
-      : 'Ballin-managed environment has errors.';
-
-  return [
-    'Ballin doctor',
-    '',
-    ...report.checks.map((check) => formatDoctorCheck(check)),
-    '',
-    `Result: ${statusSummary}`,
-    '',
-  ].join('\n');
-};
-
-const formatDefaultDoctorReport = (report: DoctorReport): string => {
-  if (report.status === 'pass') {
-    return 'Your Ballin-managed environment is healthy.\n';
-  }
-
-  const visibleStatus = report.status === 'fail' ? 'fail' : 'warn';
-  const visibleChecks = report.checks.filter(({ status }) => status === visibleStatus);
-  return `${visibleChecks.map((check) => formatDoctorCheck(check, 'Next: ')).join('\n')}\n`;
 };
 
 const runDoctorCommand = (args: string[]): void => {

--- a/commands/doctor_report.ts
+++ b/commands/doctor_report.ts
@@ -1,0 +1,76 @@
+type DoctorStatus = 'pass' | 'warn' | 'fail' | 'info';
+type DoctorCheck = {
+  id: string;
+  label: string;
+  status: DoctorStatus;
+  summary: string;
+};
+type DoctorReport = {
+  status: Exclude<DoctorStatus, 'info'>;
+  checks: DoctorCheck[];
+};
+
+const statusLabels: Record<DoctorStatus, string> = {
+  pass: 'OK',
+  warn: 'WARN',
+  fail: 'ERROR',
+  info: 'INFO',
+};
+
+const nextSteps: Record<string, string> = {
+  'runtime.node': 'Install a supported Node.js version and reopen your shell.',
+  'commands.path': 'Run the installer again or add the Ballin command directory to PATH.',
+  'config.read': 'Recreate ballin.config.json from config/.defaultConfig.json.',
+  'gu.host': 'Set the backup host with ballin_config set gu.host <host>.',
+  'gu.gist': 'Run the installer to create or adopt a backup Gist.',
+  'gu.gh': 'Install GitHub CLI and authenticate it for your backup host.',
+  'gu.auth': 'Run gh auth login for the configured backup host.',
+};
+
+const formatDoctorCheck = (check: DoctorCheck, nextPrefix = '      Next: '): string => {
+  const lines = [
+    `${statusLabels[check.status].padEnd(5)} ${check.label}: ${check.summary}`,
+  ];
+  if (check.status === 'warn' || check.status === 'fail') {
+    lines.push(`${nextPrefix}${nextSteps[check.id] ?? 'Review the check output above.'}`);
+  }
+  return lines.join('\n');
+};
+
+const formatVerboseDoctorReport = (report: DoctorReport): string => {
+  const statusSummary = report.status === 'pass'
+    ? 'Ballin-managed environment health looks good.'
+    : report.status === 'warn'
+      ? 'Ballin-managed environment has warnings. Warnings do not fail this command.'
+      : 'Ballin-managed environment has errors.';
+
+  return [
+    'Ballin doctor',
+    '',
+    ...report.checks.map((check) => formatDoctorCheck(check)),
+    '',
+    `Result: ${statusSummary}`,
+    '',
+  ].join('\n');
+};
+
+const formatDefaultDoctorReport = (report: DoctorReport): string => {
+  if (report.status === 'pass') {
+    return 'Your Ballin-managed environment is healthy.\n';
+  }
+
+  const visibleStatus = report.status === 'fail' ? 'fail' : 'warn';
+  const visibleChecks = report.checks.filter(({ status }) => status === visibleStatus);
+  return `${visibleChecks.map((check) => formatDoctorCheck(check, 'Next: ')).join('\n')}\n`;
+};
+
+module.exports = {
+  formatDefaultDoctorReport,
+  formatVerboseDoctorReport,
+};
+
+export type {
+  DoctorCheck,
+  DoctorReport,
+  DoctorStatus,
+};

--- a/commands/up.ts
+++ b/commands/up.ts
@@ -4,6 +4,12 @@ const {
   runWithCommandAnalytics,
 } = require('./analytics.ts');
 const {
+  formatDefaultDoctorReport,
+} = require('./doctor_report.ts');
+const {
+  collectSetupReadiness,
+} = require('./setup_readiness.ts');
+const {
   commandExists,
   makeTempFile,
   progress,
@@ -13,6 +19,7 @@ const {
   runVisibleCommand,
   writeStderrLine,
 } = require('./commandHelpers.ts');
+import type { DoctorReport } from './doctor_report.ts';
 
 const configValue = (key: string, env = process.env): string => {
   const result = runCommand('ballin_config', ['get', key], {
@@ -75,6 +82,17 @@ const runNvmInstall = (env: NodeJS.ProcessEnv): NodeJS.ProcessEnv | null => {
   }
 };
 
+const reportBallinReadiness = (env: NodeJS.ProcessEnv): void => {
+  const repoDir = path.join(__dirname, '..');
+  const report = collectSetupReadiness({
+    repoDir,
+    configPath: env.BALLIN_TEST_CONFIG_PATH || undefined,
+    env,
+  }) as DoctorReport;
+
+  process.stdout.write(formatDefaultDoctorReport(report));
+};
+
 function runUpCommand(): void {
   let childEnv = process.env;
 
@@ -126,7 +144,11 @@ function runUpCommand(): void {
 
   if (configValue('up.ballin', childEnv) === 'true') {
     progress('Updating ballin-scripts');
-    runVisibleCommand('ballin_update', [], { env: childEnv });
+    const updateStatus = runVisibleCommand('ballin_update', [], { env: childEnv });
+    if (updateStatus === 0) {
+      progress('Checking Ballin readiness');
+      reportBallinReadiness(childEnv);
+    }
   }
 
   if (configValue('up.gu', childEnv) === 'true') {

--- a/commands/up.ts
+++ b/commands/up.ts
@@ -82,12 +82,24 @@ const runNvmInstall = (env: NodeJS.ProcessEnv): NodeJS.ProcessEnv | null => {
   }
 };
 
+const nodeVersionForEnv = (env: NodeJS.ProcessEnv): string | undefined => {
+  const result = runCommand('node', ['-p', 'process.versions.node'], {
+    env,
+    stdio: ['ignore', 'pipe', 'ignore'],
+  });
+  if (result.status !== 0 || result.error) {
+    return undefined;
+  }
+  return result.stdout.trim() || undefined;
+};
+
 const reportBallinReadiness = (env: NodeJS.ProcessEnv): void => {
   const repoDir = path.join(__dirname, '..');
   const report = collectSetupReadiness({
     repoDir,
     configPath: env.BALLIN_TEST_CONFIG_PATH || undefined,
     env,
+    nodeVersion: nodeVersionForEnv(env),
   }) as DoctorReport;
 
   process.stdout.write(formatDefaultDoctorReport(report));

--- a/docs/optional-capabilities.md
+++ b/docs/optional-capabilities.md
@@ -110,7 +110,7 @@ Change a setting with `ballin_config set up.<name> true` or
 | Setting | Default | Behavior |
 | --- | --- | --- |
 | `up.cleanup` | `true` | Runs `brew cleanup` after upgrading Homebrew packages. |
-| `up.ballin` | `true` | Updates `ballin-scripts` when `up` runs. |
+| `up.ballin` | `true` | Updates `ballin-scripts` when `up` runs, then checks Ballin readiness if the update succeeds. |
 | `up.gu` | `false` | Runs `gu` to back up your development environment. Enable it when you want each update to also modify your backup gist. |
 | `up.softwareupdate` | `true` | Installs available macOS updates with `softwareupdate`. |
 | `up.nvm` | `false` | Installs the latest Node.js LTS release through a configured nvm installation. See [Node.js](#nodejs) for the setup and tradeoffs. |

--- a/test/up.test.ts
+++ b/test/up.test.ts
@@ -20,8 +20,8 @@ describe('up', () => {
   let configPath: string;
   let logPath: string;
 
-  const writeTestExecutable = (name: string, contents: string) => {
-    fs.writeFileSync(path.join(binDir, name), contents, { mode: 0o755 });
+  const writeTestExecutable = (name: string, contents: string, directory = binDir) => {
+    fs.writeFileSync(path.join(directory, name), contents, { mode: 0o755 });
   };
 
   const installCommandStub = (
@@ -233,6 +233,41 @@ esac
     assert.include(result.stdout, 'Your Ballin-managed environment is healthy.');
     assert.deepEqual(commandLog(), [
       'ballin_update|,|',
+      'gh|,|auth status --hostname example.test',
+    ]);
+  });
+
+  it('checks Ballin readiness with the Node.js runtime from the updated nvm PATH', () => {
+    const nvmDir = path.join(tempDir, 'custom-nvm');
+    const nvmBinDir = path.join(tempDir, 'nvm-bin');
+    fs.mkdirSync(nvmBinDir);
+    installPathUpdatingNvmStub(nvmDir, nvmBinDir);
+    writeTestExecutable('node', `#!/usr/bin/env bash
+printf 'node|%s|%s\\n' "$HOMEBREW_NO_ENV_HINTS,$HOMEBREW_NO_ASK" "$*" >> "$UP_TEST_LOG"
+if [ "$*" = '-p process.versions.node' ]; then
+  printf '%s\\n' '99.0.0'
+  exit 0
+fi
+if [ "$1" = '-e' ]; then
+  ${JSON.stringify(process.execPath)} -e "$2"
+  exit "$?"
+fi
+exit 2
+`, nvmBinDir);
+    installHealthyReadinessCommands();
+
+    const result = runUp({
+      NVM_DIR: nvmDir,
+      TEST_UP_BALLIN: 'true',
+    });
+
+    assert.equal(result.status, 0);
+    assert.include(result.stdout, 'Checking Ballin readiness');
+    assert.include(result.stdout, 'Your Ballin-managed environment is healthy.');
+    assert.deepEqual(commandLog().slice(1), [
+      'node|,|-e process.stdout.write(JSON.stringify(process.env))',
+      'ballin_update|,|',
+      'node|,|-p process.versions.node',
       'gh|,|auth status --hostname example.test',
     ]);
   });

--- a/test/up.test.ts
+++ b/test/up.test.ts
@@ -3,6 +3,9 @@ const { spawnSync } = require('child_process');
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
+const {
+  requiredCommandShims,
+} = require('../commands/setup_readiness.ts');
 
 const upPath = path.join(__dirname, '..', 'bin', 'up');
 type InstallCommandStubOptions = {
@@ -14,6 +17,7 @@ type InstallCommandStubOptions = {
 describe('up', () => {
   let tempDir: string;
   let binDir: string;
+  let configPath: string;
   let logPath: string;
 
   const writeTestExecutable = (name: string, contents: string) => {
@@ -31,9 +35,23 @@ exit ${status}
 `, { mode: 0o755 });
   };
 
+  const writeConfig = (config: unknown) => {
+    fs.writeFileSync(configPath, `${JSON.stringify(config)}\n`);
+  };
+
+  const installHealthyReadinessCommands = () => {
+    requiredCommandShims.forEach((command: string) => {
+      if (!fs.existsSync(path.join(binDir, command))) {
+        installCommandStub(command);
+      }
+    });
+    installCommandStub('gh');
+  };
+
   beforeEach(() => {
     tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ballin-up-'));
     binDir = path.join(tempDir, 'bin');
+    configPath = path.join(tempDir, 'ballin.config.json');
     logPath = path.join(tempDir, 'commands.log');
     fs.mkdirSync(binDir);
     fs.symlinkSync('/bin/bash', path.join(binDir, 'bash'));
@@ -49,6 +67,16 @@ case "$2" in
   *) printf '%s\\n' 'false' ;;
 esac
 `);
+    writeConfig({
+      up: {},
+      gu: {
+        id: 'test-gist-id',
+        host: 'example.test',
+      },
+      analytics: {
+        enabled: 'false',
+      },
+    });
   });
 
   afterEach(() => {
@@ -62,6 +90,7 @@ esac
       PATH: binDir,
       NVM_TEST_LOG: logPath,
       UP_TEST_LOG: logPath,
+      BALLIN_TEST_CONFIG_PATH: configPath,
       TEST_UP_NVM: 'true',
       ...env,
     },
@@ -134,6 +163,7 @@ esac
   it('passes exported Homebrew flags to later integrations', () => {
     installCommandStub('brew');
     installCommandStub('ballin_update');
+    installHealthyReadinessCommands();
 
     const result = runUp({
       TEST_UP_NVM: 'false',
@@ -145,6 +175,7 @@ esac
       'brew|1,1|upgrade',
       'brew|1,1|doctor',
       'ballin_update|1,1|',
+      'gh|1,1|auth status --hostname example.test',
     ]);
   });
 
@@ -166,6 +197,7 @@ esac
     ['npm', 'softwareupdate', 'ballin_update', 'gu'].forEach((command) => {
       installCommandStub(command);
     });
+    installHealthyReadinessCommands();
 
     const result = runUp({
       TEST_UP_NVM: 'false',
@@ -180,7 +212,67 @@ esac
       'npm|,|update -g',
       'softwareupdate|,|-ia',
       'ballin_update|,|',
+      'gh|,|auth status --hostname example.test',
       'gu|,|',
+    ]);
+  });
+
+  it('checks Ballin readiness after a successful ballin update', () => {
+    installCommandStub('ballin_update', { output: 'updated ballin-scripts' });
+    installHealthyReadinessCommands();
+
+    const result = runUp({
+      TEST_UP_NVM: 'false',
+      TEST_UP_BALLIN: 'true',
+    });
+
+    assert.equal(result.status, 0);
+    assert.include(result.stdout, 'Updating ballin-scripts');
+    assert.include(result.stdout, 'updated ballin-scripts');
+    assert.include(result.stdout, 'Checking Ballin readiness');
+    assert.include(result.stdout, 'Your Ballin-managed environment is healthy.');
+    assert.deepEqual(commandLog(), [
+      'ballin_update|,|',
+      'gh|,|auth status --hostname example.test',
+    ]);
+  });
+
+  it('keeps Ballin readiness failures informational after update', () => {
+    installCommandStub('ballin_update');
+    installHealthyReadinessCommands();
+    fs.rmSync(path.join(binDir, 'up'));
+
+    const result = runUp({
+      TEST_UP_NVM: 'false',
+      TEST_UP_BALLIN: 'true',
+    });
+
+    assert.equal(result.status, 0);
+    assert.include(result.stdout, 'Checking Ballin readiness');
+    assert.include(result.stdout, 'ERROR Command shims on PATH: Missing command shims on PATH: up.');
+    assert.include(result.stdout, 'Next: Run the installer again or add the Ballin command directory to PATH.');
+    assert.notInclude(result.stdout, 'Your Ballin-managed environment is healthy.');
+    assert.deepEqual(commandLog(), [
+      'ballin_update|,|',
+      'gh|,|auth status --hostname example.test',
+    ]);
+  });
+
+  it('skips Ballin readiness when ballin update fails', () => {
+    installCommandStub('ballin_update', { output: 'simulated update failure', status: 23 });
+    installHealthyReadinessCommands();
+
+    const result = runUp({
+      TEST_UP_NVM: 'false',
+      TEST_UP_BALLIN: 'true',
+    });
+
+    assert.equal(result.status, 0);
+    assert.include(result.stdout, 'simulated update failure');
+    assert.notInclude(result.stdout, 'Checking Ballin readiness');
+    assert.notInclude(result.stdout, 'Your Ballin-managed environment is healthy.');
+    assert.deepEqual(commandLog(), [
+      'ballin_update|,|',
     ]);
   });
 
@@ -203,6 +295,7 @@ esac
     installCommandStub('npm', { output: 'simulated npm failure', status: 23 });
     installCommandStub('ballin_update');
     installCommandStub('gu');
+    installHealthyReadinessCommands();
 
     const result = runUp({
       TEST_UP_NVM: 'false',
@@ -216,6 +309,28 @@ esac
     assert.deepEqual(commandLog(), [
       'npm|,|update -g',
       'ballin_update|,|',
+      'gh|,|auth status --hostname example.test',
+      'gu|,|',
+    ]);
+  });
+
+  it('still uses final gu status after informational Ballin readiness', () => {
+    installCommandStub('ballin_update');
+    installCommandStub('gu', { output: 'simulated gu failure', status: 17 });
+    installHealthyReadinessCommands();
+
+    const result = runUp({
+      TEST_UP_NVM: 'false',
+      TEST_UP_BALLIN: 'true',
+      TEST_UP_GU: 'true',
+    });
+
+    assert.equal(result.status, 17);
+    assert.include(result.stdout, 'Your Ballin-managed environment is healthy.');
+    assert.include(result.stdout, 'simulated gu failure');
+    assert.deepEqual(commandLog(), [
+      'ballin_update|,|',
+      'gh|,|auth status --hostname example.test',
       'gu|,|',
     ]);
   });


### PR DESCRIPTION
## Summary

Closes #191.

This keeps the first install/update readiness slice narrow:

- shares the settled `ballin doctor` report formatting so other flows can reuse the quiet default output
- shows Ballin readiness after a successful `ballin_update` when `up.ballin=true`
- keeps readiness warnings/errors informational so they do not affect `up` exit status
- leaves `install.sh`, `install_setup.ts setup`, and `ballin_update` output/exit behavior unchanged

## Scope notes

- No new readiness checks were added.
- No Homebrew-specific `brew doctor` behavior was added.
- No broader `ballin <subcommand>` routing or config reset recovery changes were included.

## Review follow-up

- Uses the post-`nvm` child environment's `node` when reporting readiness, so the runtime check reflects a Node.js version updated earlier in `up`.
- Merged current `main` and kept the mixed error/warning doctor output behavior in the shared formatter.

## Validation

- `npm test` (`247 passing`)
- `git diff --check`
