### PR TITLE
[codex] Report up integration failures

### DIFF
--- a/commands/up.ts
+++ b/commands/up.ts
@@ -18,9 +18,15 @@ const {
   removeTempFile,
   runCommand,
   runVisibleCommand,
+  spawnResultStatus,
   writeStderrLine,
 } = require('./commandHelpers.ts');
 import type { DoctorReport } from './doctor_report.ts';
+
+type NvmInstallResult = {
+  env: NodeJS.ProcessEnv | null;
+  status: number;
+};
 
 const configValue = (key: string, env = process.env): string => {
   const result = runCommand('ballin_config', ['get', key], {
@@ -49,12 +55,12 @@ const parseEnvOutput = (output: string): NodeJS.ProcessEnv | null => {
   }
 };
 
-const runNvmInstall = (env: NodeJS.ProcessEnv): NodeJS.ProcessEnv | null => {
+const runNvmInstall = (env: NodeJS.ProcessEnv): NvmInstallResult => {
   const envPath = makeTempFile('ballin-up-env-');
   try {
     const result = runCommand('bash', [
       '-c',
-      '. "$NVM_DIR/nvm.sh"; nvm install --lts; node -e \'process.stdout.write(JSON.stringify(process.env))\' > "$BALLIN_UP_ENV_PATH"',
+      '. "$NVM_DIR/nvm.sh"; nvm install --lts; nvm_status="$?"; node -e \'process.stdout.write(JSON.stringify(process.env))\' > "$BALLIN_UP_ENV_PATH"; exit "$nvm_status"',
     ], {
       env: {
         ...env,
@@ -64,20 +70,32 @@ const runNvmInstall = (env: NodeJS.ProcessEnv): NodeJS.ProcessEnv | null => {
     });
 
     if (result.error) {
-      reportSpawnError('bash', result.error);
-      return null;
+      return {
+        env: null,
+        status: reportSpawnError('bash', result.error),
+      };
     }
-    if (result.status !== 0 || !fs.existsSync(envPath)) {
-      return null;
+    const status = spawnResultStatus(result);
+    if (status !== 0 || !fs.existsSync(envPath)) {
+      return {
+        env: null,
+        status,
+      };
     }
 
     const nextEnv = parseEnvOutput(fs.readFileSync(envPath, 'utf8'));
     if (!nextEnv) {
-      return null;
+      return {
+        env: null,
+        status,
+      };
     }
 
     delete nextEnv.BALLIN_UP_ENV_PATH;
-    return nextEnv;
+    return {
+      env: nextEnv,
+      status,
+    };
   } finally {
     removeTempFile(envPath);
   }
@@ -145,7 +163,11 @@ function runUpCommand(): void {
     const nvmDir = process.env.NVM_DIR ?? '';
     const nvmScript = path.join(nvmDir, 'nvm.sh');
     if (nvmDir && fs.existsSync(nvmScript) && fs.statSync(nvmScript).size > 0) {
-      childEnv = runNvmInstall(childEnv) ?? childEnv;
+      const result = runNvmInstall(childEnv);
+      if (result.status !== 0) {
+        exitStatus = result.status;
+      }
+      childEnv = result.env ?? childEnv;
     } else {
       writeStderrLine();
       writeStderrLine('⚠️  Skipping Node.js LTS update: unable to load nvm.');

--- a/commands/up.ts
+++ b/commands/up.ts
@@ -108,6 +108,19 @@ const reportBallinReadiness = (env: NodeJS.ProcessEnv): void => {
 
 function runUpCommand(): void {
   let childEnv = process.env;
+  let exitStatus = 0;
+
+  const runIntegrationCommand = (
+    command: string,
+    args: string[] = [],
+    options: { env?: NodeJS.ProcessEnv } = {},
+  ): number => {
+    const status = runVisibleCommand(command, args, options);
+    if (status !== 0) {
+      exitStatus = status;
+    }
+    return status;
+  };
 
   if (commandExists('brew')) {
     progress('Updating Homebrew packages');
@@ -116,15 +129,15 @@ function runUpCommand(): void {
       HOMEBREW_NO_ENV_HINTS: '1',
       HOMEBREW_NO_ASK: '1',
     };
-    runVisibleCommand('brew', ['upgrade'], { env: childEnv });
+    runIntegrationCommand('brew', ['upgrade'], { env: childEnv });
 
     if (configValue('up.cleanup', childEnv) === 'true') {
       progress('Cleaning up Homebrew packages');
-      runVisibleCommand('brew', ['cleanup'], { env: childEnv });
+      runIntegrationCommand('brew', ['cleanup'], { env: childEnv });
     }
 
     progress('Checking Homebrew installation');
-    runVisibleCommand('brew', ['doctor'], { env: childEnv });
+    runIntegrationCommand('brew', ['doctor'], { env: childEnv });
   }
 
   if (configValue('up.nvm', childEnv) === 'true') {
@@ -142,22 +155,22 @@ function runUpCommand(): void {
 
   if (commandExists('npm', { env: childEnv }) && configValue('up.npm', childEnv) === 'true') {
     progress('Updating global npm packages');
-    runVisibleCommand('npm', ['update', '-g'], { env: childEnv });
+    runIntegrationCommand('npm', ['update', '-g'], { env: childEnv });
   }
 
   if (commandExists('mas', { env: childEnv })) {
     progress('Updating App Store apps');
-    runVisibleCommand('mas', ['upgrade'], { env: childEnv });
+    runIntegrationCommand('mas', ['upgrade'], { env: childEnv });
   }
 
   if (commandExists('softwareupdate', { env: childEnv }) && configValue('up.softwareupdate', childEnv) === 'true') {
     progress('Installing macOS updates');
-    runVisibleCommand('softwareupdate', ['-ia'], { env: childEnv });
+    runIntegrationCommand('softwareupdate', ['-ia'], { env: childEnv });
   }
 
   if (configValue('up.ballin', childEnv) === 'true') {
     progress('Updating ballin-scripts');
-    const updateStatus = runVisibleCommand('ballin_update', [], { env: childEnv });
+    const updateStatus = runIntegrationCommand('ballin_update', [], { env: childEnv });
     if (updateStatus === 0) {
       progress('Checking Ballin readiness');
       reportBallinReadiness(childEnv);
@@ -166,7 +179,11 @@ function runUpCommand(): void {
 
   if (configValue('up.gu', childEnv) === 'true') {
     progress('Backing up development environment');
-    process.exitCode = runVisibleCommand('gu', [], { env: childEnv });
+    runIntegrationCommand('gu', [], { env: childEnv });
+  }
+
+  if (exitStatus !== 0) {
+    process.exitCode = exitStatus;
   }
 }
 

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -7,6 +7,8 @@ setting is available.
 ## `up`
 
 `up` updates the local development environment through these integrations:
+It keeps running later integrations after a failed integration command, then
+exits nonzero if any integration command failed.
 
 | Area | Behavior | Requirement |
 | --- | --- | --- |

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -6,9 +6,10 @@ setting is available.
 
 ## `up`
 
-`up` updates the local development environment through these integrations. It
-keeps running later integrations after a failed Homebrew, Node.js LTS, npm,
-App Store, macOS, Ballin update, or backup command, then exits nonzero.
+`up` updates the local development environment through these integrations. If
+any Homebrew, Node.js LTS, npm, App Store, macOS, ballin-scripts update, or
+backup command fails, `up` still runs any later integrations and exits nonzero
+at the end.
 
 | Area | Behavior | Requirement |
 | --- | --- | --- |

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -7,9 +7,8 @@ setting is available.
 ## `up`
 
 `up` updates the local development environment through these integrations. If
-any Homebrew, Node.js LTS, npm, App Store, macOS, ballin-scripts update, or
-backup command fails, `up` still runs any later integrations and exits nonzero
-at the end.
+an integration command fails, `up` still runs any later integrations and exits
+nonzero at the end.
 
 | Area | Behavior | Requirement |
 | --- | --- | --- |

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -6,9 +6,9 @@ setting is available.
 
 ## `up`
 
-`up` updates the local development environment through these integrations:
-It keeps running later integrations after a failed integration command, then
-exits nonzero if any integration command failed.
+`up` updates the local development environment through these integrations. It
+keeps running later integrations after a failed Homebrew, npm, App Store, macOS,
+Ballin update, or backup command, then exits nonzero.
 
 | Area | Behavior | Requirement |
 | --- | --- | --- |

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -7,8 +7,8 @@ setting is available.
 ## `up`
 
 `up` updates the local development environment through these integrations. It
-keeps running later integrations after a failed Homebrew, npm, App Store, macOS,
-Ballin update, or backup command, then exits nonzero.
+keeps running later integrations after a failed Homebrew, Node.js LTS, npm,
+App Store, macOS, Ballin update, or backup command, then exits nonzero.
 
 | Area | Behavior | Requirement |
 | --- | --- | --- |

--- a/test/up.test.ts
+++ b/test/up.test.ts
@@ -160,6 +160,38 @@ esac
     ]);
   });
 
+  it('reports a Homebrew substep failure after running later integrations', () => {
+    writeTestExecutable('brew', `#!/usr/bin/env bash
+printf 'brew|%s|%s\\n' "$HOMEBREW_NO_ENV_HINTS,$HOMEBREW_NO_ASK" "$*" >> "$UP_TEST_LOG"
+if [ "$1" = 'cleanup' ]; then
+  printf '%s\\n' 'simulated cleanup failure'
+  exit 42
+fi
+exit 0
+`);
+    installCommandStub('ballin_update');
+    installHealthyReadinessCommands();
+
+    const result = runUp({
+      TEST_UP_NVM: 'false',
+      TEST_UP_CLEANUP: 'true',
+      TEST_UP_BALLIN: 'true',
+    });
+
+    assert.equal(result.status, 42);
+    assert.include(result.stdout, 'simulated cleanup failure');
+    assert.include(result.stdout, 'Checking Homebrew installation');
+    assert.include(result.stdout, 'Updating ballin-scripts');
+    assert.include(result.stdout, 'Your Ballin-managed environment is healthy.');
+    assert.deepEqual(commandLog(), [
+      'brew|1,1|upgrade',
+      'brew|1,1|cleanup',
+      'brew|1,1|doctor',
+      'ballin_update|1,1|',
+      'gh|1,1|auth status --hostname example.test',
+    ]);
+  });
+
   it('passes exported Homebrew flags to later integrations', () => {
     installCommandStub('brew');
     installCommandStub('ballin_update');
@@ -302,7 +334,7 @@ exit 2
       TEST_UP_BALLIN: 'true',
     });
 
-    assert.equal(result.status, 0);
+    assert.equal(result.status, 23);
     assert.include(result.stdout, 'simulated update failure');
     assert.notInclude(result.stdout, 'Checking Ballin readiness');
     assert.notInclude(result.stdout, 'Your Ballin-managed environment is healthy.');
@@ -339,7 +371,7 @@ exit 2
       TEST_UP_GU: 'true',
     });
 
-    assert.equal(result.status, 0);
+    assert.equal(result.status, 23);
     assert.include(result.stdout, 'simulated npm failure');
     assert.deepEqual(commandLog(), [
       'npm|,|update -g',

--- a/test/up.test.ts
+++ b/test/up.test.ts
@@ -468,6 +468,33 @@ kill -TERM "$$"
     assert.equal(fs.readFileSync(logPath, 'utf8'), 'install --lts\n');
   });
 
+  it('reports nvm install failures after running later integrations', () => {
+    const nvmDir = path.join(tempDir, 'custom-nvm');
+    fs.mkdirSync(nvmDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(nvmDir, 'nvm.sh'),
+      `nvm() {
+  printf '%s\\n' "$*" >> "$NVM_TEST_LOG"
+  return 24
+}
+`,
+    );
+    writeTestExecutable('gu', `#!/usr/bin/env bash
+printf '%s\\n' 'gu still ran' >> "$UP_TEST_LOG"
+`);
+
+    const result = runUp({
+      NVM_DIR: nvmDir,
+      TEST_UP_GU: 'true',
+    });
+
+    assert.equal(result.status, 24);
+    assert.include(result.stdout, 'Updating Node.js LTS');
+    assert.deepEqual(commandLog().slice(1), [
+      'gu still ran',
+    ]);
+  });
+
   it('keeps nvm PATH changes for the npm update', () => {
     const nvmDir = path.join(tempDir, 'custom-nvm');
     const nvmBinDir = path.join(tempDir, 'nvm-bin');


### PR DESCRIPTION
Closes #182

## Summary

- track nonzero statuses from visible `up` integration commands while continuing through later integrations
- report a final nonzero `up` exit status when any run integration command fails
- preserve informational Ballin readiness behavior and existing command output shape
- document the continuation-plus-failure exit policy in the supported capabilities reference

## Validation

- `npm test` (251 passing)