### PR TITLE
ci: deploy analytics worker from main

### DIFF
--- a/.github/workflows/deploy-analytics-worker.yml
+++ b/.github/workflows/deploy-analytics-worker.yml
@@ -29,6 +29,8 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
 
       - name: Set up Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/deploy-analytics-worker.yml
+++ b/.github/workflows/deploy-analytics-worker.yml
@@ -23,6 +23,7 @@ jobs:
   deploy:
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
+    environment: analytics-worker-production
     timeout-minutes: 10
 
     steps:

--- a/.github/workflows/deploy-analytics-worker.yml
+++ b/.github/workflows/deploy-analytics-worker.yml
@@ -48,6 +48,7 @@ jobs:
 
       - name: Check for manual D1 migrations
         if: github.event_name == 'push'
+        shell: bash
         env:
           BEFORE_SHA: ${{ github.event.before }}
           CURRENT_SHA: ${{ github.sha }}
@@ -113,8 +114,12 @@ jobs:
             base_sha="${last_success_sha}"
           fi
 
-          if git diff --name-only "${base_sha}" "${CURRENT_SHA}" -- analytics-worker/migrations/ \
-            | grep -q .; then
+          if ! migration_changes="$(git diff --name-only "${base_sha}" "${CURRENT_SHA}" -- analytics-worker/migrations/)"; then
+            echo "::error::Could not diff analytics-worker migrations between ${base_sha} and ${CURRENT_SHA}. Refusing to deploy until the migration guard can verify whether remote D1 migrations are needed."
+            exit 1
+          fi
+
+          if [ -n "${migration_changes}" ]; then
             echo "::error::Remote D1 migrations remain manual. Apply migrations with wrangler d1 migrations apply ballin-scripts-analytics --remote, then rerun this workflow from main."
             exit 1
           fi

--- a/.github/workflows/deploy-analytics-worker.yml
+++ b/.github/workflows/deploy-analytics-worker.yml
@@ -56,6 +56,7 @@ jobs:
           base_sha="${BEFORE_SHA}"
           last_success_sha="$(node <<'NODE'
           const https = require('https');
+          const lookupFailed = '__LOOKUP_FAILED__';
 
           const apiUrl = new URL(
             `${process.env.GITHUB_API_URL}/repos/${process.env.GITHUB_REPOSITORY}/actions/workflows/deploy-analytics-worker.yml/runs`,
@@ -78,12 +79,14 @@ jobs:
             });
             response.on('end', () => {
               if (response.statusCode >= 400) {
+                process.stdout.write(lookupFailed);
                 return;
               }
               let data;
               try {
                 data = JSON.parse(body);
               } catch {
+                process.stdout.write(lookupFailed);
                 return;
               }
               const lastSuccess = (data.workflow_runs || []).find((run) => (
@@ -95,9 +98,16 @@ jobs:
             });
           });
 
-          request.on('error', () => {});
+          request.on('error', () => {
+            process.stdout.write(lookupFailed);
+          });
           NODE
           )"
+
+          if [ "${last_success_sha}" = "__LOOKUP_FAILED__" ]; then
+            echo "::error::Could not inspect prior deploy history. Refusing to deploy until the migration guard can verify whether remote D1 migrations are needed."
+            exit 1
+          fi
 
           if [ -n "${last_success_sha}" ]; then
             base_sha="${last_success_sha}"

--- a/.github/workflows/deploy-analytics-worker.yml
+++ b/.github/workflows/deploy-analytics-worker.yml
@@ -15,8 +15,13 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: deploy-analytics-worker
+  cancel-in-progress: true
+
 jobs:
   deploy:
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     timeout-minutes: 10
 
@@ -36,6 +41,18 @@ jobs:
 
       - name: Run validation
         run: npm test
+
+      - name: Check for manual D1 migrations
+        if: github.event_name == 'push'
+        env:
+          BEFORE_SHA: ${{ github.event.before }}
+          CURRENT_SHA: ${{ github.sha }}
+        run: |
+          if git diff --name-only "${BEFORE_SHA}" "${CURRENT_SHA}" -- analytics-worker/migrations/ \
+            | grep -q .; then
+            echo "::error::Remote D1 migrations remain manual. Apply migrations with wrangler d1 migrations apply ballin-scripts-analytics --remote, then rerun this workflow from main."
+            exit 1
+          fi
 
       - name: Create Wrangler config
         working-directory: analytics-worker

--- a/.github/workflows/deploy-analytics-worker.yml
+++ b/.github/workflows/deploy-analytics-worker.yml
@@ -1,0 +1,68 @@
+name: Deploy Analytics Worker
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - analytics-worker/**
+      - .github/workflows/deploy-analytics-worker.yml
+      - .github/workflows/ci.yml
+      - package.json
+      - package-lock.json
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: .nvmrc
+          check-latest: true
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run validation
+        run: npm test
+
+      - name: Create Wrangler config
+        working-directory: analytics-worker
+        env:
+          CLOUDFLARE_D1_DATABASE_ID: ${{ secrets.CLOUDFLARE_D1_DATABASE_ID }}
+        run: |
+          if [ -z "${CLOUDFLARE_D1_DATABASE_ID}" ]; then
+            echo "::error::CLOUDFLARE_D1_DATABASE_ID is not configured"
+            exit 1
+          fi
+          cp wrangler.toml.example wrangler.toml
+          node <<'NODE'
+          const fs = require('fs');
+          const path = 'wrangler.toml';
+          const value = fs
+            .readFileSync(path, 'utf8')
+            .replace(
+              'replace-with-cloudflare-d1-database-id',
+              process.env.CLOUDFLARE_D1_DATABASE_ID,
+            );
+          fs.writeFileSync(path, value);
+          NODE
+
+      - name: Deploy Worker
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: deploy
+          workingDirectory: analytics-worker

--- a/.github/workflows/deploy-analytics-worker.yml
+++ b/.github/workflows/deploy-analytics-worker.yml
@@ -13,6 +13,7 @@ on:
   workflow_dispatch:
 
 permissions:
+  actions: read
   contents: read
 
 concurrency:
@@ -50,8 +51,59 @@ jobs:
         env:
           BEFORE_SHA: ${{ github.event.before }}
           CURRENT_SHA: ${{ github.sha }}
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
-          if git diff --name-only "${BEFORE_SHA}" "${CURRENT_SHA}" -- analytics-worker/migrations/ \
+          base_sha="${BEFORE_SHA}"
+          last_success_sha="$(node <<'NODE'
+          const https = require('https');
+
+          const apiUrl = new URL(
+            `${process.env.GITHUB_API_URL}/repos/${process.env.GITHUB_REPOSITORY}/actions/workflows/deploy-analytics-worker.yml/runs`,
+          );
+          apiUrl.searchParams.set('branch', 'main');
+          apiUrl.searchParams.set('status', 'success');
+          apiUrl.searchParams.set('per_page', '10');
+
+          const request = https.get(apiUrl, {
+            headers: {
+              accept: 'application/vnd.github+json',
+              authorization: `Bearer ${process.env.GITHUB_TOKEN}`,
+              'user-agent': 'ballin-scripts-deploy',
+            },
+          }, (response) => {
+            let body = '';
+            response.setEncoding('utf8');
+            response.on('data', (chunk) => {
+              body += chunk;
+            });
+            response.on('end', () => {
+              if (response.statusCode >= 400) {
+                return;
+              }
+              let data;
+              try {
+                data = JSON.parse(body);
+              } catch {
+                return;
+              }
+              const lastSuccess = (data.workflow_runs || []).find((run) => (
+                run.head_sha && run.head_sha !== process.env.CURRENT_SHA
+              ));
+              if (lastSuccess) {
+                process.stdout.write(lastSuccess.head_sha);
+              }
+            });
+          });
+
+          request.on('error', () => {});
+          NODE
+          )"
+
+          if [ -n "${last_success_sha}" ]; then
+            base_sha="${last_success_sha}"
+          fi
+
+          if git diff --name-only "${base_sha}" "${CURRENT_SHA}" -- analytics-worker/migrations/ \
             | grep -q .; then
             echo "::error::Remote D1 migrations remain manual. Apply migrations with wrangler d1 migrations apply ballin-scripts-analytics --remote, then rerun this workflow from main."
             exit 1

--- a/analytics-worker/README.md
+++ b/analytics-worker/README.md
@@ -126,20 +126,18 @@ globally, use `npx wrangler` in place of `wrangler`.
    wrangler d1 migrations apply ballin-scripts-analytics --remote
    ```
 
-7. Create the `analytics-worker-production` GitHub deployment environment, set
-   its deployment branch rule to `main`, and add these environment secrets so
-   Actions can deploy the Worker:
+7. Create the `analytics-worker-production` GitHub deployment environment, allow
+   deployments only from `main`, and add these environment secrets:
 
    - `CLOUDFLARE_API_TOKEN`, from a Cloudflare Account API Token created with
      the `Edit Cloudflare Workers` template
    - `CLOUDFLARE_ACCOUNT_ID`
    - `CLOUDFLARE_D1_DATABASE_ID`
 
-   Keep these values as environment secrets rather than repository secrets so
-   other workflows and manually dispatched branch runs cannot access them.
-
 8. Confirm the `Deploy Analytics Worker` GitHub Actions workflow completes
    after Worker-impacting changes land on `main`.
+
+## Automatic Deploys
 
 The deploy workflow runs `npm test`, creates an ignored runner-local
 `wrangler.toml` from `wrangler.toml.example`, fills in the D1 database ID from
@@ -147,21 +145,18 @@ The deploy workflow runs `npm test`, creates an ignored runner-local
 does not set or rotate the existing Cloudflare Worker secrets
 `INSTALL_ID_HASH_SECRET` or `INGEST_TOKEN`.
 
-The workflow runs automatically on pushes to `main` that touch Worker-impacting
-paths, including `analytics-worker/**`, the deploy workflow, CI workflow, and
-package metadata. It can also be run manually from GitHub Actions with
-`workflow_dispatch`.
+Keep the Cloudflare values as environment secrets rather than repository
+secrets. The workflow runs automatically on Worker-impacting pushes to `main`
+and can also be run manually from GitHub Actions, but production deploys are
+guarded by the `analytics-worker-production` environment and a `main` ref check.
 
-Remote D1 migrations remain manual. Run this command after adding or changing a
-migration that should affect production:
+Remote D1 migrations remain manual. The deploy workflow stops before deploying
+when a push includes `analytics-worker/migrations/`; after applying the remote
+migration, rerun the workflow manually from `main`.
 
 ```shell
 wrangler d1 migrations apply ballin-scripts-analytics --remote
 ```
-
-The deploy workflow stops before deploying when a push includes files under
-`analytics-worker/migrations/`. After applying the remote migration, rerun the
-workflow manually from the `main` branch.
 
 Manual deploys remain available for emergency or local maintenance:
 

--- a/analytics-worker/README.md
+++ b/analytics-worker/README.md
@@ -151,8 +151,8 @@ and can also be run manually from GitHub Actions, but production deploys are
 guarded by the `analytics-worker-production` environment and a `main` ref check.
 
 Remote D1 migrations remain manual. The deploy workflow stops before deploying
-when a push includes `analytics-worker/migrations/`; after applying the remote
-migration, rerun the workflow manually from `main`.
+when `analytics-worker/migrations/` changed since the last successful deploy;
+after applying the remote migration, rerun the workflow manually from `main`.
 
 ```shell
 wrangler d1 migrations apply ballin-scripts-analytics --remote

--- a/analytics-worker/README.md
+++ b/analytics-worker/README.md
@@ -128,7 +128,8 @@ globally, use `npx wrangler` in place of `wrangler`.
 
 7. Add these GitHub repository secrets so Actions can deploy the Worker:
 
-   - `CLOUDFLARE_API_TOKEN`
+   - `CLOUDFLARE_API_TOKEN`, from a Cloudflare Account API Token created with
+     the `Edit Cloudflare Workers` template
    - `CLOUDFLARE_ACCOUNT_ID`
    - `CLOUDFLARE_D1_DATABASE_ID`
 

--- a/analytics-worker/README.md
+++ b/analytics-worker/README.md
@@ -154,6 +154,10 @@ migration that should affect production:
 wrangler d1 migrations apply ballin-scripts-analytics --remote
 ```
 
+The deploy workflow stops before deploying when a push includes files under
+`analytics-worker/migrations/`. After applying the remote migration, rerun the
+workflow manually from the `main` branch.
+
 Manual deploys remain available for emergency or local maintenance:
 
 ```shell

--- a/analytics-worker/README.md
+++ b/analytics-worker/README.md
@@ -126,12 +126,17 @@ globally, use `npx wrangler` in place of `wrangler`.
    wrangler d1 migrations apply ballin-scripts-analytics --remote
    ```
 
-7. Add these GitHub repository secrets so Actions can deploy the Worker:
+7. Create the `analytics-worker-production` GitHub deployment environment, set
+   its deployment branch rule to `main`, and add these environment secrets so
+   Actions can deploy the Worker:
 
    - `CLOUDFLARE_API_TOKEN`, from a Cloudflare Account API Token created with
      the `Edit Cloudflare Workers` template
    - `CLOUDFLARE_ACCOUNT_ID`
    - `CLOUDFLARE_D1_DATABASE_ID`
+
+   Keep these values as environment secrets rather than repository secrets so
+   other workflows and manually dispatched branch runs cannot access them.
 
 8. Confirm the `Deploy Analytics Worker` GitHub Actions workflow completes
    after Worker-impacting changes land on `main`.

--- a/analytics-worker/README.md
+++ b/analytics-worker/README.md
@@ -126,11 +126,38 @@ globally, use `npx wrangler` in place of `wrangler`.
    wrangler d1 migrations apply ballin-scripts-analytics --remote
    ```
 
-7. Deploy:
+7. Add these GitHub repository secrets so Actions can deploy the Worker:
 
-   ```shell
-   wrangler deploy
-   ```
+   - `CLOUDFLARE_API_TOKEN`
+   - `CLOUDFLARE_ACCOUNT_ID`
+   - `CLOUDFLARE_D1_DATABASE_ID`
+
+8. Confirm the `Deploy Analytics Worker` GitHub Actions workflow completes
+   after Worker-impacting changes land on `main`.
+
+The deploy workflow runs `npm test`, creates an ignored runner-local
+`wrangler.toml` from `wrangler.toml.example`, fills in the D1 database ID from
+`CLOUDFLARE_D1_DATABASE_ID`, and runs `wrangler deploy` from this directory. It
+does not set or rotate the existing Cloudflare Worker secrets
+`INSTALL_ID_HASH_SECRET` or `INGEST_TOKEN`.
+
+The workflow runs automatically on pushes to `main` that touch Worker-impacting
+paths, including `analytics-worker/**`, the deploy workflow, CI workflow, and
+package metadata. It can also be run manually from GitHub Actions with
+`workflow_dispatch`.
+
+Remote D1 migrations remain manual. Run this command after adding or changing a
+migration that should affect production:
+
+```shell
+wrangler d1 migrations apply ballin-scripts-analytics --remote
+```
+
+Manual deploys remain available for emergency or local maintenance:
+
+```shell
+wrangler deploy
+```
 
 The production endpoint is:
 

--- a/docs/analytics-backend.md
+++ b/docs/analytics-backend.md
@@ -17,8 +17,8 @@ https://ballin-scripts-analytics.jballin.workers.dev/v1/events
 
 The Worker has a D1 binding, scheduled retention cleanup, two Cloudflare
 secrets, and an `ANALYTICS_RATE_LIMITER` binding for `POST /v1/events`.
-Worker-impacting changes deploy through the `Deploy Analytics Worker` GitHub
-Actions workflow after they land on `main`.
+Worker-impacting changes deploy from `main` through the `Deploy Analytics
+Worker` GitHub Actions workflow.
 
 ## Why Cloudflare Worker and D1
 
@@ -88,11 +88,9 @@ For production setup or recreation:
 - set the D1 database ID in local `analytics-worker/wrangler.toml`
 - set `INSTALL_ID_HASH_SECRET`
 - set `INGEST_TOKEN`
-- create the `analytics-worker-production` GitHub deployment environment, limit
-  its deployment branch rule to `main`, and add environment secrets
-  `CLOUDFLARE_API_TOKEN`, `CLOUDFLARE_ACCOUNT_ID`, and
-  `CLOUDFLARE_D1_DATABASE_ID`; use a Cloudflare Account API Token created with
-  the `Edit Cloudflare Workers` template for `CLOUDFLARE_API_TOKEN`
+- create the `analytics-worker-production` GitHub deployment environment with a
+  `main` branch rule and environment secrets `CLOUDFLARE_API_TOKEN`,
+  `CLOUDFLARE_ACCOUNT_ID`, and `CLOUDFLARE_D1_DATABASE_ID`
 - apply `analytics-worker/migrations/0001_initial.sql` with `--remote`
 - confirm the `Deploy Analytics Worker` workflow completed after the relevant
   change landed on `main`
@@ -102,6 +100,6 @@ For production setup or recreation:
   stored
 
 Deploy failures are visible in GitHub Actions. Remote D1 migrations remain
-manual and should use `--remote`; the deploy workflow stops before publishing
-when a push includes migration files. After applying the remote migration,
-rerun the deploy workflow manually from the `main` branch.
+manual and should use `--remote`; migration-changing pushes stop before
+publishing until the remote migration is applied and the deploy workflow is
+rerun from `main`.

--- a/docs/analytics-backend.md
+++ b/docs/analytics-backend.md
@@ -101,5 +101,6 @@ For production setup or recreation:
   stored
 
 Deploy failures are visible in GitHub Actions. Remote D1 migrations remain
-manual and should use `--remote`; the deploy workflow only publishes Worker
-code and configuration.
+manual and should use `--remote`; the deploy workflow stops before publishing
+when a push includes migration files. After applying the remote migration,
+rerun the deploy workflow manually from the `main` branch.

--- a/docs/analytics-backend.md
+++ b/docs/analytics-backend.md
@@ -17,6 +17,8 @@ https://ballin-scripts-analytics.jballin.workers.dev/v1/events
 
 The Worker has a D1 binding, scheduled retention cleanup, two Cloudflare
 secrets, and an `ANALYTICS_RATE_LIMITER` binding for `POST /v1/events`.
+Worker-impacting changes deploy through the `Deploy Analytics Worker` GitHub
+Actions workflow after they land on `main`.
 
 ## Why Cloudflare Worker and D1
 
@@ -86,9 +88,16 @@ For production setup or recreation:
 - set the D1 database ID in local `analytics-worker/wrangler.toml`
 - set `INSTALL_ID_HASH_SECRET`
 - set `INGEST_TOKEN`
+- add GitHub repository secrets `CLOUDFLARE_API_TOKEN`,
+  `CLOUDFLARE_ACCOUNT_ID`, and `CLOUDFLARE_D1_DATABASE_ID`
 - apply `analytics-worker/migrations/0001_initial.sql` with `--remote`
-- deploy the Worker
+- confirm the `Deploy Analytics Worker` workflow completed after the relevant
+  change landed on `main`
 - confirm the deployed Worker returns `204` for a valid event, `401` for a
   missing or bad token, and `400` for unsupported fields or invalid enums
 - query D1 to confirm only hashed install/day rows and aggregate counts are
   stored
+
+Deploy failures are visible in GitHub Actions. Remote D1 migrations remain
+manual and should use `--remote`; the deploy workflow only publishes Worker
+code and configuration.

--- a/docs/analytics-backend.md
+++ b/docs/analytics-backend.md
@@ -100,6 +100,5 @@ For production setup or recreation:
   stored
 
 Deploy failures are visible in GitHub Actions. Remote D1 migrations remain
-manual and should use `--remote`; migration-changing pushes stop before
-publishing until the remote migration is applied and the deploy workflow is
-rerun from `main`.
+manual and should use `--remote`; migration changes stop publishing until the
+remote migration is applied and the deploy workflow succeeds from `main`.

--- a/docs/analytics-backend.md
+++ b/docs/analytics-backend.md
@@ -89,7 +89,9 @@ For production setup or recreation:
 - set `INSTALL_ID_HASH_SECRET`
 - set `INGEST_TOKEN`
 - add GitHub repository secrets `CLOUDFLARE_API_TOKEN`,
-  `CLOUDFLARE_ACCOUNT_ID`, and `CLOUDFLARE_D1_DATABASE_ID`
+  `CLOUDFLARE_ACCOUNT_ID`, and `CLOUDFLARE_D1_DATABASE_ID`; use a Cloudflare
+  Account API Token created with the `Edit Cloudflare Workers` template for
+  `CLOUDFLARE_API_TOKEN`
 - apply `analytics-worker/migrations/0001_initial.sql` with `--remote`
 - confirm the `Deploy Analytics Worker` workflow completed after the relevant
   change landed on `main`

--- a/docs/analytics-backend.md
+++ b/docs/analytics-backend.md
@@ -88,10 +88,11 @@ For production setup or recreation:
 - set the D1 database ID in local `analytics-worker/wrangler.toml`
 - set `INSTALL_ID_HASH_SECRET`
 - set `INGEST_TOKEN`
-- add GitHub repository secrets `CLOUDFLARE_API_TOKEN`,
-  `CLOUDFLARE_ACCOUNT_ID`, and `CLOUDFLARE_D1_DATABASE_ID`; use a Cloudflare
-  Account API Token created with the `Edit Cloudflare Workers` template for
-  `CLOUDFLARE_API_TOKEN`
+- create the `analytics-worker-production` GitHub deployment environment, limit
+  its deployment branch rule to `main`, and add environment secrets
+  `CLOUDFLARE_API_TOKEN`, `CLOUDFLARE_ACCOUNT_ID`, and
+  `CLOUDFLARE_D1_DATABASE_ID`; use a Cloudflare Account API Token created with
+  the `Edit Cloudflare Workers` template for `CLOUDFLARE_API_TOKEN`
 - apply `analytics-worker/migrations/0001_initial.sql` with `--remote`
 - confirm the `Deploy Analytics Worker` workflow completed after the relevant
   change landed on `main`


### PR DESCRIPTION
## Summary

- add a path-scoped GitHub Actions workflow that deploys the analytics Worker after relevant changes land on `main`
- run the repo validation gate before deploy, generate runner-local `analytics-worker/wrangler.toml`, and deploy with `cloudflare/wrangler-action`
- scope deploy credentials to the `analytics-worker-production` GitHub environment, documented with a `main` deployment branch rule and environment secrets
- guard production deploys with concurrency, a `main` ref check for manual dispatch, and a migration-file check that keeps remote D1 migrations manual

Closes #228

## Validation

- `git diff --check`
- parsed `.github/workflows/deploy-analytics-worker.yml` with Ruby YAML
- extracted embedded workflow `run:` blocks and checked them with `bash -n`
- skipped local `npm test` because this is workflow/docs-only per repo instructions; the deploy workflow itself runs `npm test` before deploying
