### PR TITLE
[codex] Make config reset recover unreadable config

### DIFF
--- a/commands/doctor_report.ts
+++ b/commands/doctor_report.ts
@@ -20,7 +20,7 @@ const statusLabels: Record<DoctorStatus, string> = {
 const nextSteps: Record<string, string> = {
   'runtime.node': 'Install a supported Node.js version and reopen your shell.',
   'commands.path': 'Run the installer again or add the Ballin command directory to PATH.',
-  'config.read': 'Recreate ballin.config.json from config/.defaultConfig.json.',
+  'config.read': 'Run ballin_config reset to recreate the config.',
   'gu.host': 'Set the backup host with ballin_config set gu.host <host>.',
   'gu.gist': 'Run the installer to create or adopt a backup Gist.',
   'gu.gh': 'Install GitHub CLI and authenticate it for your backup host.',

--- a/config/index.ts
+++ b/config/index.ts
@@ -9,6 +9,9 @@ type NestedValueResult = {
   value?: ConfigValue;
   missingKeys?: string;
 };
+type ResetPreviousConfigResult = {
+  display: string;
+};
 
 const userConfigPath = path.join(__dirname, '..', 'ballin.config.json');
 const configPath = process.env.BALLIN_TEST_CONFIG_PATH || userConfigPath;
@@ -36,6 +39,14 @@ const fetchConfig = () => {
   const configJSON = fs.readFileSync(configPath, 'utf8');
   const configObj = JSON.parse(configJSON) as ConfigObject;
   return { configObj, configJSON };
+};
+
+const readPreviousConfigForReset = (): ResetPreviousConfigResult => {
+  try {
+    return { display: fs.readFileSync(configPath, 'utf8') };
+  } catch {
+    return { display: `Unable to read ${configPath}.\n` };
+  }
 };
 
 // Return the value, or the first path prefix that cannot be resolved.
@@ -68,7 +79,7 @@ const getConfig = (keys?: string, val?: string): ConfigValue | string => {
 };
 
 const resetConfig = () => {
-  const prevConfig = getConfig();
+  const { display: prevConfig } = readPreviousConfigForReset();
   const defaultConfig = fs.readFileSync(defaultConfigPath, 'utf8');
   fs.writeFileSync(configPath, defaultConfig, 'utf8');
   return configMessages.reset(prevConfig, defaultConfig);

--- a/test/ballin.test.ts
+++ b/test/ballin.test.ts
@@ -204,7 +204,7 @@ esac
 
     assert.equal(missingConfig.status, 1);
     assert.include(missingConfig.stdout, 'ERROR Config readability: Unable to read');
-    assert.include(missingConfig.stdout, 'Next: Recreate ballin.config.json from config/.defaultConfig.json.');
+    assert.include(missingConfig.stdout, 'Next: Run ballin_config reset to recreate the config.');
   });
 
   it('rejects invalid doctor usage', () => {

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -237,13 +237,55 @@ describe('config', () => {
 
   it('CLI reset restores the default config', () => {
     setConfig('gu.id', 'changed-id');
+    const changedConfig = fetchConfigJSON();
 
     const result = runConfigCli(['reset']);
 
     assert.equal(result.status, 0);
     assert.include(result.stdout, 'Config has been reset...\nFROM:');
+    assert.include(result.stdout, changedConfig);
     assert.isNull(getConfig('gu.id'));
     assert.deepEqual(fetchConfig().configObj, defaultConfig);
+  });
+
+  it('CLI reset recreates the default config when the config file is missing', () => {
+    fs.rmSync(configPath);
+
+    const result = runConfigCli(['reset']);
+
+    assert.equal(result.status, 0);
+    assert.include(result.stdout, 'Config has been reset...\nFROM:');
+    assert.include(result.stdout, `Unable to read ${configPath}.`);
+    assert.deepEqual(fetchConfig().configObj, defaultConfig);
+    assert.equal(result.stderr, '');
+  });
+
+  it('CLI reset recreates the default config when the config file is malformed JSON', () => {
+    fs.writeFileSync(configPath, '{not json\n', 'utf8');
+
+    const result = runConfigCli(['reset']);
+
+    assert.equal(result.status, 0);
+    assert.include(result.stdout, 'Config has been reset...\nFROM:\n{not json\nTO:\n');
+    assert.deepEqual(fetchConfig().configObj, defaultConfig);
+    assert.equal(result.stderr, '');
+  });
+
+  [
+    ['array', '[]\n'],
+    ['null', 'null\n'],
+    ['string', '"not object"\n'],
+  ].forEach(([name, configContents]) => {
+    it(`CLI reset recreates the default config when the config parses to ${name}`, () => {
+      fs.writeFileSync(configPath, configContents, 'utf8');
+
+      const result = runConfigCli(['reset']);
+
+      assert.equal(result.status, 0);
+      assert.include(result.stdout, `Config has been reset...\nFROM:\n${configContents}TO:\n`);
+      assert.deepEqual(fetchConfig().configObj, defaultConfig);
+      assert.equal(result.stderr, '');
+    });
   });
 
   it('CLI invalid action exits cleanly in test mode', () => {


### PR DESCRIPTION
## Summary

Closes #199.

Makes `ballin_config reset` reliable as a recovery path when the local config file is missing, malformed JSON, or valid JSON that is not a config object.

## What changed

- `ballin_config reset` now reads the previous config as raw display text when possible, then writes the existing default config without parsing the current file first.
- Missing or unreadable current config still returns the normal reset success shape with an `Unable to read <path>.` placeholder under `FROM:`.
- `ballin doctor` config-readability guidance now points users to `ballin_config reset`.
- No install, update, `up`, config schema default, migration, or automatic doctor repair behavior changed.

## Validation

- `npm test` (`254 passing`)
- `git diff --check`
