### PR TITLE
[codex] Show doctor warnings with failures

### DIFF
--- a/commands/ballin.ts
+++ b/commands/ballin.ts
@@ -114,8 +114,8 @@ const formatDefaultDoctorReport = (report: DoctorReport): string => {
     return 'Your Ballin-managed environment is healthy.\n';
   }
 
-  const visibleStatus = report.status === 'fail' ? 'fail' : 'warn';
-  const visibleChecks = report.checks.filter(({ status }) => status === visibleStatus);
+  const visibleStatuses = report.status === 'fail' ? ['fail', 'warn'] : ['warn'];
+  const visibleChecks = report.checks.filter(({ status }) => visibleStatuses.includes(status));
   return `${visibleChecks.map((check) => formatDoctorCheck(check, 'Next: ')).join('\n')}\n`;
 };
 

--- a/test/ballin.test.ts
+++ b/test/ballin.test.ts
@@ -175,16 +175,27 @@ esac
 
   it('fails doctor when a required health check fails', () => {
     fs.rmSync(path.join(binDir, 'up'));
+    writeConfig({
+      up: {},
+      gu: {
+        id: null,
+        host: 'example.test',
+      },
+      analytics: {
+        enabled: 'false',
+      },
+    });
 
     const missingShim = runBallin(['doctor']);
 
     assert.equal(missingShim.status, 1);
     assert.include(missingShim.stdout, 'ERROR Command shims on PATH: Missing command shims on PATH: up.');
     assert.include(missingShim.stdout, '\nNext: Run the installer again or add the Ballin command directory to PATH.');
+    assert.include(missingShim.stdout, 'WARN  Gist ID: Backup Gist ID is not configured yet.');
+    assert.include(missingShim.stdout, '\nNext: Run the installer to create or adopt a backup Gist.');
     assert.notInclude(missingShim.stdout, '      Next:');
     assert.notInclude(missingShim.stdout, 'OK    Node.js runtime:');
     assert.notInclude(missingShim.stdout, 'OK    Config readability:');
-    assert.notInclude(missingShim.stdout, 'WARN');
     assert.notInclude(missingShim.stdout, 'INFO');
     assert.notInclude(missingShim.stdout, 'Result: Ballin-managed environment has errors.');
 


### PR DESCRIPTION
## Summary

Follow-up to #204 / PR #208.

Addresses post-merge review feedback: https://github.com/JBallin/ballin-scripts/pull/208#discussion_r3500518784

When quiet `ballin doctor` output has required failures and warnings, show both actionable failure and warning checks instead of hiding warnings until failures are fixed.

## What changed

- Default failed doctor output now includes `ERROR` and `WARN` checks.
- Default warning-only output still includes only `WARN` checks.
- `OK` and `INFO` checks remain hidden unless `--verbose` is used.
- Added a mixed error+warning test case.

## Validation

- `npm test` (`242 passing`)