### PR TITLE
Clean up legacy command implementation names

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 /node_modules
 ballin.config.json
-/.gu-cache
+/.backup-cache
 /.analytics
 /analytics-worker/.wrangler/
 /analytics-worker/wrangler.toml

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,16 +25,16 @@ surface.
 
 ## Testing and safety
 
-- Do not run install, uninstall, `up`, `gu`, Homebrew, Gist, GitHub, npm-global,
+- Do not run install, uninstall, `ballin update`, `ballin backup`, Homebrew, Gist, GitHub, npm-global,
   `softwareupdate`, symlink, or other network-affecting operations against the
   real user environment.
-- Tests for install, uninstall, `up`, `gu`, Homebrew, Gist, GitHub, npm-global,
+- Tests for install, uninstall, `ballin update`, `ballin backup`, Homebrew, Gist, GitHub, npm-global,
   `softwareupdate`, symlink, or other network-affecting operations must use
   temporary directories, fixture files, complete child-process environments, and
   command stubs instead of the real user environment.
-- Do not manually smoke-test `bin/ballin_uninstall`, `bin/ballin_update`,
-  `install.sh`, `bin/up`, or `bin/gu` against the live checkout. If a direct
-  invocation is needed, run it through the test harness with temp roots such as
+- Do not manually smoke-test `install.sh` or `bin/ballin` with `uninstall`,
+  `update`, or `backup` against the live checkout. If a direct invocation is
+  needed, run it through the test harness with temp roots such as
   `BALLIN_UNINSTALL_TEST_SYSTEM_ROOT`, isolated config, and stubbed external
   commands.
 - Follow the existing `spawnSync` harness style, using hooks like
@@ -58,4 +58,4 @@ surface.
 - Keep `config/.defaultConfig.json`, `config/updateConfig.ts`, and config tests
   in sync when adding or changing settings.
 - `docs/optional-capabilities.md` covers Node.js setup, optional integrations,
-  and `up` settings; update it when those user-facing choices change.
+  and `ballin update` settings; update it when those user-facing choices change.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@
 
 ```shell
 $ cd /path/to/ballin-scripts
-$ ballin_update # Update project/config
+$ ballin self-update # Update project/config
 $ git checkout -b $BRANCH_NAME
 $ nvm use # If you use nvm
 $ npm install
@@ -23,4 +23,4 @@ For more repo context, see [AGENTS.md](AGENTS.md).
 
 ## Suggestions Welcome
 
-Please open issues (or PR's) with any suggestions for additions to `gu`/`up` or anything else.
+Please open issues (or PR's) with any suggestions for additions to `ballin backup`, `ballin update`, or anything else.

--- a/analytics-worker/src/index.ts
+++ b/analytics-worker/src/index.ts
@@ -53,9 +53,6 @@ const allowedCommands = new Set([
   'ballin self-update',
   'ballin uninstall',
   'ballin update',
-  'ballin_config',
-  'ballin_uninstall',
-  'ballin_update',
 ]);
 const allowedPayloadKeys = new Set([
   'schemaVersion',

--- a/bin/ballin_config
+++ b/bin/ballin_config
@@ -1,3 +1,0 @@
-#!/usr/bin/env node
-
-require('../config/cli.ts').runConfigCli();

--- a/bin/ballin_uninstall
+++ b/bin/ballin_uninstall
@@ -1,3 +1,0 @@
-#!/usr/bin/env node
-
-require('../commands/ballin_uninstall.ts').runBallinUninstallCli();

--- a/bin/ballin_update
+++ b/bin/ballin_update
@@ -1,3 +1,0 @@
-#!/usr/bin/env node
-
-require('../commands/ballin_update.ts').runBallinUpdateCli();

--- a/commands/analytics.ts
+++ b/commands/analytics.ts
@@ -76,9 +76,6 @@ const allowedCommands = new Set([
   'ballin self-update',
   'ballin uninstall',
   'ballin update',
-  'ballin_config',
-  'ballin_uninstall',
-  'ballin_update',
 ]);
 const allowedStatuses = new Set(['success', 'failure', 'unknown']);
 const allowedDurations = new Set(['unknown', '<1s', '1-10s', '10-60s', '1-10m', '10m+']);
@@ -89,7 +86,7 @@ const productionAnalyticsEndpoint = 'https://ballin-scripts-analytics.jballin.wo
 const productionAnalyticsIngestToken = '6jC_OqsMynyQc3FKXgUN7aP3bbDQ_H_DMhGDrw7t6RE';
 const analyticsNoticeFor = (docsUrl = defaultAnalyticsDocsUrl): string => [
   'ballin-scripts collects minimal anonymous usage analytics after this notice.',
-  'Disable: ballin_config set analytics.enabled false',
+  'Disable: ballin config set analytics.enabled false',
   `Details: ${docsUrl}`,
 ].join('\n');
 const analyticsNotice = analyticsNoticeFor();

--- a/commands/backup.ts
+++ b/commands/backup.ts
@@ -6,6 +6,9 @@ const {
   runWithCommandAnalytics,
 } = require('./analytics.ts');
 const {
+  getConfig,
+} = require('../config/index.ts');
+const {
   commandExists,
   ensureDir,
   makeTempFile,
@@ -42,7 +45,7 @@ type ConfigValueResult = {
   spawnStatus?: number;
 };
 
-type GuConfigResult = {
+type BackupConfigResult = {
   config: { id: string; host: string } | null;
   exitStatus: number;
 };
@@ -71,9 +74,10 @@ type CommandOptions = {
 };
 
 const emptySnapshotContent = 'empty\n';
+const configSnapshotFileName = 'ballin_config';
 
 const fileSuggestions = `
-  ballin_config
+  ${configSnapshotFileName}
   bash_completions
   bash_profile.sh
   bashrc.sh
@@ -133,23 +137,23 @@ const reportSpawnError = (command: string, error: Error): number => {
 };
 
 const configValue = (key: string): ConfigValueResult => {
-  const result = runCommand('ballin_config', ['get', key], {
-    stdio: ['ignore', 'pipe', 'inherit'],
-  });
-  if (result.error) {
+  try {
+    const value = getConfig(key);
+    if (typeof value === 'string' && value.startsWith('INVALID:')) {
+      return { value: '' };
+    }
     return {
-      value: '',
-      spawnStatus: reportSpawnError('ballin_config', result.error),
+      value: value === null ? '' : String(value).trim(),
     };
-  }
-  if (result.status !== 0) {
+  } catch (error) {
+    if (error instanceof Error) {
+      writeStderrLine(`Unable to read config: ${error.message}`);
+    }
     return { value: '' };
   }
-  const value = result.stdout.trim();
-  return { value: value === 'null' ? '' : value };
 };
 
-const guConfig = (): GuConfigResult => {
+const backupConfig = (): BackupConfigResult => {
   const idResult = configValue('backup.id');
   const hostResult = configValue('backup.host');
   const id = idResult.value;
@@ -160,10 +164,10 @@ const guConfig = (): GuConfigResult => {
   }
 
   if (!id) {
-    writeStderrLine('gu: missing config value backup.id');
+    writeStderrLine('ballin backup: missing config value backup.id');
   }
   if (!host) {
-    writeStderrLine('gu: missing config value backup.host');
+    writeStderrLine('ballin backup: missing config value backup.host');
   }
   return {
     config: null,
@@ -229,8 +233,8 @@ const ghAuthStatus = (host: string): CommandCheckResult => {
     };
   }
   if (result.status !== 0) {
-    writeStderrLine(`gu: GitHub CLI authentication is required for ${host}`);
-    writeStderrLine(`gu: run 'gh auth login --hostname ${host}'`);
+    writeStderrLine(`ballin backup: GitHub CLI authentication is required for ${host}`);
+    writeStderrLine(`ballin backup: run 'gh auth login --hostname ${host}'`);
     return { ok: false, exitStatus: shellStyleExitStatus(result) };
   }
   return { ok: true, exitStatus: 0 };
@@ -262,7 +266,7 @@ const uploadGistFile = (host: string, id: string, filePath: string, isNew: boole
   const addArgs = ['gist', 'edit', id, '--add', filePath];
   const editArgs = ['gist', 'edit', id, '--filename', path.basename(filePath), filePath];
   const args = isNew ? addArgs : editArgs;
-  const stderrFile = makeTempFile('ballin-gu-upload-stderr-');
+  const stderrFile = makeTempFile('ballin-backup-upload-stderr-');
   const stderrFd = fs.openSync(stderrFile, 'w');
   let result: ReturnType<typeof runCommand>;
   try {
@@ -325,7 +329,7 @@ const readGistFileToStdout = (host: string, id: string, fileName: string): boole
 
 const captureSnapshotInput = (snapshot: SnapshotCommand, inputFile: string): boolean => {
   const outputFd = fs.openSync(inputFile, 'w');
-  const stderrFile = makeTempFile('ballin-gu-stderr-');
+  const stderrFile = makeTempFile('ballin-backup-stderr-');
   const stderrFd = fs.openSync(stderrFile, 'w');
   let result: ReturnType<typeof runCommand>;
   try {
@@ -386,7 +390,7 @@ const snapshotIsEmpty = (filePath: string): boolean => (
 );
 
 const createSnapshotUploadFile = (sourceFile: string, fileName: string): string => {
-  const tempFile = makeTempFile('ballin-gu-upload-');
+  const tempFile = makeTempFile('ballin-backup-upload-');
   const uploadFile = path.join(path.dirname(tempFile), fileName);
   fs.copyFileSync(sourceFile, uploadFile);
   return uploadFile;
@@ -438,7 +442,7 @@ const updateSnapshot = (
   let resultState: SnapshotResultState = 'updated';
   let isEmpty = false;
 
-  const inputFile = makeTempFile('ballin-gu-input-');
+  const inputFile = makeTempFile('ballin-backup-input-');
   try {
     if (!captureSnapshotInput(snapshot, inputFile)) {
       return false;
@@ -538,7 +542,7 @@ const collectSnapshots = (homeDir: string): SnapshotCommand[] => {
   addFile('.zshrc', 'zshrc.sh');
 
   const brewAvailable = commandExists('brew');
-  let bashCompletionDir = process.env.BALLIN_GU_BASH_COMPLETION_DIR ?? '';
+  let bashCompletionDir = process.env.BALLIN_BACKUP_BASH_COMPLETION_DIR ?? '';
   if (!bashCompletionDir && brewAvailable) {
     const brewPrefix = readCommandOutput('brew', ['--prefix'], {
       env: {
@@ -612,7 +616,7 @@ const collectSnapshots = (homeDir: string): SnapshotCommand[] => {
 
   addFile('.vimrc', 'vimrc');
   addFile('.nanorc', 'nanorc');
-  addFile(path.join('.ballin-scripts', 'ballin.config.json'), 'ballin_config');
+  addFile(path.join('.ballin-scripts', 'ballin.config.json'), configSnapshotFileName);
 
   if (commandExists('mas')) {
     addShellCommand('mas', 'mas list');
@@ -621,13 +625,13 @@ const collectSnapshots = (homeDir: string): SnapshotCommand[] => {
   return snapshots;
 };
 
-function runGuCommand(args = process.argv.slice(2)): void {
+function runBackupCommand(args = process.argv.slice(2)): void {
   const homeDir = process.env.HOME ?? '';
   const command = args[0];
 
   if (command === 'help') {
     if (args.length !== 1) {
-      writeStderrLine('gu help: expected no arguments');
+      writeStderrLine('ballin backup help: expected no arguments');
       process.exitCode = 1;
       return;
     }
@@ -636,13 +640,13 @@ function runGuCommand(args = process.argv.slice(2)): void {
   }
 
   if (command && !['open', 'read'].includes(command)) {
-    writeStderrLine(`gu: unknown command '${command}'`);
+    writeStderrLine(`ballin backup: unknown command '${command}'`);
     process.exitCode = 1;
     return;
   }
 
   if (command === 'open' && args.length !== 1) {
-    writeStderrLine('gu open: expected no arguments');
+    writeStderrLine('ballin backup open: expected no arguments');
     process.exitCode = 1;
     return;
   }
@@ -654,12 +658,12 @@ function runGuCommand(args = process.argv.slice(2)): void {
   }
 
   if (command === 'read' && args.length !== 2) {
-    writeStderrLine('gu read: expected exactly one filename');
+    writeStderrLine('ballin backup read: expected exactly one filename');
     process.exitCode = 1;
     return;
   }
 
-  const { config, exitStatus } = guConfig();
+  const { config, exitStatus } = backupConfig();
   if (!config) {
     process.exitCode = exitStatus;
     return;
@@ -683,7 +687,7 @@ function runGuCommand(args = process.argv.slice(2)): void {
 
   const gistReadable = verifyGistReadable(config.host, config.id);
   if (!gistReadable.ok) {
-    writeStdoutLine("Error retrieving your gist, please run 'ballin_update'.");
+    writeStdoutLine("Error retrieving your gist, please run 'ballin self-update'.");
     process.exitCode = gistReadable.exitStatus;
     return;
   }
@@ -698,13 +702,13 @@ function runGuCommand(args = process.argv.slice(2)): void {
     return;
   }
 
-  const cacheDir = path.join(homeDir, '.ballin-scripts', '.gu-cache');
+  const cacheDir = path.join(homeDir, '.ballin-scripts', '.backup-cache');
   ensureDir(cacheDir);
 
   let failed = false;
   collectSnapshots(homeDir).forEach((snapshot) => {
     if (!updateSnapshot(config.host, config.id, cacheDir, snapshot)) {
-      writeStderrLine(`gu: failed to snapshot ${snapshot.fileName}`);
+      writeStderrLine(`ballin backup: failed to snapshot ${snapshot.fileName}`);
       failed = true;
     }
   });
@@ -714,11 +718,11 @@ function runGuCommand(args = process.argv.slice(2)): void {
   }
 }
 
-const runGuCli = (args = process.argv.slice(2)): void => {
-  void runWithCommandAnalytics('gu', () => runGuCommand(args)).catch(rethrowCommandError);
+const runBackupCli = (args = process.argv.slice(2)): void => {
+  void runWithCommandAnalytics('ballin backup', () => runBackupCommand(args)).catch(rethrowCommandError);
 };
 
 module.exports = {
-  runGuCommand,
-  runGuCli,
+  runBackupCommand,
+  runBackupCli,
 };

--- a/commands/ballin.ts
+++ b/commands/ballin.ts
@@ -7,11 +7,11 @@ const {
   runConfigCli,
 } = require('../config/cli.ts');
 const {
-  runBallinUpdateCommand,
-} = require('./ballin_update.ts');
+  runSelfUpdateCommand,
+} = require('./self_update.ts');
 const {
-  runBallinUninstallCli,
-} = require('./ballin_uninstall.ts');
+  runUninstallCommand,
+} = require('./uninstall.ts');
 const {
   collectSetupReadiness,
 } = require('./setup_readiness.ts');
@@ -20,11 +20,11 @@ const {
   formatVerboseDoctorReport,
 } = require('./doctor_report.ts');
 const {
-  runGuCommand,
-} = require('./gu.ts');
+  runBackupCommand,
+} = require('./backup.ts');
 const {
-  runUpCommand,
-} = require('./up.ts');
+  runUpdateCommand,
+} = require('./update.ts');
 import type { DoctorReport } from './doctor_report.ts';
 
 const format = {
@@ -126,14 +126,14 @@ function runBallinCommand(args = process.argv.slice(2)): void {
       writeStdout(ballinHelp);
       return;
     case 'update':
-      runNoArgCommand('ballin update', commandArgs, runUpCommand);
+      runNoArgCommand('ballin update', commandArgs, runUpdateCommand);
       return;
     case 'backup':
       if (commandArgs.length === 1 && commandArgs[0] === 'help') {
         writeStdout(ballinHelp);
         return;
       }
-      runGuCommand(commandArgs);
+      runBackupCommand(commandArgs);
       return;
     case 'doctor':
       runDoctorCommand(commandArgs);
@@ -142,10 +142,10 @@ function runBallinCommand(args = process.argv.slice(2)): void {
       runConfigCli(commandArgs);
       return;
     case 'self-update':
-      runNoArgCommand('ballin self-update', commandArgs, runBallinUpdateCommand);
+      runNoArgCommand('ballin self-update', commandArgs, runSelfUpdateCommand);
       return;
     case 'uninstall':
-      runNoArgCommand('ballin uninstall', commandArgs, runBallinUninstallCli);
+      runNoArgCommand('ballin uninstall', commandArgs, runUninstallCommand);
       return;
     default:
       writeStderr(`Unknown Ballin command: ${command}\nTry: ballin --help\n`);

--- a/commands/doctor_report.ts
+++ b/commands/doctor_report.ts
@@ -20,8 +20,8 @@ const statusLabels: Record<DoctorStatus, string> = {
 const nextSteps: Record<string, string> = {
   'runtime.node': 'Install a supported Node.js version and reopen your shell.',
   'commands.path': 'Run the installer again or add the Ballin command directory to PATH.',
-  'config.read': 'Run ballin_config reset to recreate the config.',
-  'backup.host': 'Set the backup host with ballin_config set backup.host <host>.',
+  'config.read': 'Run ballin config reset to recreate the config.',
+  'backup.host': 'Set the backup host with ballin config set backup.host <host>.',
   'backup.gist': 'Run the installer to create or adopt a backup Gist.',
   'backup.gh': 'Install GitHub CLI and authenticate it for your backup host.',
   'backup.auth': 'Run gh auth login for the configured backup host.',

--- a/commands/install_setup.ts
+++ b/commands/install_setup.ts
@@ -87,6 +87,8 @@ const readJsonObject = (filePath: string): ConfigObject | null => {
   }
 };
 
+// Installer setup can target an arbitrary checkout, while config/index.ts binds
+// its config path at module load. Keep these repoDir-scoped helpers local.
 const getNestedConfigValue = (config: ConfigObject, keyPath: string): ConfigValue | undefined => {
   const keys = keyPath.split('.');
   let value: ConfigValue = config;

--- a/commands/install_setup.ts
+++ b/commands/install_setup.ts
@@ -13,6 +13,7 @@ const {
 const backupMarker = '### Backup of your dev environment\n'
   + 'Created by [ballin-scripts](https://github.com/JBallin/ballin-scripts)\n'
   + '\n';
+const configSnapshotFileName = 'ballin_config';
 
 const readPrompt = (prompt: string): string => {
   process.stdout.write(prompt);
@@ -41,7 +42,9 @@ const supportedCommands = new Set([
   'symlink-binaries',
 ]);
 
-type ConfigObject = { [key: string]: unknown };
+type ConfigObject = { [key: string]: ConfigValue };
+type ConfigLeaf = string | number | boolean | null;
+type ConfigValue = ConfigLeaf | ConfigObject;
 
 const isConfigObject = (value: unknown): value is ConfigObject => (
   typeof value === 'object' && value !== null && !Array.isArray(value)
@@ -82,6 +85,53 @@ const readJsonObject = (filePath: string): ConfigObject | null => {
   } catch {
     return null;
   }
+};
+
+const getNestedConfigValue = (config: ConfigObject, keyPath: string): ConfigValue | undefined => {
+  const keys = keyPath.split('.');
+  let value: ConfigValue = config;
+
+  for (const key of keys) {
+    if (value === null || typeof value !== 'object' || !Object.prototype.hasOwnProperty.call(value, key)) {
+      return undefined;
+    }
+    value = value[key];
+  }
+
+  return value;
+};
+
+const setNestedConfigValue = (config: ConfigObject, keyPath: string, value: ConfigLeaf): boolean => {
+  const keys = keyPath.split('.');
+  const keyToSet = keys.pop();
+  let container: ConfigValue = config;
+
+  if (!keyToSet) {
+    return false;
+  }
+
+  for (const key of keys) {
+    if (
+      container === null
+      || typeof container !== 'object'
+      || !Object.prototype.hasOwnProperty.call(container, key)
+    ) {
+      return false;
+    }
+    container = container[key];
+  }
+
+  if (
+    container === null
+    || typeof container !== 'object'
+    || !Object.prototype.hasOwnProperty.call(container, keyToSet)
+    || (typeof container[keyToSet] === 'object' && container[keyToSet] !== null)
+  ) {
+    return false;
+  }
+
+  container[keyToSet] = value;
+  return true;
 };
 
 const configHasBackupHost = (repoDir: string): boolean => {
@@ -133,26 +183,26 @@ const configure = (repoDir: string, docsUrl: string): boolean => {
   return updateConfig(repoDir, docsUrl);
 };
 
-const configValue = (ballinConfig: string, key: string): string | null => {
-  const result = runCommand(ballinConfig, ['get', key]);
-  if (result.stderr) {
-    process.stderr.write(result.stderr);
-  }
-  if (result.status !== 0 || result.error) {
+const configValue = (configPath: string, key: string): string | null => {
+  const config = readJsonObject(configPath);
+  if (!config) {
     return null;
   }
-  return result.stdout.trimEnd();
+  const value = getNestedConfigValue(config, key);
+  if (value === undefined || (typeof value === 'object' && value !== null)) {
+    return null;
+  }
+  return value === null ? 'null' : String(value);
 };
 
-const setConfigValue = (ballinConfig: string, key: string, value: string): boolean => {
-  const result = runCommand(ballinConfig, ['set', key, value]);
-  if (result.stdout) {
-    process.stdout.write(result.stdout);
+const setConfigValue = (configPath: string, key: string, value: string): boolean => {
+  const config = readJsonObject(configPath);
+  if (!config || !setNestedConfigValue(config, key, value)) {
+    return false;
   }
-  if (result.stderr) {
-    process.stderr.write(result.stderr);
-  }
-  return result.status === 0 && !result.error;
+  fs.writeFileSync(configPath, JSON.stringify(config, null, 2), 'utf8');
+  process.stdout.write(`"${key}" set to: ${JSON.stringify(value)}\n`);
+  return true;
 };
 
 const runGh = (
@@ -181,7 +231,7 @@ const restoreAdoptedConfig = (
   try {
     fs.copyFileSync(configPath, previousConfig);
 
-    const gistResult = runGh(host, ['gist', 'view', gistId, '--raw', '--filename', 'ballin_config'], {
+    const gistResult = runGh(host, ['gist', 'view', gistId, '--raw', '--filename', configSnapshotFileName], {
       cwd: repoDir,
     });
     if (gistResult.stderr) {
@@ -189,7 +239,7 @@ const restoreAdoptedConfig = (
     }
 
     if (gistResult.status !== 0 || gistResult.error) {
-      writeStdoutLine('\nℹ️  No ballin_config snapshot was found in that gist; keeping the local config defaults.');
+      writeStdoutLine(`\nℹ️  No ${configSnapshotFileName} snapshot was found in that gist; keeping the local config defaults.`);
       return true;
     }
 
@@ -216,30 +266,30 @@ const restoreAdoptedConfig = (
 };
 
 const configureGist = (repoDir: string, docsUrl: string, backupHostExisted: boolean): boolean => {
-  const ballinConfig = path.join(repoDir, 'bin', 'ballin_config');
-  let guHost = configValue(ballinConfig, 'backup.host');
-  let guId = configValue(ballinConfig, 'backup.id');
+  const ballinConfig = configPathFor(repoDir);
+  let backupHost = configValue(ballinConfig, 'backup.host');
+  let backupId = configValue(ballinConfig, 'backup.id');
 
-  if (guHost === null || guId === null) {
+  if (backupHost === null || backupId === null) {
     return false;
   }
 
-  if (process.env.BALLIN_GU_HOST) {
-    if (!setConfigValue(ballinConfig, 'backup.host', process.env.BALLIN_GU_HOST)) {
+  if (process.env.BALLIN_BACKUP_HOST) {
+    if (!setConfigValue(ballinConfig, 'backup.host', process.env.BALLIN_BACKUP_HOST)) {
       return false;
     }
-    guHost = configValue(ballinConfig, 'backup.host');
-    if (guHost === null) {
+    backupHost = configValue(ballinConfig, 'backup.host');
+    if (backupHost === null) {
       return false;
     }
-  } else if (guId === 'null' || !backupHostExisted) {
-    const inputHost = readPrompt(`\n🤔 What GitHub host should be used for Gist backups? [${guHost}] `);
+  } else if (backupId === 'null' || !backupHostExisted) {
+    const inputHost = readPrompt(`\n🤔 What GitHub host should be used for Gist backups? [${backupHost}] `);
     if (inputHost) {
       if (!setConfigValue(ballinConfig, 'backup.host', inputHost)) {
         return false;
       }
-      guHost = configValue(ballinConfig, 'backup.host');
-      if (guHost === null) {
+      backupHost = configValue(ballinConfig, 'backup.host');
+      if (backupHost === null) {
         return false;
       }
     }
@@ -249,26 +299,26 @@ const configureGist = (repoDir: string, docsUrl: string, backupHostExisted: bool
     writeStdoutLine('\n⚠️  ERROR: GitHub CLI is required for Gist backup setup.');
     writeStdoutLine('\nInstall gh, authenticate it, then run this installer again.');
     writeStdoutLine(`\nSetup guide: ${docsUrl}`);
-    writeStdoutLine(`\nRun after installing gh:\n  gh auth login --hostname ${guHost}`);
+    writeStdoutLine(`\nRun after installing gh:\n  gh auth login --hostname ${backupHost}`);
     return false;
   }
 
-  const authResult = runCommand('gh', ['auth', 'status', '--hostname', guHost], {
+  const authResult = runCommand('gh', ['auth', 'status', '--hostname', backupHost], {
     cwd: repoDir,
     env: {
       ...process.env,
-      GH_HOST: guHost,
+      GH_HOST: backupHost,
     },
   });
 
   if (authResult.status !== 0 || authResult.error) {
-    writeStdoutLine(`\n⚠️  ERROR: gh is not authenticated for ${guHost}.`);
-    writeStdoutLine(`\nRun:\n  gh auth login --hostname ${guHost}`);
+    writeStdoutLine(`\n⚠️  ERROR: gh is not authenticated for ${backupHost}.`);
+    writeStdoutLine(`\nRun:\n  gh auth login --hostname ${backupHost}`);
     writeStdoutLine('\nThen run this installer again.');
     return false;
   }
 
-  if (guId !== 'null') {
+  if (backupId !== 'null') {
     return true;
   }
 
@@ -278,7 +328,7 @@ const configureGist = (repoDir: string, docsUrl: string, backupHostExisted: bool
     let validGistId = false;
     while (!validGistId) {
       const gistId = readPrompt('Enter your gist ID: ');
-      const markerResult = runGh(guHost, ['gist', 'view', gistId, '--raw', '--filename', '.MyConfig.md'], {
+      const markerResult = runGh(backupHost, ['gist', 'view', gistId, '--raw', '--filename', '.MyConfig.md'], {
         cwd: repoDir,
       });
 
@@ -287,7 +337,7 @@ const configureGist = (repoDir: string, docsUrl: string, backupHostExisted: bool
         && stripTrailingNewlines(markerResult.stdout) === stripTrailingNewlines(backupMarker)
       ) {
         writeStdoutLine('\n👍 Storing your previous gist ID in your config:');
-        if (!restoreAdoptedConfig(repoDir, docsUrl, guHost, gistId)) {
+        if (!restoreAdoptedConfig(repoDir, docsUrl, backupHost, gistId)) {
           return false;
         }
         if (!setConfigValue(ballinConfig, 'backup.id', gistId)) {
@@ -300,17 +350,17 @@ const configureGist = (repoDir: string, docsUrl: string, backupHostExisted: bool
     }
   }
 
-  guId = configValue(ballinConfig, 'backup.id');
-  if (guId === null) {
+  backupId = configValue(ballinConfig, 'backup.id');
+  if (backupId === null) {
     return false;
   }
 
-  if (guId === 'null') {
+  if (backupId === 'null') {
     const markerPath = path.join(repoDir, '.MyConfig.md');
     fs.writeFileSync(markerPath, backupMarker);
 
     try {
-      const createResult = runGh(guHost, ['gist', 'create', '.MyConfig.md', '--desc', backupMarker], {
+      const createResult = runGh(backupHost, ['gist', 'create', '.MyConfig.md', '--desc', backupMarker], {
         cwd: repoDir,
       });
       if (createResult.stderr) {
@@ -329,10 +379,10 @@ const configureGist = (repoDir: string, docsUrl: string, backupHostExisted: bool
         return false;
       }
 
-      const guCacheDir = path.join(repoDir, '.gu-cache');
-      if (fs.existsSync(guCacheDir) && fs.statSync(guCacheDir).isDirectory()) {
-        fs.rmSync(guCacheDir, { recursive: true, force: true });
-        writeStdoutLine('\n🗑  Deleted existing .gu-cache folder');
+      const backupCacheDir = path.join(repoDir, '.backup-cache');
+      if (fs.existsSync(backupCacheDir) && fs.statSync(backupCacheDir).isDirectory()) {
+        fs.rmSync(backupCacheDir, { recursive: true, force: true });
+        writeStdoutLine('\n🗑  Deleted existing .backup-cache folder');
       }
     } finally {
       fs.rmSync(markerPath, { force: true });

--- a/commands/install_setup.ts
+++ b/commands/install_setup.ts
@@ -14,6 +14,11 @@ const backupMarker = '### Backup of your dev environment\n'
   + 'Created by [ballin-scripts](https://github.com/JBallin/ballin-scripts)\n'
   + '\n';
 const configSnapshotFileName = 'ballin_config';
+const legacyBinNames = [
+  'ballin_config',
+  'ballin_update',
+  'ballin_uninstall',
+];
 
 const readPrompt = (prompt: string): string => {
   process.stdout.write(prompt);
@@ -403,6 +408,18 @@ const symlinkBinaries = (repoDir: string, binDir: string): boolean => {
   }
 
   try {
+    legacyBinNames.forEach((binName) => {
+      const targetPath = path.join(binDir, binName);
+      try {
+        if (fs.lstatSync(targetPath).isSymbolicLink()
+          && fs.readlinkSync(targetPath) === path.join(sourceBinDir, binName)) {
+          fs.rmSync(targetPath, { force: true });
+        }
+      } catch {
+        // Missing or unreadable legacy targets are handled like absent targets.
+      }
+    });
+
     for (const binName of fs.readdirSync(sourceBinDir)) {
       const sourcePath = path.join(sourceBinDir, binName);
       const targetPath = path.join(binDir, binName);

--- a/commands/install_setup.ts
+++ b/commands/install_setup.ts
@@ -14,11 +14,6 @@ const backupMarker = '### Backup of your dev environment\n'
   + 'Created by [ballin-scripts](https://github.com/JBallin/ballin-scripts)\n'
   + '\n';
 const configSnapshotFileName = 'ballin_config';
-const legacyBinNames = [
-  'ballin_config',
-  'ballin_update',
-  'ballin_uninstall',
-];
 
 const readPrompt = (prompt: string): string => {
   process.stdout.write(prompt);
@@ -408,18 +403,6 @@ const symlinkBinaries = (repoDir: string, binDir: string): boolean => {
   }
 
   try {
-    legacyBinNames.forEach((binName) => {
-      const targetPath = path.join(binDir, binName);
-      try {
-        if (fs.lstatSync(targetPath).isSymbolicLink()
-          && fs.readlinkSync(targetPath) === path.join(sourceBinDir, binName)) {
-          fs.rmSync(targetPath, { force: true });
-        }
-      } catch {
-        // Missing or unreadable legacy targets are handled like absent targets.
-      }
-    });
-
     for (const binName of fs.readdirSync(sourceBinDir)) {
       const sourcePath = path.join(sourceBinDir, binName);
       const targetPath = path.join(binDir, binName);

--- a/commands/self_update.ts
+++ b/commands/self_update.ts
@@ -14,7 +14,7 @@ const {
 
 const docsUrl = 'https://github.com/JBallin/ballin-scripts/blob/main/docs/README.md';
 
-function runBallinUpdateCommand(): void {
+function runSelfUpdateCommand(): void {
   const repoDir = path.join(process.env.HOME ?? '', '.ballin-scripts');
 
   writeStdoutLine('👟 getting fresh kicks...');
@@ -35,11 +35,11 @@ function runBallinUpdateCommand(): void {
   });
 }
 
-const runBallinUpdateCli = (): void => {
-  void runWithCommandAnalytics('ballin_update', runBallinUpdateCommand).catch(rethrowCommandError);
+const runSelfUpdateCli = (): void => {
+  void runWithCommandAnalytics('ballin self-update', runSelfUpdateCommand).catch(rethrowCommandError);
 };
 
 module.exports = {
-  runBallinUpdateCommand,
-  runBallinUpdateCli,
+  runSelfUpdateCommand,
+  runSelfUpdateCli,
 };

--- a/commands/setup_readiness.ts
+++ b/commands/setup_readiness.ts
@@ -46,9 +46,6 @@ type CollectSetupReadinessOptions = {
 
 const requiredCommandShims = [
   'ballin',
-  'ballin_config',
-  'ballin_uninstall',
-  'ballin_update',
 ];
 
 const isConfigObject = (value: unknown): value is ConfigObject => (

--- a/commands/uninstall.ts
+++ b/commands/uninstall.ts
@@ -39,7 +39,13 @@ const removeOwnedLink = (linkPath: string, targetPath: string): void => {
   }
 };
 
-const runBallinUninstallCli = (): void => {
+const legacyBinNames = [
+  'ballin_config',
+  'ballin_update',
+  'ballin_uninstall',
+];
+
+const runUninstallCommand = (): void => {
   const homeDir = process.env.HOME ?? '';
   const repoDir = path.join(homeDir, '.ballin-scripts');
   const systemRoot = process.env.BALLIN_UNINSTALL_TEST_SYSTEM_ROOT ?? '';
@@ -64,7 +70,7 @@ const runBallinUninstallCli = (): void => {
 
   const repoBinDir = path.join(repoDir, 'bin');
   if (fs.existsSync(repoBinDir)) {
-    fs.readdirSync(repoBinDir).forEach((binName: string) => {
+    [...fs.readdirSync(repoBinDir), ...legacyBinNames].forEach((binName: string) => {
       const targetPath = path.join(repoBinDir, binName);
       binDirs.forEach((binDir) => {
         removeOwnedLink(path.join(binDir, binName), targetPath);
@@ -80,5 +86,5 @@ const runBallinUninstallCli = (): void => {
 
 module.exports = {
   relocateSystemPath,
-  runBallinUninstallCli,
+  runUninstallCommand,
 };

--- a/commands/uninstall.ts
+++ b/commands/uninstall.ts
@@ -39,12 +39,6 @@ const removeOwnedLink = (linkPath: string, targetPath: string): void => {
   }
 };
 
-const legacyBinNames = [
-  'ballin_config',
-  'ballin_update',
-  'ballin_uninstall',
-];
-
 const runUninstallCommand = (): void => {
   const homeDir = process.env.HOME ?? '';
   const repoDir = path.join(homeDir, '.ballin-scripts');
@@ -70,7 +64,7 @@ const runUninstallCommand = (): void => {
 
   const repoBinDir = path.join(repoDir, 'bin');
   if (fs.existsSync(repoBinDir)) {
-    [...fs.readdirSync(repoBinDir), ...legacyBinNames].forEach((binName: string) => {
+    fs.readdirSync(repoBinDir).forEach((binName: string) => {
       const targetPath = path.join(repoBinDir, binName);
       binDirs.forEach((binDir) => {
         removeOwnedLink(path.join(binDir, binName), targetPath);

--- a/commands/update.ts
+++ b/commands/update.ts
@@ -5,6 +5,9 @@ const {
   runWithCommandAnalytics,
 } = require('./analytics.ts');
 const {
+  getConfig,
+} = require('../config/index.ts');
+const {
   formatDefaultDoctorReport,
 } = require('./doctor_report.ts');
 const {
@@ -28,19 +31,19 @@ type NvmInstallResult = {
   status: number;
 };
 
-const configValue = (key: string, env = process.env): string => {
-  const result = runCommand('ballin_config', ['get', key], {
-    env,
-    stdio: ['ignore', 'pipe', 'inherit'],
-  });
-  if (result.error) {
-    reportSpawnError('ballin_config', result.error);
+const configValue = (key: string): string => {
+  try {
+    const value = getConfig(key);
+    if (typeof value === 'string' && value.startsWith('INVALID:')) {
+      return '';
+    }
+    return value === null ? '' : String(value).trim();
+  } catch (error) {
+    if (error instanceof Error) {
+      writeStderrLine(`Unable to read config: ${error.message}`);
+    }
     return '';
   }
-  if (result.status !== 0) {
-    return '';
-  }
-  return result.stdout.trim();
 };
 
 const parseEnvOutput = (output: string): NodeJS.ProcessEnv | null => {
@@ -56,15 +59,15 @@ const parseEnvOutput = (output: string): NodeJS.ProcessEnv | null => {
 };
 
 const runNvmInstall = (env: NodeJS.ProcessEnv): NvmInstallResult => {
-  const envPath = makeTempFile('ballin-up-env-');
+  const envPath = makeTempFile('ballin-update-env-');
   try {
     const result = runCommand('bash', [
       '-c',
-      '. "$NVM_DIR/nvm.sh"; nvm install --lts; nvm_status="$?"; node -e \'process.stdout.write(JSON.stringify(process.env))\' > "$BALLIN_UP_ENV_PATH"; exit "$nvm_status"',
+      '. "$NVM_DIR/nvm.sh"; nvm install --lts; nvm_status="$?"; node -e \'process.stdout.write(JSON.stringify(process.env))\' > "$BALLIN_UPDATE_ENV_PATH"; exit "$nvm_status"',
     ], {
       env: {
         ...env,
-        BALLIN_UP_ENV_PATH: envPath,
+        BALLIN_UPDATE_ENV_PATH: envPath,
       },
       stdio: 'inherit',
     });
@@ -91,7 +94,7 @@ const runNvmInstall = (env: NodeJS.ProcessEnv): NvmInstallResult => {
       };
     }
 
-    delete nextEnv.BALLIN_UP_ENV_PATH;
+    delete nextEnv.BALLIN_UPDATE_ENV_PATH;
     return {
       env: nextEnv,
       status,
@@ -112,6 +115,10 @@ const nodeVersionForEnv = (env: NodeJS.ProcessEnv): string | undefined => {
   return result.stdout.trim() || undefined;
 };
 
+const ballinCommandPath = (): string => (
+  process.env.BALLIN_TEST_BALLIN_PATH || path.join(__dirname, '..', 'bin', 'ballin')
+);
+
 const reportBallinReadiness = (env: NodeJS.ProcessEnv): void => {
   const repoDir = path.join(__dirname, '..');
   const report = collectSetupReadiness({
@@ -124,7 +131,7 @@ const reportBallinReadiness = (env: NodeJS.ProcessEnv): void => {
   process.stdout.write(formatDefaultDoctorReport(report));
 };
 
-function runUpCommand(): void {
+function runUpdateCommand(): void {
   let childEnv = process.env;
   let exitStatus = 0;
 
@@ -149,7 +156,7 @@ function runUpCommand(): void {
     };
     runIntegrationCommand('brew', ['upgrade'], { env: childEnv });
 
-    if (configValue('update.cleanup', childEnv) === 'true') {
+    if (configValue('update.cleanup') === 'true') {
       progress('Cleaning up Homebrew packages');
       runIntegrationCommand('brew', ['cleanup'], { env: childEnv });
     }
@@ -158,7 +165,7 @@ function runUpCommand(): void {
     runIntegrationCommand('brew', ['doctor'], { env: childEnv });
   }
 
-  if (configValue('update.nvm', childEnv) === 'true') {
+  if (configValue('update.nvm') === 'true') {
     progress('Updating Node.js LTS');
     const nvmDir = process.env.NVM_DIR ?? '';
     const nvmScript = path.join(nvmDir, 'nvm.sh');
@@ -171,11 +178,11 @@ function runUpCommand(): void {
     } else {
       writeStderrLine();
       writeStderrLine('⚠️  Skipping Node.js LTS update: unable to load nvm.');
-      writeStderrLine('Set NVM_DIR to your nvm installation or disable this update with: ballin_config set update.nvm false');
+      writeStderrLine('Set NVM_DIR to your nvm installation or disable this update with: ballin config set update.nvm false');
     }
   }
 
-  if (commandExists('npm', { env: childEnv }) && configValue('update.npm', childEnv) === 'true') {
+  if (commandExists('npm', { env: childEnv }) && configValue('update.npm') === 'true') {
     progress('Updating global npm packages');
     runIntegrationCommand('npm', ['update', '-g'], { env: childEnv });
   }
@@ -185,23 +192,23 @@ function runUpCommand(): void {
     runIntegrationCommand('mas', ['upgrade'], { env: childEnv });
   }
 
-  if (commandExists('softwareupdate', { env: childEnv }) && configValue('update.softwareupdate', childEnv) === 'true') {
+  if (commandExists('softwareupdate', { env: childEnv }) && configValue('update.softwareupdate') === 'true') {
     progress('Installing macOS updates');
     runIntegrationCommand('softwareupdate', ['-ia'], { env: childEnv });
   }
 
-  if (configValue('update.selfUpdate', childEnv) === 'true') {
+  if (configValue('update.selfUpdate') === 'true') {
     progress('Updating ballin-scripts');
-    const updateStatus = runIntegrationCommand('ballin_update', [], { env: childEnv });
+    const updateStatus = runIntegrationCommand(ballinCommandPath(), ['self-update'], { env: childEnv });
     if (updateStatus === 0) {
       progress('Checking Ballin readiness');
       reportBallinReadiness(childEnv);
     }
   }
 
-  if (configValue('update.backup', childEnv) === 'true') {
+  if (configValue('update.backup') === 'true') {
     progress('Backing up development environment');
-    runIntegrationCommand('ballin', ['backup'], { env: childEnv });
+    runIntegrationCommand(ballinCommandPath(), ['backup'], { env: childEnv });
   }
 
   if (exitStatus !== 0) {
@@ -209,11 +216,11 @@ function runUpCommand(): void {
   }
 }
 
-const runUpCli = (): void => {
-  void runWithCommandAnalytics('up', runUpCommand).catch(rethrowCommandError);
+const runUpdateCli = (): void => {
+  void runWithCommandAnalytics('ballin update', runUpdateCommand).catch(rethrowCommandError);
 };
 
 module.exports = {
-  runUpCommand,
-  runUpCli,
+  runUpdateCommand,
+  runUpdateCli,
 };

--- a/config/index.ts
+++ b/config/index.ts
@@ -21,7 +21,7 @@ const stringify = (obj: ConfigObject) => JSON.stringify(obj, null, 2);
 const hasOwn = (obj: ConfigObject, key: string) => Object.prototype.hasOwnProperty.call(obj, key);
 
 const configMessages = {
-  actionErr: 'INVALID: ballin_config accepts "", "get", "set", or "reset"',
+  actionErr: 'INVALID: ballin config accepts "", "get", "set", or "reset"',
   getKeysDneErr: (keys: string) => `INVALID: "${keys}" doesn't exist in config`,
   reset: (prevConfig: ConfigValue, defaultConfig: string) => (
     `Config has been reset...\nFROM:\n${prevConfig}TO:\n${defaultConfig}`
@@ -119,7 +119,7 @@ const setConfig = (keys?: string, val?: ConfigValue, other?: string[]) => {
 
 const configAction = (request?: string, keys?: string, value?: string, other?: string[]) => {
   if (request === 'reset') return resetConfig();
-  // send config auto if not given a request with ballin_config command
+  // Send config automatically when no explicit request is provided.
   if (request === 'get' || !request) return getConfig(keys, value);
   if (request === 'set') return setConfig(keys, value, other);
   if (process.env.NODE_ENV !== 'test') {

--- a/config/index.ts
+++ b/config/index.ts
@@ -119,7 +119,7 @@ const setConfig = (keys?: string, val?: ConfigValue, other?: string[]) => {
 
 const configAction = (request?: string, keys?: string, value?: string, other?: string[]) => {
   if (request === 'reset') return resetConfig();
-  // Send config automatically when no explicit request is provided.
+  // Send full config when no explicit request is provided.
   if (request === 'get' || !request) return getConfig(keys, value);
   if (request === 'set') return setConfig(keys, value, other);
   if (process.env.NODE_ENV !== 'test') {

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -28,7 +28,7 @@ can snapshot:
 | Area | Snapshot files | Requirement |
 | --- | --- | --- |
 | Shell startup files | `bash_profile.sh`, `bashrc.sh`, `profile.sh`, `zprofile.sh`, `zshrc.sh` | Matching dotfiles in `HOME`. |
-| Bash completions | `bash_completions` | Homebrew completion directory or `BALLIN_GU_BASH_COMPLETION_DIR`. |
+| Bash completions | `bash_completions` | Homebrew completion directory or `BALLIN_BACKUP_BASH_COMPLETION_DIR`. |
 | Homebrew inventory | `brew_list`, `brew_leaves`, `brew_cask`, `brew_services`, `Brewfile` | `brew` on `PATH`. |
 | Git config | `gitconfig`, `gitignore_global` | Matching dotfiles in `HOME`. |
 | Global npm packages | `npm_global` | `npm` on `PATH`. |
@@ -37,5 +37,5 @@ can snapshot:
 | VS Code Insiders | `vsI_settings`, `vsI_keybindings`, `vsI_extensions` | VS Code Insiders user files; `code-insiders` for extension list. |
 | Brackets | `brackets_settings.json`, `brackets_keymap.json`, `brackets_extensions`, `brackets_disabled_extensions` | Brackets support files in `HOME`. |
 | Editor config files | `vimrc`, `nanorc` | Matching dotfiles in `HOME`. |
-| Ballin config | `ballin_config` | Local `ballin.config.json`. |
+| Ballin config | `ballin_config` | Local `ballin.config.json` snapshot filename. |
 | Mac App Store apps | `mas` | `mas` on `PATH`. |

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -37,5 +37,5 @@ can snapshot:
 | VS Code Insiders | `vsI_settings`, `vsI_keybindings`, `vsI_extensions` | VS Code Insiders user files; `code-insiders` for extension list. |
 | Brackets | `brackets_settings.json`, `brackets_keymap.json`, `brackets_extensions`, `brackets_disabled_extensions` | Brackets support files in `HOME`. |
 | Editor config files | `vimrc`, `nanorc` | Matching dotfiles in `HOME`. |
-| Ballin config | `ballin_config` | Local `ballin.config.json` snapshot filename. |
+| Ballin config | `ballin_config` | Local `ballin.config.json` file. |
 | Mac App Store apps | `mas` | `mas` on `PATH`. |

--- a/docs/optional-capabilities.md
+++ b/docs/optional-capabilities.md
@@ -78,7 +78,7 @@ setting is required.
 the configured backup Gist. During install, `ballin-scripts` prompts for the
 GitHub host, including GitHub Enterprise hosts, checks `gh` authentication for
 that host, and either adopts an existing backup Gist or creates a new one. When
-an adopted backup includes saved `ballin_config` values, the installer restores
+an adopted backup includes saved `ballin.config.json` values, the installer restores
 them before continuing.
 
 ## Readiness checks

--- a/docs/optional-capabilities.md
+++ b/docs/optional-capabilities.md
@@ -78,7 +78,7 @@ setting is required.
 the configured backup Gist. During install, `ballin-scripts` prompts for the
 GitHub host, including GitHub Enterprise hosts, checks `gh` authentication for
 that host, and either adopts an existing backup Gist or creates a new one. When
-an adopted backup includes saved `ballin.config.json` values, the installer restores
+an adopted backup includes a saved `ballin_config` snapshot, the installer restores
 them before continuing.
 
 ## Readiness checks

--- a/test/analytics.test.ts
+++ b/test/analytics.test.ts
@@ -130,7 +130,7 @@ describe('analytics client', () => {
     writeInstallId();
 
     const { payloads, notices } = await recordWithSender({
-      command: 'up',
+      command: 'ballin update',
       now: fixedNow,
     });
 
@@ -151,7 +151,7 @@ describe('analytics client', () => {
       writeInstallId();
 
       const { payloads } = await recordWithSender({
-        command: 'up',
+        command: 'ballin update',
         now: fixedNow,
       }, { env });
 
@@ -212,7 +212,7 @@ describe('analytics client', () => {
     });
 
     const { payloads, notices } = await recordWithSender({
-      command: 'up',
+      command: 'ballin update',
       now: fixedNow,
     });
 
@@ -227,7 +227,7 @@ describe('analytics client', () => {
     writeRawInstallId('not-a-uuid\n');
 
     const { payloads, notices } = await recordWithSender({
-      command: 'up',
+      command: 'ballin update',
       now: fixedNow,
     });
 
@@ -243,7 +243,7 @@ describe('analytics client', () => {
     writeInstallId();
 
     await recordAnalyticsEvent({
-      command: 'up',
+      command: 'ballin update',
       now: fixedNow,
     }, {
       installIdPath: testInstallIdPath,
@@ -260,7 +260,7 @@ describe('analytics client', () => {
     writeInstallId();
 
     const { payloads } = await recordWithSender({
-      command: 'ballin_config',
+      command: 'ballin config',
       status: 'failure',
       durationBucket: '1-10s',
       args: ['get', 'backup.id'],
@@ -275,7 +275,7 @@ describe('analytics client', () => {
       schemaVersion: 1,
       installId: fixedInstallId,
       dateBucket: '2026-06-27',
-      command: 'ballin_config',
+      command: 'ballin config',
       status: 'failure',
       durationBucket: '1-10s',
     });
@@ -458,7 +458,7 @@ describe('analytics client', () => {
     process.exitCode = 17;
 
     try {
-      await runWithCommandAnalytics('ballin_update', () => {}, {
+      await runWithCommandAnalytics('ballin self-update', () => {}, {
         endpoint: 'https://analytics.example.test/v1/events',
         ingestToken: 'test-token',
         env: {},
@@ -475,7 +475,7 @@ describe('analytics client', () => {
     }
 
     assert.deepInclude(payloads[0], {
-      command: 'ballin_update',
+      command: 'ballin self-update',
       status: 'success',
       durationBucket: '<1s',
     });
@@ -643,7 +643,7 @@ describe('analytics client', () => {
         schemaVersion: 1,
         installId: fixedInstallId,
         dateBucket: '2026-06-27',
-        command: 'up',
+        command: 'ballin update',
         status: 'success',
         durationBucket: '<1s',
         appVersion: '1.0.0',

--- a/test/analytics_report.test.ts
+++ b/test/analytics_report.test.ts
@@ -73,7 +73,7 @@ describe('analytics D1 report', () => {
       ],
       commandStatus: [
         {
-          command: 'up',
+          command: 'ballin update',
           total: 5,
           successes: 3,
           failures: 1,
@@ -98,7 +98,7 @@ describe('analytics D1 report', () => {
 
     assert.include(output, 'Analytics report (2026-06-01 to 2026-06-03)');
     assert.include(output, '2026-06-02  0');
-    assert.include(output, 'up       5      3        1        1        20.0%');
+    assert.include(output, 'ballin update  5      3        1        1        20.0%');
     assert.include(output, '2026-06-01  1.0.0        24          darwin  15          5');
   });
 
@@ -131,7 +131,7 @@ describe('analytics D1 report', () => {
       }
       if (sql.includes('command_events_daily')) {
         return [{
-          command: 'gu',
+          command: 'ballin backup',
           failures: 0,
           successes: 2,
           total: 2,
@@ -150,20 +150,20 @@ describe('analytics D1 report', () => {
 
     assert.lengthOf(sqlStatements, 3);
     assert.include(report, '2026-06-01  4');
-    assert.include(report, 'gu       2      2        0        0        0.0%');
+    assert.include(report, 'ballin backup  2      2        0        0        0.0%');
   });
 
   it('parses Wrangler D1 JSON result rows', () => {
     const rows = parseD1Json(JSON.stringify([
       {
         results: [
-          { command: 'up', total: 3 },
+          { command: 'ballin update', total: 3 },
         ],
         success: true,
       },
     ]));
 
-    assert.deepEqual(rows, [{ command: 'up', total: 3 }]);
+    assert.deepEqual(rows, [{ command: 'ballin update', total: 3 }]);
   });
 
   it('rejects unsuccessful Wrangler D1 JSON responses', () => {

--- a/test/backup.test.ts
+++ b/test/backup.test.ts
@@ -6,7 +6,7 @@ const path = require('path');
 
 const ballinPath = path.join(__dirname, '..', 'bin', 'ballin');
 const snapshotFileName = 'zshrc.sh';
-// Expose only the basic commands gu needs; package managers remain unavailable.
+// Expose only the basic commands backup needs; package managers remain unavailable.
 const requiredCommands = [
   'bash',
   'cat',
@@ -21,7 +21,7 @@ const requiredCommands = [
 ];
 type StringSpawnResult = import('child_process').SpawnSyncReturns<string>;
 
-type RunGuOptions = {
+type RunBackupOptions = {
   args?: string[];
   failedPaths?: string[];
   emitUnderlyingStderr?: boolean;
@@ -37,10 +37,11 @@ type RunGuOptions = {
   commandPath?: string;
 };
 
-describe('gu', () => {
+describe('ballin backup', () => {
   let testHomeDir: string;
   let testBinDir: string;
-  let guCacheDir: string;
+  let backupCacheDir: string;
+  let configPath: string;
   let fakeGistDir: string;
   let gistReadLogPath: string;
   let scratchDir: string;
@@ -56,7 +57,7 @@ describe('gu', () => {
       .map((directory) => path.join(directory, command))
       .find((candidate) => fs.existsSync(candidate));
 
-    assert.exists(commandPath, `${command} is required to run the gu test harness`);
+    assert.exists(commandPath, `${command} is required to run the backup test harness`);
     fs.symlinkSync(commandPath, path.join(testBinDir, command));
   };
 
@@ -64,20 +65,17 @@ describe('gu', () => {
     fs.writeFileSync(path.join(testBinDir, name), contents, { mode: 0o755 });
   };
 
-  const installFakeBallinConfigCommand = () => {
-    writeTestExecutable('ballin_config', `#!/usr/bin/env bash
-if [ "$1" != 'get' ]; then
-  printf '%s\\n' 'Unexpected ballin_config action' >&2
-  exit 2
-elif [ "$2" = 'backup.id' ]; then
-  printf '%s\\n' 'test-gist-id'
-elif [ "$2" = 'backup.host' ]; then
-  printf '%s\\n' 'example.test'
-else
-  printf '%s\\n' 'Unexpected ballin_config call' >&2
-  exit 2
-fi
-`);
+  const writeBackupConfig = (id: string | null = 'test-gist-id', host: string | null = 'example.test') => {
+    fs.writeFileSync(configPath, `${JSON.stringify({
+      update: {},
+      backup: {
+        id,
+        ...(host === null ? {} : { host }),
+      },
+      analytics: {
+        enabled: 'false',
+      },
+    })}\n`);
   };
 
   const installFakeGhCommand = () => {
@@ -170,36 +168,12 @@ printf '%s\\n' "$*" >> "$FAKE_OPEN_LOG"
 `);
   };
 
-  const installFailingBallinConfigCommand = () => {
-    writeTestExecutable('ballin_config', `#!/usr/bin/env bash
-printf 'ballin_config failed for %s\\n' "$2" >&2
-exit 42
-`);
+  const writeInvalidConfig = () => {
+    fs.writeFileSync(configPath, '{not json\n');
   };
 
-  const installDefaultIdBallinConfigCommand = () => {
-    writeTestExecutable('ballin_config', `#!/usr/bin/env bash
-if [ "$1" != 'get' ]; then
-  printf '%s\\n' 'Unexpected ballin_config action' >&2
-  exit 2
-elif [ "$2" = 'backup.id' ]; then
-  printf '%s\\n' 'null'
-elif [ "$2" = 'backup.host' ]; then
-  printf '%s\\n' 'example.test'
-else
-  printf '%s\\n' 'Unexpected ballin_config call' >&2
-  exit 2
-fi
-`);
-  };
-
-  const removeBallinConfigCommand = () => {
-    fs.rmSync(path.join(testBinDir, 'ballin_config'));
-  };
-
-  const makeBallinConfigCommandPermissionDenied = () => {
-    fs.writeFileSync(path.join(testBinDir, 'ballin_config'), 'not executable\n', { mode: 0o644 });
-    fs.chmodSync(path.join(testBinDir, 'ballin_config'), 0o644);
+  const removeConfig = () => {
+    fs.rmSync(configPath);
   };
 
   const removeGhCommand = () => {
@@ -256,9 +230,10 @@ done
   };
 
   beforeEach(() => {
-    testHomeDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ballin-gu-'));
+    testHomeDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ballin-backup-'));
     testBinDir = path.join(testHomeDir, 'bin');
-    guCacheDir = path.join(testHomeDir, '.ballin-scripts', '.gu-cache');
+    backupCacheDir = path.join(testHomeDir, '.ballin-scripts', '.backup-cache');
+    configPath = path.join(testHomeDir, 'ballin.config.json');
     fakeGistDir = path.join(testHomeDir, 'fake-gist');
     gistReadLogPath = path.join(testHomeDir, 'fake-gist-reads.log');
     scratchDir = path.join(testHomeDir, 'tmp');
@@ -276,7 +251,7 @@ done
     ].forEach((directory) => fs.mkdirSync(directory, { recursive: true }));
     requiredCommands.forEach(linkRequiredCommand);
     realCatPath = installControllableCatCommand();
-    installFakeBallinConfigCommand();
+    writeBackupConfig();
     installFakeGhCommand();
     installFakeOpenCommand();
   });
@@ -286,7 +261,7 @@ done
   });
 
   // Pass a complete child environment so real tools and credentials are not inherited.
-  const runGu = ({
+  const runBackup = ({
     args = [],
     failedPaths = [],
     emitUnderlyingStderr = false,
@@ -300,7 +275,7 @@ done
     ghEditMissingFile = false,
     ghUploadFail = false,
     commandPath = ballinPath,
-  }: RunGuOptions = {}) => spawnSync(commandPath, ['backup', ...args], {
+  }: RunBackupOptions = {}) => spawnSync(commandPath, ['backup', ...args], {
     encoding: 'utf8',
     maxBuffer: 10 * 1024 * 1024,
     env: {
@@ -308,8 +283,10 @@ done
       PATH: testBinDir,
       TMPDIR: scratchDir,
       ...(completionDir === undefined ? {} : {
-        BALLIN_GU_BASH_COMPLETION_DIR: completionDir,
+        BALLIN_BACKUP_BASH_COMPLETION_DIR: completionDir,
       }),
+      BALLIN_TEST_CONFIG_PATH: configPath,
+      BALLIN_NO_ANALYTICS: '1',
       FAKE_GIST_STORAGE_DIR: fakeGistDir,
       FAKE_GIST_READ_LOG: gistReadLogPath,
       FAKE_GIST_UPLOAD_LOG: gistUploadLogPath,
@@ -332,18 +309,18 @@ done
   });
 
   const snapshotPath = () => path.join(testHomeDir, '.zshrc');
-  const cachedSnapshotPath = () => path.join(guCacheDir, snapshotFileName);
+  const cachedSnapshotPath = () => path.join(backupCacheDir, snapshotFileName);
   const fakeGistFilePath = () => path.join(fakeGistDir, snapshotFileName);
   const writeSnapshot = (content: string) => fs.writeFileSync(snapshotPath(), content);
-  const seedGuCache = (content: string) => {
-    fs.mkdirSync(guCacheDir, { recursive: true });
+  const seedBackupCache = (content: string) => {
+    fs.mkdirSync(backupCacheDir, { recursive: true });
     fs.writeFileSync(cachedSnapshotPath(), content);
   };
   const seedFakeGist = (content: string) => fs.writeFileSync(fakeGistFilePath(), content);
   const seedFakeGistFile = (fileName: string, content: string) => {
     fs.writeFileSync(path.join(fakeGistDir, fileName), content);
   };
-  const assertGuSucceeded = (result: StringSpawnResult) => {
+  const assertBackupSucceeded = (result: StringSpawnResult) => {
     assert.equal(result.status, 0);
     assert.equal(result.stderr, '');
     assert.deepEqual(fs.readdirSync(scratchDir), []);
@@ -370,58 +347,53 @@ done
   };
 
   it('opens the configured Gist through gh', () => {
-    const result = runGu({ args: ['open'] });
+    const result = runBackup({ args: ['open'] });
 
-    assertGuSucceeded(result);
+    assertBackupSucceeded(result);
     assert.equal(result.stdout, '');
     assert.deepEqual(openCalls(), ['gist view test-gist-id --web']);
   });
 
   it('opens the configured Gist without requiring a readable Gist', () => {
-    const result = runGu({ args: ['open'], ghInitialReadFail: true });
+    const result = runBackup({ args: ['open'], ghInitialReadFail: true });
 
-    assertGuSucceeded(result);
+    assertBackupSucceeded(result);
     assert.equal(result.stdout, '');
     assert.deepEqual(openCalls(), ['gist view test-gist-id --web']);
     assert.deepEqual(gistReads(), []);
   });
 
   it('fails open when extra arguments are provided', () => {
-    const result = runGu({ args: ['open', 'extra'] });
+    const result = runBackup({ args: ['open', 'extra'] });
 
     assert.equal(result.status, 1);
     assert.equal(result.stdout, '');
-    assert.equal(result.stderr, 'gu open: expected no arguments\n');
+    assert.equal(result.stderr, 'ballin backup open: expected no arguments\n');
     assert.deepEqual(openCalls(), []);
     assert.deepEqual(gistReads(), []);
   });
 
   it('fails open when Gist config cannot be read', () => {
-    installFailingBallinConfigCommand();
+    writeInvalidConfig();
 
-    const result = runGu({ args: ['open'] });
+    const result = runBackup({ args: ['open'] });
 
     assert.equal(result.status, 1);
     assert.equal(result.stdout, '');
-    assert.equal(
-      result.stderr,
-      'ballin_config failed for backup.id\n'
-        + 'ballin_config failed for backup.host\n'
-        + 'gu: missing config value backup.id\n'
-        + 'gu: missing config value backup.host\n',
-    );
+    assert.include(result.stderr, 'ballin backup: missing config value backup.id\n');
+    assert.include(result.stderr, 'ballin backup: missing config value backup.host\n');
     assert.deepEqual(openCalls(), []);
     assert.deepEqual(gistReads(), []);
   });
 
   it('treats a default null Gist ID as missing when opening', () => {
-    installDefaultIdBallinConfigCommand();
+    writeBackupConfig(null);
 
-    const result = runGu({ args: ['open'] });
+    const result = runBackup({ args: ['open'] });
 
     assert.equal(result.status, 1);
     assert.equal(result.stdout, '');
-    assert.equal(result.stderr, 'gu: missing config value backup.id\n');
+    assert.equal(result.stderr, 'ballin backup: missing config value backup.id\n');
     assert.deepEqual(openCalls(), []);
     assert.deepEqual(gistReads(), []);
   });
@@ -431,9 +403,9 @@ done
     fs.symlinkSync(ballinPath, linkPath);
     seedFakeGistFile('vimrc', 'set number\n');
 
-    const result = runGu({ args: ['read', 'vimrc'], commandPath: linkPath });
+    const result = runBackup({ args: ['read', 'vimrc'], commandPath: linkPath });
 
-    assertGuSucceeded(result);
+    assertBackupSucceeded(result);
     assert.equal(result.stdout, 'set number\n');
   });
 
@@ -444,7 +416,7 @@ if [ "$*" = 'gist view test-gist-id --web' ]; then kill -TERM "$$"; fi
 exit 2
 `);
 
-    const result = runGu({ args: ['open'] });
+    const result = runBackup({ args: ['open'] });
 
     assert.equal(result.status, 143);
     assert.equal(result.stdout, '');
@@ -454,7 +426,7 @@ exit 2
   it('reports missing gh before opening', () => {
     removeGhCommand();
 
-    const result = runGu({ args: ['open'] });
+    const result = runBackup({ args: ['open'] });
 
     assert.equal(result.status, 127);
     assert.equal(result.stdout, '');
@@ -464,7 +436,7 @@ exit 2
   it('reports permission-denied gh before opening', () => {
     makeGhCommandPermissionDenied();
 
-    const result = runGu({ args: ['open'] });
+    const result = runBackup({ args: ['open'] });
 
     assert.equal(result.status, 126);
     assert.equal(result.stdout, '');
@@ -472,48 +444,48 @@ exit 2
   });
 
   it('prints help through the ballin command', () => {
-    const result = runGu({ args: ['help'] });
+    const result = runBackup({ args: ['help'] });
 
-    assertGuSucceeded(result);
+    assertBackupSucceeded(result);
     assert.include(result.stdout, 'Ballin');
     assert.include(result.stdout, 'ballin backup');
   });
 
   it('prints help without requiring a readable Gist', () => {
-    const result = runGu({ args: ['help'], ghInitialReadFail: true });
+    const result = runBackup({ args: ['help'], ghInitialReadFail: true });
 
-    assertGuSucceeded(result);
+    assertBackupSucceeded(result);
     assert.include(result.stdout, 'Ballin');
     assert.include(result.stdout, 'ballin backup');
     assert.deepEqual(gistReads(), []);
   });
 
   it('fails help when extra arguments are provided', () => {
-    const result = runGu({ args: ['help', 'extra'] });
+    const result = runBackup({ args: ['help', 'extra'] });
 
     assert.equal(result.status, 1);
     assert.equal(result.stdout, '');
-    assert.equal(result.stderr, 'gu help: expected no arguments\n');
+    assert.equal(result.stderr, 'ballin backup help: expected no arguments\n');
     assert.deepEqual(ballinCalls(), []);
     assert.deepEqual(gistReads(), []);
   });
 
   it('fails unknown commands instead of ignoring them', () => {
-    const result = runGu({ args: ['typo'] });
+    const result = runBackup({ args: ['typo'] });
 
     assert.equal(result.status, 1);
     assert.equal(result.stdout, '');
-    assert.equal(result.stderr, "gu: unknown command 'typo'\n");
+    assert.equal(result.stderr, "ballin backup: unknown command 'typo'\n");
     assert.deepEqual(gistReads(), []);
     assert.deepEqual(gistUploads(), []);
   });
 
   it('fails unknown commands before checking Gist readability', () => {
-    const result = runGu({ args: ['typo'], ghInitialReadFail: true });
+    const result = runBackup({ args: ['typo'], ghInitialReadFail: true });
 
     assert.equal(result.status, 1);
     assert.equal(result.stdout, '');
-    assert.equal(result.stderr, "gu: unknown command 'typo'\n");
+    assert.equal(result.stderr, "ballin backup: unknown command 'typo'\n");
     assert.deepEqual(gistReads(), []);
     assert.deepEqual(gistUploads(), []);
   });
@@ -521,19 +493,19 @@ exit 2
   it('reads a named Gist file', () => {
     seedFakeGistFile('vimrc', 'set number\n');
 
-    const result = runGu({ args: ['read', 'vimrc'] });
+    const result = runBackup({ args: ['read', 'vimrc'] });
 
-    assertGuSucceeded(result);
+    assertBackupSucceeded(result);
     assert.equal(result.stdout, 'set number\n');
     assert.deepEqual(gistReads(), ['vimrc']);
   });
 
   it('fails read when extra arguments are provided', () => {
-    const result = runGu({ args: ['read', 'vimrc', 'extra'] });
+    const result = runBackup({ args: ['read', 'vimrc', 'extra'] });
 
     assert.equal(result.status, 1);
     assert.equal(result.stdout, '');
-    assert.equal(result.stderr, 'gu read: expected exactly one filename\n');
+    assert.equal(result.stderr, 'ballin backup read: expected exactly one filename\n');
     assert.deepEqual(gistReads(), []);
   });
 
@@ -541,9 +513,9 @@ exit 2
     const largeSnapshot = `${'r'.repeat(1024 * 1024 + 1)}\n`;
     seedFakeGistFile('vimrc', largeSnapshot);
 
-    const result = runGu({ args: ['read', 'vimrc'] });
+    const result = runBackup({ args: ['read', 'vimrc'] });
 
-    assertGuSucceeded(result);
+    assertBackupSucceeded(result);
     assert.equal(result.stdout.length, largeSnapshot.length);
     assert.equal(result.stdout.slice(0, 1), 'r');
     assert.equal(result.stdout.slice(-1), '\n');
@@ -551,7 +523,7 @@ exit 2
   });
 
   it('prints options when a requested Gist file is missing', () => {
-    const result = runGu({ args: ['read', 'missing_file'] });
+    const result = runBackup({ args: ['read', 'missing_file'] });
 
     assert.equal(result.status, 1);
     assert.include(result.stdout, '\nOptions: ');
@@ -561,7 +533,7 @@ exit 2
   });
 
   it('prints options when read is missing a filename', () => {
-    const result = runGu({ args: ['read'] });
+    const result = runBackup({ args: ['read'] });
 
     assert.equal(result.status, 1);
     assert.include(result.stdout, "Error: 'read' needs a filename.");
@@ -570,7 +542,7 @@ exit 2
   });
 
   it('reports a missing read filename before checking Gist readability', () => {
-    const result = runGu({ args: ['read'], ghInitialReadFail: true });
+    const result = runBackup({ args: ['read'], ghInitialReadFail: true });
 
     assert.equal(result.status, 1);
     assert.include(result.stdout, "Error: 'read' needs a filename.");
@@ -580,39 +552,39 @@ exit 2
   });
 
   it('uses the initial Gist retrieval failure status before snapshotting', () => {
-    const result = runGu({ ghInitialReadFail: true });
+    const result = runBackup({ ghInitialReadFail: true });
 
     assert.equal(result.status, 17);
-    assert.equal(result.stdout, "Error retrieving your gist, please run 'ballin_update'.\n");
+    assert.equal(result.stdout, "Error retrieving your gist, please run 'ballin self-update'.\n");
     assert.equal(result.stderr, 'simulated initial gh gist read failure\n');
-    assert.isFalse(fs.existsSync(guCacheDir));
+    assert.isFalse(fs.existsSync(backupCacheDir));
     assert.deepEqual(gistReads(), []);
     assert.deepEqual(gistUploads(), []);
   });
 
   it('uses a shell-style signal exit status for initial Gist retrieval', () => {
-    const result = runGu({ ghInitialReadSignal: true });
+    const result = runBackup({ ghInitialReadSignal: true });
 
     assert.equal(result.status, 143);
-    assert.equal(result.stdout, "Error retrieving your gist, please run 'ballin_update'.\n");
+    assert.equal(result.stdout, "Error retrieving your gist, please run 'ballin self-update'.\n");
     assert.equal(result.stderr, '');
-    assert.isFalse(fs.existsSync(guCacheDir));
+    assert.isFalse(fs.existsSync(backupCacheDir));
     assert.deepEqual(gistReads(), []);
     assert.deepEqual(gistUploads(), []);
   });
 
   it('reports gh authentication failures before snapshotting', () => {
-    const result = runGu({ ghAuthFail: true });
+    const result = runBackup({ ghAuthFail: true });
 
     assert.equal(result.status, 4);
     assert.equal(result.stdout, '');
     assert.equal(
       result.stderr,
       'simulated gh auth failure\n'
-        + 'gu: GitHub CLI authentication is required for example.test\n'
-        + "gu: run 'gh auth login --hostname example.test'\n",
+        + 'ballin backup: GitHub CLI authentication is required for example.test\n'
+        + "ballin backup: run 'gh auth login --hostname example.test'\n",
     );
-    assert.isFalse(fs.existsSync(guCacheDir));
+    assert.isFalse(fs.existsSync(backupCacheDir));
     assert.deepEqual(gistReads(), []);
     assert.deepEqual(gistUploads(), []);
   });
@@ -620,12 +592,12 @@ exit 2
   it('reports missing gh before snapshotting', () => {
     removeGhCommand();
 
-    const result = runGu();
+    const result = runBackup();
 
     assert.equal(result.status, 127);
     assert.equal(result.stdout, '');
     assert.equal(result.stderr, 'gh: command not found\n');
-    assert.isFalse(fs.existsSync(guCacheDir));
+    assert.isFalse(fs.existsSync(backupCacheDir));
     assert.deepEqual(gistReads(), []);
     assert.deepEqual(gistUploads(), []);
   });
@@ -633,69 +605,54 @@ exit 2
   it('reports permission-denied gh before snapshotting', () => {
     makeGhCommandPermissionDenied();
 
-    const result = runGu();
+    const result = runBackup();
 
     assert.equal(result.status, 126);
     assert.equal(result.stdout, '');
     assert.equal(result.stderr, 'gh: Permission denied\n');
-    assert.isFalse(fs.existsSync(guCacheDir));
+    assert.isFalse(fs.existsSync(backupCacheDir));
     assert.deepEqual(gistReads(), []);
     assert.deepEqual(gistUploads(), []);
   });
 
-  it('preserves config stderr when config reads fail', () => {
-    installFailingBallinConfigCommand();
+  it('stops before snapshotting when config reads fail', () => {
+    writeInvalidConfig();
 
-    const result = runGu();
+    const result = runBackup();
 
     assert.equal(result.status, 1);
     assert.equal(result.stdout, '');
-    assert.equal(
-      result.stderr,
-      'ballin_config failed for backup.id\n'
-        + 'ballin_config failed for backup.host\n'
-        + 'gu: missing config value backup.id\n'
-        + 'gu: missing config value backup.host\n',
-    );
-    assert.isFalse(fs.existsSync(guCacheDir));
+    assert.include(result.stderr, 'ballin backup: missing config value backup.id\n');
+    assert.include(result.stderr, 'ballin backup: missing config value backup.host\n');
+    assert.isFalse(fs.existsSync(backupCacheDir));
     assert.deepEqual(gistReads(), []);
     assert.deepEqual(gistUploads(), []);
   });
 
-  it('reports missing ballin_config reads before snapshotting', () => {
-    removeBallinConfigCommand();
+  it('reports missing config reads before snapshotting', () => {
+    removeConfig();
 
-    const result = runGu();
+    const result = runBackup();
 
-    assert.equal(result.status, 127);
+    assert.equal(result.status, 1);
     assert.equal(result.stdout, '');
-    assert.equal(
-      result.stderr,
-      'ballin_config: command not found\n'
-        + 'ballin_config: command not found\n'
-        + 'gu: missing config value backup.id\n'
-        + 'gu: missing config value backup.host\n',
-    );
-    assert.isFalse(fs.existsSync(guCacheDir));
+    assert.include(result.stderr, 'Unable to read');
+    assert.include(result.stderr, 'ballin backup: missing config value backup.id\n');
+    assert.include(result.stderr, 'ballin backup: missing config value backup.host\n');
+    assert.isFalse(fs.existsSync(backupCacheDir));
     assert.deepEqual(gistReads(), []);
     assert.deepEqual(gistUploads(), []);
   });
 
-  it('reports permission-denied ballin_config reads before snapshotting', () => {
-    makeBallinConfigCommandPermissionDenied();
+  it('reports missing backup host before snapshotting', () => {
+    writeBackupConfig('test-gist-id', null);
 
-    const result = runGu();
+    const result = runBackup();
 
-    assert.equal(result.status, 126);
+    assert.equal(result.status, 1);
     assert.equal(result.stdout, '');
-    assert.equal(
-      result.stderr,
-      'ballin_config: Permission denied\n'
-        + 'ballin_config: Permission denied\n'
-        + 'gu: missing config value backup.id\n'
-        + 'gu: missing config value backup.host\n',
-    );
-    assert.isFalse(fs.existsSync(guCacheDir));
+    assert.equal(result.stderr, 'ballin backup: missing config value backup.host\n');
+    assert.isFalse(fs.existsSync(backupCacheDir));
     assert.deepEqual(gistReads(), []);
     assert.deepEqual(gistUploads(), []);
   });
@@ -717,9 +674,9 @@ if [ "$*" != '--list-extensions' ]; then exit 2; fi
 printf '%s\\n' 'publisher.insiders-extension'
 `);
 
-    const result = runGu();
+    const result = runBackup();
 
-    assertGuSucceeded(result);
+    assertBackupSucceeded(result);
     assert.deepEqual(result.stdout.trim().split('\n'), [
       '💾 vs_settings',
       '💾 vs_keybindings',
@@ -728,22 +685,22 @@ printf '%s\\n' 'publisher.insiders-extension'
       '💾 vsI_keybindings',
       '💾 vsI_extensions',
     ]);
-    assert.equal(fs.readFileSync(path.join(guCacheDir, 'vs_settings'), 'utf8'), '{"fontSize":14}\n');
+    assert.equal(fs.readFileSync(path.join(backupCacheDir, 'vs_settings'), 'utf8'), '{"fontSize":14}\n');
     assert.equal(
-      fs.readFileSync(path.join(guCacheDir, 'vs_keybindings'), 'utf8'),
+      fs.readFileSync(path.join(backupCacheDir, 'vs_keybindings'), 'utf8'),
       '[{"key":"cmd+k"}]\n',
     );
     assert.equal(
-      fs.readFileSync(path.join(guCacheDir, 'vs_extensions'), 'utf8'),
+      fs.readFileSync(path.join(backupCacheDir, 'vs_extensions'), 'utf8'),
       'publisher.stable-extension\n',
     );
-    assert.equal(fs.readFileSync(path.join(guCacheDir, 'vsI_settings'), 'utf8'), '{"fontSize":15}\n');
+    assert.equal(fs.readFileSync(path.join(backupCacheDir, 'vsI_settings'), 'utf8'), '{"fontSize":15}\n');
     assert.equal(
-      fs.readFileSync(path.join(guCacheDir, 'vsI_keybindings'), 'utf8'),
+      fs.readFileSync(path.join(backupCacheDir, 'vsI_keybindings'), 'utf8'),
       '[{"key":"cmd+i"}]\n',
     );
     assert.equal(
-      fs.readFileSync(path.join(guCacheDir, 'vsI_extensions'), 'utf8'),
+      fs.readFileSync(path.join(backupCacheDir, 'vsI_extensions'), 'utf8'),
       'publisher.insiders-extension\n',
     );
     assert.deepEqual(gistUploads(), [
@@ -765,9 +722,9 @@ printf '%s\\n' 'publisher.insiders-extension'
     fs.writeFileSync(path.join(bracketsDir, 'extensions', 'user', 'beautify'), '');
     fs.writeFileSync(path.join(bracketsDir, 'extensions', 'disabled', 'legacy-lint'), '');
 
-    const result = runGu();
+    const result = runBackup();
 
-    assertGuSucceeded(result);
+    assertBackupSucceeded(result);
     assert.deepEqual(result.stdout.trim().split('\n'), [
       '💾 brackets_settings',
       '💾 brackets_keymap',
@@ -775,16 +732,16 @@ printf '%s\\n' 'publisher.insiders-extension'
       '💾 brackets_disabled_extensions',
     ]);
     assert.equal(
-      fs.readFileSync(path.join(guCacheDir, 'brackets_settings.json'), 'utf8'),
+      fs.readFileSync(path.join(backupCacheDir, 'brackets_settings.json'), 'utf8'),
       '{"linting.enabled":true}\n',
     );
     assert.equal(
-      fs.readFileSync(path.join(guCacheDir, 'brackets_keymap.json'), 'utf8'),
+      fs.readFileSync(path.join(backupCacheDir, 'brackets_keymap.json'), 'utf8'),
       '{"Ctrl-E":"edit"}\n',
     );
-    assert.equal(fs.readFileSync(path.join(guCacheDir, 'brackets_extensions'), 'utf8'), 'beautify\n');
+    assert.equal(fs.readFileSync(path.join(backupCacheDir, 'brackets_extensions'), 'utf8'), 'beautify\n');
     assert.equal(
-      fs.readFileSync(path.join(guCacheDir, 'brackets_disabled_extensions'), 'utf8'),
+      fs.readFileSync(path.join(backupCacheDir, 'brackets_disabled_extensions'), 'utf8'),
       'legacy-lint\n',
     );
     assert.deepEqual(gistUploads(), [
@@ -805,18 +762,18 @@ if [ "$*" != 'list' ]; then exit 2; fi
 printf '%s\\n' '123456 Example App'
 `);
 
-    const result = runGu();
+    const result = runBackup();
 
-    assertGuSucceeded(result);
+    assertBackupSucceeded(result);
     assert.deepEqual(result.stdout.trim().split('\n'), [
       '💾 npm_global',
       '💾 mas',
     ]);
     assert.equal(
-      fs.readFileSync(path.join(guCacheDir, 'npm_global'), 'utf8'),
+      fs.readFileSync(path.join(backupCacheDir, 'npm_global'), 'utf8'),
       '/fake/npm\n+-- eslint@1.0.0\n',
     );
-    assert.equal(fs.readFileSync(path.join(guCacheDir, 'mas'), 'utf8'), '123456 Example App\n');
+    assert.equal(fs.readFileSync(path.join(backupCacheDir, 'mas'), 'utf8'), '123456 Example App\n');
     assert.deepEqual(gistUploads(), ['npm_global', 'mas']);
   });
 
@@ -830,12 +787,12 @@ printf '%s\\n' '123456 Example App'
       installFakeBrewCommand();
       writeBashCompletions(brewPrefix, ['git', 'npm']);
 
-      const result = runGu({ brewPrefix });
+      const result = runBackup({ brewPrefix });
 
-      assertGuSucceeded(result);
+      assertBackupSucceeded(result);
       assert.include(result.stdout, '💾 bash_completions\n');
       assert.equal(
-        fs.readFileSync(path.join(guCacheDir, 'bash_completions'), 'utf8'),
+        fs.readFileSync(path.join(backupCacheDir, 'bash_completions'), 'utf8'),
         'git\nnpm\n',
       );
       assert.equal(brewCalls().filter((call: string) => call.endsWith('|--prefix')).length, 1);
@@ -846,11 +803,11 @@ printf '%s\\n' '123456 Example App'
   it('skips bash completions when the active Homebrew completion directory is missing', () => {
     installFakeBrewCommand();
 
-    const result = runGu();
+    const result = runBackup();
 
-    assertGuSucceeded(result);
+    assertBackupSucceeded(result);
     assert.notInclude(result.stdout, 'bash_completions');
-    assert.isFalse(fs.existsSync(path.join(guCacheDir, 'bash_completions')));
+    assert.isFalse(fs.existsSync(path.join(backupCacheDir, 'bash_completions')));
   });
 
   it('snapshots only the active prefix when multiple Homebrew prefixes coexist', () => {
@@ -860,11 +817,11 @@ printf '%s\\n' '123456 Example App'
     writeBashCompletions(activePrefix, ['active-tool']);
     writeBashCompletions(inactivePrefix, ['inactive-tool']);
 
-    const result = runGu({ brewPrefix: activePrefix });
+    const result = runBackup({ brewPrefix: activePrefix });
 
-    assertGuSucceeded(result);
+    assertBackupSucceeded(result);
     assert.equal(
-      fs.readFileSync(path.join(guCacheDir, 'bash_completions'), 'utf8'),
+      fs.readFileSync(path.join(backupCacheDir, 'bash_completions'), 'utf8'),
       'active-tool\n',
     );
     assert.equal(gistUploads().filter((name: string) => name === 'bash_completions').length, 1);
@@ -875,12 +832,12 @@ printf '%s\\n' '123456 Example App'
     const completionDir = path.join(appleSiliconPrefix, 'etc', 'bash_completion.d');
     writeBashCompletions(appleSiliconPrefix, ['apple-silicon-tool']);
 
-    const result = runGu({ completionDir });
+    const result = runBackup({ completionDir });
 
-    assertGuSucceeded(result);
+    assertBackupSucceeded(result);
     assert.equal(result.stdout, '💾 bash_completions\n');
     assert.equal(
-      fs.readFileSync(path.join(guCacheDir, 'bash_completions'), 'utf8'),
+      fs.readFileSync(path.join(backupCacheDir, 'bash_completions'), 'utf8'),
       'apple-silicon-tool\n',
     );
     assert.deepEqual(brewCalls(), []);
@@ -890,11 +847,11 @@ printf '%s\\n' '123456 Example App'
     writeBashCompletions(path.join(testHomeDir, 'opt', 'homebrew'), ['apple-silicon-tool']);
     writeBashCompletions(path.join(testHomeDir, 'usr', 'local'), ['intel-tool']);
 
-    const result = runGu();
+    const result = runBackup();
 
-    assertGuSucceeded(result);
+    assertBackupSucceeded(result);
     assert.notInclude(result.stdout, 'bash_completions');
-    assert.isFalse(fs.existsSync(path.join(guCacheDir, 'bash_completions')));
+    assert.isFalse(fs.existsSync(path.join(backupCacheDir, 'bash_completions')));
     assert.deepEqual(brewCalls(), []);
   });
 
@@ -902,13 +859,13 @@ printf '%s\\n' '123456 Example App'
     installNonExecutableBrewCommand();
     writeBashCompletions(path.join(testHomeDir, 'opt', 'homebrew'), ['apple-silicon-tool']);
 
-    const result = runGu();
+    const result = runBackup();
 
-    assertGuSucceeded(result);
+    assertBackupSucceeded(result);
     assert.equal(result.stdout, '');
     assert.deepEqual(brewCalls(), []);
-    assert.isFalse(fs.existsSync(path.join(guCacheDir, 'bash_completions')));
-    assert.isFalse(fs.existsSync(path.join(guCacheDir, 'brew_list')));
+    assert.isFalse(fs.existsSync(path.join(backupCacheDir, 'bash_completions')));
+    assert.isFalse(fs.existsSync(path.join(backupCacheDir, 'brew_list')));
   });
 
   it('skips bash completions instead of guessing a prefix when brew prefix discovery fails', () => {
@@ -916,20 +873,20 @@ printf '%s\\n' '123456 Example App'
     writeBashCompletions(path.join(testHomeDir, 'opt', 'homebrew'), ['apple-silicon-tool']);
     writeBashCompletions(path.join(testHomeDir, 'usr', 'local'), ['intel-tool']);
 
-    const result = runGu({ brewPrefixFail: true });
+    const result = runBackup({ brewPrefixFail: true });
 
-    assertGuSucceeded(result);
+    assertBackupSucceeded(result);
     assert.notInclude(result.stdout, 'bash_completions');
-    assert.isFalse(fs.existsSync(path.join(guCacheDir, 'bash_completions')));
+    assert.isFalse(fs.existsSync(path.join(backupCacheDir, 'bash_completions')));
     assert.equal(brewCalls().filter((call: string) => call.endsWith('|--prefix')).length, 1);
   });
 
   it('captures Homebrew inventory with flags while suppressing successful services stderr', () => {
     installFakeBrewCommand();
 
-    const result = runGu();
+    const result = runBackup();
 
-    assertGuSucceeded(result);
+    assertBackupSucceeded(result);
     assert.deepEqual(result.stdout.trim().split('\n'), [
       '💾 brew_list',
       '💾 brew_leaves',
@@ -946,7 +903,7 @@ printf '%s\\n' '123456 Example App'
       '1|1|bundle dump --file=-',
     ]);
     assert.equal(
-      fs.readFileSync(path.join(guCacheDir, 'brew_services'), 'utf8'),
+      fs.readFileSync(path.join(backupCacheDir, 'brew_services'), 'utf8'),
       'service-one started\n',
     );
     assert.deepEqual(gistUploads(), [
@@ -961,12 +918,12 @@ printf '%s\\n' '123456 Example App'
   it('surfaces failed brew services stderr and preserves other inventory snapshots', () => {
     installFakeBrewCommand();
 
-    const result = runGu({ brewServicesFail: true });
+    const result = runBackup({ brewServicesFail: true });
 
     assert.equal(result.status, 1);
     assert.include(result.stderr, 'simulated services warning\n');
-    assert.include(result.stderr, 'gu: failed to snapshot brew_services\n');
-    assert.isFalse(fs.existsSync(path.join(guCacheDir, 'brew_services')));
+    assert.include(result.stderr, 'ballin backup: failed to snapshot brew_services\n');
+    assert.isFalse(fs.existsSync(path.join(backupCacheDir, 'brew_services')));
     assert.deepEqual(gistUploads(), [
       'brew_list',
       'brew_leaves',
@@ -979,9 +936,9 @@ printf '%s\\n' '123456 Example App'
   it('creates and uploads the first snapshot when cache and Gist are missing', () => {
     writeSnapshot('alias hello="world"\n');
 
-    const result = runGu();
+    const result = runBackup();
 
-    assertGuSucceeded(result);
+    assertBackupSucceeded(result);
     assert.equal(result.stdout, '💾 zshrc\n');
     assert.equal(fs.readFileSync(cachedSnapshotPath(), 'utf8'), 'alias hello="world"\n');
     assert.equal(fs.readFileSync(fakeGistFilePath(), 'utf8'), 'alias hello="world"\n');
@@ -992,9 +949,9 @@ printf '%s\\n' '123456 Example App'
   it('uses the current new-file icon for a first empty snapshot', () => {
     writeSnapshot('');
 
-    const result = runGu();
+    const result = runBackup();
 
-    assertGuSucceeded(result);
+    assertBackupSucceeded(result);
     assert.equal(result.stdout, '💾 zshrc\n');
     assert.equal(fs.readFileSync(cachedSnapshotPath(), 'utf8'), 'empty\n');
     assert.equal(fs.readFileSync(fakeGistFilePath(), 'utf8'), 'empty\n');
@@ -1006,9 +963,9 @@ printf '%s\\n' '123456 Example App'
     writeSnapshot('export EDITOR=vim\n');
     seedFakeGist('export EDITOR=vim\n');
 
-    const result = runGu();
+    const result = runBackup();
 
-    assertGuSucceeded(result);
+    assertBackupSucceeded(result);
     assert.equal(result.stdout, '✔ zshrc\n');
     assert.equal(fs.readFileSync(cachedSnapshotPath(), 'utf8'), 'export EDITOR=vim\n');
     assert.deepEqual(gistReads(), [snapshotFileName]);
@@ -1020,9 +977,9 @@ printf '%s\\n' '123456 Example App'
     writeSnapshot(largeSnapshot);
     seedFakeGist(largeSnapshot);
 
-    const result = runGu();
+    const result = runBackup();
 
-    assertGuSucceeded(result);
+    assertBackupSucceeded(result);
     assert.equal(result.stdout, '✔ zshrc\n');
     assert.equal(fs.statSync(cachedSnapshotPath()).size, largeSnapshot.length);
     assert.deepEqual(gistReads(), [snapshotFileName]);
@@ -1033,9 +990,9 @@ printf '%s\\n' '123456 Example App'
     writeSnapshot('new value\n');
     seedFakeGist('old value\n');
 
-    const result = runGu();
+    const result = runBackup();
 
-    assertGuSucceeded(result);
+    assertBackupSucceeded(result);
     assert.equal(result.stdout, '✚ zshrc\n');
     assert.equal(fs.readFileSync(cachedSnapshotPath(), 'utf8'), 'new value\n');
     assert.equal(fs.readFileSync(fakeGistFilePath(), 'utf8'), 'new value\n');
@@ -1045,22 +1002,22 @@ printf '%s\\n' '123456 Example App'
 
   it('reports unchanged non-empty output without uploading it', () => {
     writeSnapshot('set -o vi\n');
-    seedGuCache('set -o vi\n');
+    seedBackupCache('set -o vi\n');
 
-    const result = runGu();
+    const result = runBackup();
 
-    assertGuSucceeded(result);
+    assertBackupSucceeded(result);
     assert.equal(result.stdout, '✔ zshrc\n');
     assert.deepEqual(gistUploads(), []);
   });
 
   it('reports and uploads changed non-empty output', () => {
     writeSnapshot('export COLOR=blue\n');
-    seedGuCache('export COLOR=red\n');
+    seedBackupCache('export COLOR=red\n');
 
-    const result = runGu();
+    const result = runBackup();
 
-    assertGuSucceeded(result);
+    assertBackupSucceeded(result);
     assert.equal(result.stdout, '✚ zshrc\n');
     assert.equal(fs.readFileSync(cachedSnapshotPath(), 'utf8'), 'export COLOR=blue\n');
     assert.deepEqual(gistUploads(), [snapshotFileName]);
@@ -1068,11 +1025,11 @@ printf '%s\\n' '123456 Example App'
 
   it('recreates a missing remote file when the local cache is warm', () => {
     writeSnapshot('export COLOR=blue\n');
-    seedGuCache('export COLOR=red\n');
+    seedBackupCache('export COLOR=red\n');
 
-    const result = runGu({ ghEditMissingFile: true });
+    const result = runBackup({ ghEditMissingFile: true });
 
-    assertGuSucceeded(result);
+    assertBackupSucceeded(result);
     assert.equal(result.stdout, '✚ zshrc\n');
     assert.equal(fs.readFileSync(cachedSnapshotPath(), 'utf8'), 'export COLOR=blue\n');
     assert.equal(fs.readFileSync(fakeGistFilePath(), 'utf8'), 'export COLOR=blue\n');
@@ -1081,13 +1038,13 @@ printf '%s\\n' '123456 Example App'
 
   it('reports a failure when a Gist upload fails', () => {
     writeSnapshot('export COLOR=blue\n');
-    seedGuCache('export COLOR=red\n');
+    seedBackupCache('export COLOR=red\n');
     seedFakeGist('export COLOR=red\n');
 
-    const result = runGu({ ghUploadFail: true });
+    const result = runBackup({ ghUploadFail: true });
 
     assert.equal(result.status, 1);
-    assert.equal(result.stderr, 'simulated gh gist upload failure\ngu: failed to snapshot zshrc.sh\n');
+    assert.equal(result.stderr, 'simulated gh gist upload failure\nballin backup: failed to snapshot zshrc.sh\n');
     assert.deepEqual(fs.readdirSync(scratchDir), []);
     assert.equal(result.stdout, '');
     assert.equal(fs.readFileSync(cachedSnapshotPath(), 'utf8'), 'export COLOR=red\n');
@@ -1097,14 +1054,14 @@ printf '%s\\n' '123456 Example App'
 
   it('retries a changed snapshot after a failed Gist upload', () => {
     writeSnapshot('export COLOR=blue\n');
-    seedGuCache('export COLOR=red\n');
+    seedBackupCache('export COLOR=red\n');
     seedFakeGist('export COLOR=red\n');
 
-    const failedResult = runGu({ ghUploadFail: true });
-    const retriedResult = runGu();
+    const failedResult = runBackup({ ghUploadFail: true });
+    const retriedResult = runBackup();
 
     assert.equal(failedResult.status, 1);
-    assertGuSucceeded(retriedResult);
+    assertBackupSucceeded(retriedResult);
     assert.equal(retriedResult.stdout, '✚ zshrc\n');
     assert.equal(fs.readFileSync(cachedSnapshotPath(), 'utf8'), 'export COLOR=blue\n');
     assert.equal(fs.readFileSync(fakeGistFilePath(), 'utf8'), 'export COLOR=blue\n');
@@ -1115,9 +1072,9 @@ printf '%s\\n' '123456 Example App'
     const largeSnapshot = `${'x'.repeat(1024 * 1024 + 1)}\n`;
     writeSnapshot(largeSnapshot);
 
-    const result = runGu();
+    const result = runBackup();
 
-    assertGuSucceeded(result);
+    assertBackupSucceeded(result);
     assert.equal(result.stdout, '💾 zshrc\n');
     assert.equal(fs.statSync(cachedSnapshotPath()).size, largeSnapshot.length);
     assert.equal(fs.statSync(fakeGistFilePath()).size, largeSnapshot.length);
@@ -1131,7 +1088,7 @@ printf 'publisher.large-stderr\\n'
 printf '%*s\\n' 1048577 '' >&2
 `);
 
-    const result = runGu();
+    const result = runBackup();
 
     assert.equal(result.status, 0);
     assert.include(result.stdout, '💾 vs_extensions\n');
@@ -1139,7 +1096,7 @@ printf '%*s\\n' 1048577 '' >&2
     assert.equal(result.stderr.slice(0, 1), ' ');
     assert.equal(result.stderr.slice(-1), '\n');
     assert.equal(
-      fs.readFileSync(path.join(guCacheDir, 'vs_extensions'), 'utf8'),
+      fs.readFileSync(path.join(backupCacheDir, 'vs_extensions'), 'utf8'),
       'publisher.large-stderr\n',
     );
     assert.include(gistUploads(), 'vs_extensions');
@@ -1148,11 +1105,11 @@ printf '%*s\\n' 1048577 '' >&2
 
   it('reports and uploads non-empty output becoming empty', () => {
     writeSnapshot('');
-    seedGuCache('old content\n');
+    seedBackupCache('old content\n');
 
-    const result = runGu();
+    const result = runBackup();
 
-    assertGuSucceeded(result);
+    assertBackupSucceeded(result);
     assert.equal(result.stdout, '✖︎ zshrc\n');
     assert.equal(fs.readFileSync(cachedSnapshotPath(), 'utf8'), 'empty\n');
     assert.deepEqual(gistUploads(), [snapshotFileName]);
@@ -1160,22 +1117,22 @@ printf '%*s\\n' 1048577 '' >&2
 
   it('hides unchanged empty output and does not upload it', () => {
     writeSnapshot('');
-    seedGuCache('empty\n');
+    seedBackupCache('empty\n');
 
-    const result = runGu();
+    const result = runBackup();
 
-    assertGuSucceeded(result);
+    assertBackupSucceeded(result);
     assert.equal(result.stdout, '');
     assert.deepEqual(gistUploads(), []);
   });
 
   it('preserves the current changed icon when empty becomes non-empty', () => {
     writeSnapshot('restored\n');
-    seedGuCache('empty\n');
+    seedBackupCache('empty\n');
 
-    const result = runGu();
+    const result = runBackup();
 
-    assertGuSucceeded(result);
+    assertBackupSucceeded(result);
     assert.equal(result.stdout, '✚ zshrc\n');
     assert.deepEqual(gistUploads(), [snapshotFileName]);
   });
@@ -1183,9 +1140,9 @@ printf '%*s\\n' 1048577 '' >&2
   it('preserves multiple trailing blank lines', () => {
     writeSnapshot('line\n\n\n');
 
-    const result = runGu();
+    const result = runBackup();
 
-    assertGuSucceeded(result);
+    assertBackupSucceeded(result);
     assert.equal(fs.readFileSync(cachedSnapshotPath(), 'utf8'), 'line\n\n\n');
     assert.equal(fs.readFileSync(fakeGistFilePath(), 'utf8'), 'line\n\n\n');
   });
@@ -1193,9 +1150,9 @@ printf '%*s\\n' 1048577 '' >&2
   it('normalizes output missing its final newline', () => {
     writeSnapshot('line');
 
-    const result = runGu();
+    const result = runBackup();
 
-    assertGuSucceeded(result);
+    assertBackupSucceeded(result);
     assert.equal(fs.readFileSync(cachedSnapshotPath(), 'utf8'), 'line\n');
     assert.equal(fs.readFileSync(fakeGistFilePath(), 'utf8'), 'line\n');
   });
@@ -1203,11 +1160,11 @@ printf '%*s\\n' 1048577 '' >&2
   it('uploads a normalized snapshot only once when a later run is unchanged', () => {
     writeSnapshot('stable without newline');
 
-    const firstResult = runGu();
-    const secondResult = runGu();
+    const firstResult = runBackup();
+    const secondResult = runBackup();
 
-    assertGuSucceeded(firstResult);
-    assertGuSucceeded(secondResult);
+    assertBackupSucceeded(firstResult);
+    assertBackupSucceeded(secondResult);
     assert.equal(secondResult.stdout, '✔ zshrc\n');
     assert.deepEqual(gistUploads(), [snapshotFileName]);
   });
@@ -1216,10 +1173,10 @@ printf '%*s\\n' 1048577 '' >&2
     const gitconfigPath = path.join(testHomeDir, '.gitconfig');
     writeSnapshot('new zsh value\n');
     fs.writeFileSync(gitconfigPath, 'new git value\n');
-    seedGuCache('old zsh value\n');
+    seedBackupCache('old zsh value\n');
     seedFakeGist('old zsh value\n');
 
-    const result = runGu({
+    const result = runBackup({
       failedPaths: ['.zshrc'],
       emitUnderlyingStderr: true,
     });
@@ -1229,12 +1186,12 @@ printf '%*s\\n' 1048577 '' >&2
     assert.equal(
       result.stderr,
       'cat: simulated failure reading .zshrc\n'
-        + 'gu: failed to snapshot zshrc.sh\n',
+        + 'ballin backup: failed to snapshot zshrc.sh\n',
     );
     assert.equal(fs.readFileSync(cachedSnapshotPath(), 'utf8'), 'old zsh value\n');
     assert.equal(fs.readFileSync(fakeGistFilePath(), 'utf8'), 'old zsh value\n');
     assert.equal(
-      fs.readFileSync(path.join(guCacheDir, 'gitconfig'), 'utf8'),
+      fs.readFileSync(path.join(backupCacheDir, 'gitconfig'), 'utf8'),
       'new git value\n',
     );
     assert.deepEqual(gistUploads(), ['gitconfig']);
@@ -1244,11 +1201,11 @@ printf '%*s\\n' 1048577 '' >&2
   it('reports a silent command failure without leaving failed Gist hydration behind', () => {
     writeSnapshot('not captured\n');
 
-    const result = runGu({ failedPaths: ['.zshrc'] });
+    const result = runBackup({ failedPaths: ['.zshrc'] });
 
     assert.equal(result.status, 1);
     assert.equal(result.stdout, '');
-    assert.equal(result.stderr, 'gu: failed to snapshot zshrc.sh\n');
+    assert.equal(result.stderr, 'ballin backup: failed to snapshot zshrc.sh\n');
     assert.isFalse(fs.existsSync(cachedSnapshotPath()));
     assert.isFalse(fs.existsSync(fakeGistFilePath()));
     assert.deepEqual(gistReads(), [snapshotFileName]);
@@ -1258,14 +1215,14 @@ printf '%*s\\n' 1048577 '' >&2
 
   it('recovers cleanly on the next successful invocation', () => {
     writeSnapshot('recovered\n');
-    seedGuCache('before failure\n');
+    seedBackupCache('before failure\n');
     seedFakeGist('before failure\n');
 
-    const failedResult = runGu({ failedPaths: ['.zshrc'] });
-    const recoveredResult = runGu();
+    const failedResult = runBackup({ failedPaths: ['.zshrc'] });
+    const recoveredResult = runBackup();
 
     assert.equal(failedResult.status, 1);
-    assertGuSucceeded(recoveredResult);
+    assertBackupSucceeded(recoveredResult);
     assert.equal(recoveredResult.stdout, '✚ zshrc\n');
     assert.equal(fs.readFileSync(cachedSnapshotPath(), 'utf8'), 'recovered\n');
     assert.equal(fs.readFileSync(fakeGistFilePath(), 'utf8'), 'recovered\n');
@@ -1277,14 +1234,14 @@ printf '%*s\\n' 1048577 '' >&2
     writeSnapshot('zsh value\n');
     fs.writeFileSync(gitconfigPath, 'git value\n');
 
-    const result = runGu({ failedPaths: ['.zshrc', '.gitconfig'] });
+    const result = runBackup({ failedPaths: ['.zshrc', '.gitconfig'] });
 
     assert.equal(result.status, 1);
     assert.equal(result.stdout, '');
     assert.equal(
       result.stderr,
-      'gu: failed to snapshot zshrc.sh\n'
-        + 'gu: failed to snapshot gitconfig\n',
+      'ballin backup: failed to snapshot zshrc.sh\n'
+        + 'ballin backup: failed to snapshot gitconfig\n',
     );
     assert.deepEqual(gistUploads(), []);
     assert.deepEqual(fs.readdirSync(scratchDir), []);

--- a/test/ballin.test.ts
+++ b/test/ballin.test.ts
@@ -46,31 +46,29 @@ describe('ballin', () => {
     return fs.readFileSync(commandLogPath, 'utf8').trimEnd().split('\n').filter(Boolean);
   };
 
-  const writeUpConfigCommand = (overrides: Record<string, string> = {}) => {
-    const cases = Object.entries({
-      'update.cleanup': 'false',
-      'update.nvm': 'false',
-      'update.npm': 'false',
-      'update.softwareupdate': 'false',
-      'update.selfUpdate': 'false',
-      'update.backup': 'false',
-      ...overrides,
-    }).map(([key, value]) => `${key}) printf '%s\\n' '${value}' ;;`).join('\n  ');
-
-    writeExecutable('ballin_config', `#!/bin/bash
-if [ "$1" != 'get' ]; then
-  printf '%s\\n' 'unexpected ballin_config action' >&2
-  exit 2
-fi
-case "$2" in
-  ${cases}
-  *) printf '%s\\n' 'false' ;;
-esac
-`);
-  };
-
   const writeConfig = (config: unknown) => {
     fs.writeFileSync(configPath, `${JSON.stringify(config)}\n`);
+  };
+
+  const writeUpdateConfig = (overrides: Record<string, string> = {}) => {
+    writeConfig({
+      update: {
+        cleanup: 'false',
+        nvm: 'false',
+        npm: 'false',
+        softwareupdate: 'false',
+        selfUpdate: 'false',
+        backup: 'false',
+        ...overrides,
+      },
+      backup: {
+        id: 'test-gist-id',
+        host: 'example.test',
+      },
+      analytics: {
+        enabled: 'false',
+      },
+    });
   };
 
   const runBallin = (args: string[] = []): StringSpawnResult => spawnSync(process.execPath, [
@@ -82,6 +80,7 @@ esac
       ...process.env,
       BALLIN_NO_ANALYTICS: '1',
       BALLIN_TEST_CONFIG_PATH: configPath,
+      BALLIN_TEST_BALLIN_PATH: path.join(binDir, 'ballin'),
       FAKE_COMMAND_LOG: commandLogPath,
       PATH: binDir,
     },
@@ -169,8 +168,8 @@ esac
     assert.equal(result.stderr, 'Unknown Ballin command: upd\nTry: ballin --help\n');
   });
 
-  it('routes update through the existing up workflow and preserves its exit status', () => {
-    writeUpConfigCommand({ 'update.backup': 'true' });
+  it('routes update through the update workflow and preserves its exit status', () => {
+    writeUpdateConfig({ backup: 'true' });
     writeExecutable('ballin', `#!/bin/bash
 if [ "$*" != 'backup' ]; then exit 2; fi
 printf '%s\\n' 'ballin backup from ballin update'
@@ -186,7 +185,7 @@ exit 17
     assert.deepEqual(commandLog(), ['ballin-backup-called']);
   });
 
-  it('routes backup through the existing gu command implementation', () => {
+  it('routes backup through the backup command implementation', () => {
     const result = runBallin(['backup', 'help']);
 
     assert.equal(result.status, 0);
@@ -283,7 +282,7 @@ exit 17
   });
 
   it('fails doctor when a required health check fails', () => {
-    fs.rmSync(path.join(binDir, 'ballin_uninstall'));
+    fs.rmSync(path.join(binDir, 'ballin'));
     writeConfig({
       update: {},
       backup: {
@@ -298,7 +297,7 @@ exit 17
     const missingShim = runBallin(['doctor']);
 
     assert.equal(missingShim.status, 1);
-    assert.include(missingShim.stdout, 'ERROR Command shims on PATH: Missing command shims on PATH: ballin_uninstall.');
+    assert.include(missingShim.stdout, 'ERROR Command shims on PATH: Missing command shims on PATH: ballin.');
     assert.include(missingShim.stdout, '\nNext: Run the installer again or add the Ballin command directory to PATH.');
     assert.include(missingShim.stdout, 'WARN  Gist ID: Backup Gist ID is not configured yet.');
     assert.include(missingShim.stdout, '\nNext: Run the installer to create or adopt a backup Gist.');
@@ -313,7 +312,7 @@ exit 17
 
     assert.equal(missingConfig.status, 1);
     assert.include(missingConfig.stdout, 'ERROR Config readability: Unable to read');
-    assert.include(missingConfig.stdout, 'Next: Run ballin_config reset to recreate the config.');
+    assert.include(missingConfig.stdout, 'Next: Run ballin config reset to recreate the config.');
   });
 
   it('rejects invalid doctor usage', () => {

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -18,7 +18,7 @@ const {
 type SpawnArgs = string[];
 
 const fetchConfigJSON = () => fetchConfig().configJSON;
-const cliPath = path.join(__dirname, '..', 'bin', 'ballin_config');
+const cliPath = path.join(__dirname, '..', 'bin', 'ballin');
 
 const currentConfigJSON = fetchConfigJSON();
 const invalidPathCases = [
@@ -40,7 +40,7 @@ const setTest = (keys: string, value: string, action = setConfig) => {
 
 const setConfigAction = (keys: string, value: string) => configAction('set', keys, value);
 
-const runConfigCli = (args: SpawnArgs = []) => spawnSync(process.execPath, [cliPath, ...args], {
+const runConfigCli = (args: SpawnArgs = []) => spawnSync(process.execPath, [cliPath, 'config', ...args], {
   encoding: 'utf8',
   env: process.env,
 });
@@ -205,7 +205,7 @@ describe('config', () => {
   });
 
   it('CLI remains executable through its shebang', () => {
-    const result = spawnSync(cliPath, ['get', 'backup.id'], {
+    const result = spawnSync(cliPath, ['config', 'get', 'backup.id'], {
       encoding: 'utf8',
       env: process.env,
     });
@@ -217,12 +217,12 @@ describe('config', () => {
 
   it('CLI remains executable through the installed symlink model', () => {
     const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ballin-config-bin-'));
-    const symlinkPath = path.join(tempDir, 'ballin_config');
+    const symlinkPath = path.join(tempDir, 'ballin');
 
     try {
       fs.symlinkSync(cliPath, symlinkPath);
 
-      const result = spawnSync(symlinkPath, ['get', 'backup.id'], {
+      const result = spawnSync(symlinkPath, ['config', 'get', 'backup.id'], {
         encoding: 'utf8',
         env: process.env,
       });

--- a/test/install_setup.test.ts
+++ b/test/install_setup.test.ts
@@ -65,6 +65,8 @@ describe('install setup', () => {
     ? fs.readFileSync(commandLogPath, 'utf8')
     : '');
 
+  const readRepoConfig = () => JSON.parse(fs.readFileSync(path.join(repoDir, 'ballin.config.json'), 'utf8'));
+
   const withEnv = (env: NodeJS.ProcessEnv, action: () => { output: string; result: boolean }) => {
     const previousValues = new Map<string, string | undefined>();
     Object.keys(env).forEach((key) => {
@@ -113,59 +115,6 @@ describe('install setup', () => {
         path.join(repoDir, 'config', fileName),
       );
     });
-  };
-
-  const installGistConfigCommand = () => {
-    writeExecutable('ballin_config', `#!/bin/bash
-printf 'ballin_config:%s\\n' "$*" >> "$FAKE_COMMAND_LOG"
-gist_id_file="$TEST_DIR/.configured-gist-id"
-host_file="$TEST_DIR/.configured-gu-host"
-configured_host='github.example.test'
-if [ -f "$host_file" ]; then
-  while IFS= read -r stored_host; do
-    configured_host="$stored_host"
-  done < "$host_file"
-fi
-case "$1:$2" in
-  get:backup.host) printf '%s\\n' "$configured_host" ;;
-  get:backup.id)
-    if [ -f "$gist_id_file" ]; then
-      while IFS= read -r gist_id; do
-        printf '%s\\n' "$gist_id"
-      done < "$gist_id_file"
-    else
-      printf '%s\\n' 'null'
-    fi
-    ;;
-  set:backup.host)
-    printf '%s\\n' "$3" > "$host_file"
-    printf '%s\\n' "\\"backup.host\\" set to: \\"$3\\""
-    ;;
-  set:backup.id)
-    printf '%s\\n' "$3" > "$gist_id_file"
-    analytics_json=''
-    if [ -f "$TEST_REPO_DIR/ballin.config.json" ]; then
-      config_json=$(<"$TEST_REPO_DIR/ballin.config.json")
-      case "$config_json" in
-        *'"analytics":{"enabled":"false"}'*) analytics_json=',"analytics":{"enabled":"false"}' ;;
-      esac
-    fi
-    printf '{"update":{"cleanup":"false","selfUpdate":"true","backup":"true","softwareupdate":"false","npm":"true","nvm":"true"},"backup":{"id":"%s","host":"%s"}%s}\\n' "$3" "$configured_host" "$analytics_json" > "$TEST_REPO_DIR/ballin.config.json"
-    printf '%s\\n' "\\"backup.id\\" set to: \\"$3\\""
-    ;;
-esac
-`, sourceBinDir);
-  };
-
-  const installStaticConfigCommand = (id = 'existing-gist-id', host = 'github.example.test') => {
-    writeExecutable('ballin_config', `#!/bin/bash
-printf 'ballin_config:%s\\n' "$*" >> "$FAKE_COMMAND_LOG"
-case "$1:$2" in
-  get:backup.host) printf '%s\\n' '${host}' ;;
-  get:backup.id) printf '%s\\n' '${id}' ;;
-  set:backup.host|set:backup.id) printf '%s\\n' "\\"$2\\" set to: \\"$3\\"" ;;
-esac
-`, sourceBinDir);
   };
 
   const installFakeGhCommand = () => {
@@ -224,27 +173,39 @@ esac
     env?: NodeJS.ProcessEnv;
     guHostExisted?: 'true' | 'false';
     input?: string;
-  } = {}) => spawnSync(process.execPath, [
-    installSetupPath,
-    'gist',
-    repoDir,
-    docsUrl,
-    guHostExisted,
-  ], {
-    encoding: 'utf8',
-    input,
-    env: {
-      ...process.env,
-      PATH: binDir,
-      FAKE_COMMAND_LOG: commandLogPath,
-      FAKE_GH_AUTH_STATUS: '0',
-      FAKE_GIST_CONFIG_STATUS: '0',
-      FAKE_RESTORED_CONFIG: '{"update":{"cleanup":"false","selfUpdate":"true","backup":"true","softwareupdate":"false","npm":"true","nvm":"true"},"backup":{"id":null,"host":"github.example.test"}}',
-      TEST_DIR: testDir,
-      TEST_REPO_DIR: repoDir,
-      ...env,
-    },
-  });
+  } = {}) => {
+    const configPath = path.join(repoDir, 'ballin.config.json');
+    if (fs.existsSync(configPath)) {
+      const config = readRepoConfig();
+      config.backup = {
+        ...config.backup,
+        host: 'github.example.test',
+      };
+      fs.writeFileSync(configPath, JSON.stringify(config));
+    }
+
+    return spawnSync(process.execPath, [
+      installSetupPath,
+      'gist',
+      repoDir,
+      docsUrl,
+      guHostExisted,
+    ], {
+      encoding: 'utf8',
+      input,
+      env: {
+        ...process.env,
+        PATH: binDir,
+        FAKE_COMMAND_LOG: commandLogPath,
+        FAKE_GH_AUTH_STATUS: '0',
+        FAKE_GIST_CONFIG_STATUS: '0',
+        FAKE_RESTORED_CONFIG: '{"update":{"cleanup":"false","selfUpdate":"true","backup":"true","softwareupdate":"false","npm":"true","nvm":"true"},"backup":{"id":null,"host":"github.example.test"}}',
+        TEST_DIR: testDir,
+        TEST_REPO_DIR: repoDir,
+        ...env,
+      },
+    });
+  };
 
   beforeEach(() => {
     testDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ballin-install-setup-'));
@@ -270,9 +231,7 @@ esac
 
     assert.isTrue(result);
     assert.isTrue(fs.lstatSync(path.join(binDir, 'ballin')).isSymbolicLink());
-    assert.isTrue(fs.lstatSync(path.join(binDir, 'ballin_config')).isSymbolicLink());
     assert.equal(fs.readlinkSync(path.join(binDir, 'ballin')), path.join(sourceBinDir, 'ballin'));
-    assert.equal(fs.readlinkSync(path.join(binDir, 'ballin_config')), path.join(sourceBinDir, 'ballin_config'));
   });
 
   it('creates the default config through setup code', () => {
@@ -496,7 +455,6 @@ esac
 
   it('reports missing GitHub CLI before Gist setup', () => {
     installConfigSources();
-    installGistConfigCommand();
     fs.copyFileSync(
       path.join(repoDir, 'config', '.defaultConfig.json'),
       path.join(repoDir, 'ballin.config.json'),
@@ -512,7 +470,6 @@ esac
 
   it('reports gh authentication failures before adoption or creation', () => {
     installConfigSources();
-    installGistConfigCommand();
     installFakeGhCommand();
     fs.copyFileSync(
       path.join(repoDir, 'config', '.defaultConfig.json'),
@@ -529,13 +486,14 @@ esac
 
   it('skips adoption and creation when a Gist ID is already configured', () => {
     installConfigSources();
-    installGistConfigCommand();
     installFakeGhCommand();
-    fs.writeFileSync(path.join(testDir, '.configured-gist-id'), 'existing-gist-id\n');
     fs.copyFileSync(
       path.join(repoDir, 'config', '.defaultConfig.json'),
       path.join(repoDir, 'ballin.config.json'),
     );
+    const config = readRepoConfig();
+    config.backup.id = 'existing-gist-id';
+    fs.writeFileSync(path.join(repoDir, 'ballin.config.json'), JSON.stringify(config));
 
     const result = runGistSetup();
 
@@ -544,9 +502,8 @@ esac
     assert.notInclude(commandLog(), 'gh:gist');
   });
 
-  it('persists BALLIN_GU_HOST and passes it to gh auth and gist commands', () => {
+  it('persists BALLIN_BACKUP_HOST and passes it to gh auth and gist commands', () => {
     installConfigSources();
-    installGistConfigCommand();
     installFakeGhCommand();
     fs.copyFileSync(
       path.join(repoDir, 'config', '.defaultConfig.json'),
@@ -555,27 +512,28 @@ esac
 
     const result = runGistSetup({
       env: {
-        BALLIN_GU_HOST: 'github.enterprise.test',
+        BALLIN_BACKUP_HOST: 'github.enterprise.test',
         FAKE_GH_HOST: 'github.enterprise.test',
       },
       input: 'n\n',
     });
 
     assert.equal(result.status, 0, result.stderr);
-    assert.include(commandLog(), 'ballin_config:set backup.host github.enterprise.test\n');
+    assert.equal(readRepoConfig().backup.host, 'github.enterprise.test');
     assert.include(commandLog(), 'gh:auth status --hostname github.enterprise.test');
     assert.include(commandLog(), 'gh:gist create .MyConfig.md --desc ');
   });
 
   it('prompts for a host when config migration adds backup.host', () => {
     installConfigSources();
-    installGistConfigCommand();
     installFakeGhCommand();
-    fs.writeFileSync(path.join(testDir, '.configured-gist-id'), 'existing-gist-id\n');
     fs.copyFileSync(
       path.join(repoDir, 'config', '.defaultConfig.json'),
       path.join(repoDir, 'ballin.config.json'),
     );
+    const config = readRepoConfig();
+    config.backup.id = 'existing-gist-id';
+    fs.writeFileSync(path.join(repoDir, 'ballin.config.json'), JSON.stringify(config));
 
     const result = runGistSetup({
       env: { FAKE_GH_HOST: 'github.enterprise.test' },
@@ -584,14 +542,13 @@ esac
     });
 
     assert.equal(result.status, 0, result.stderr);
-    assert.include(commandLog(), 'ballin_config:set backup.host github.enterprise.test\n');
+    assert.equal(readRepoConfig().backup.host, 'github.enterprise.test');
     assert.include(commandLog(), 'gh:auth status --hostname github.enterprise.test');
     assert.notInclude(commandLog(), 'gh:gist');
   });
 
   it('rejects invalid backup Gist IDs until a valid marker is found', () => {
     installConfigSources();
-    installGistConfigCommand();
     installFakeGhCommand();
     fs.copyFileSync(
       path.join(repoDir, 'config', '.defaultConfig.json'),
@@ -603,13 +560,11 @@ esac
     assert.equal(result.status, 0, result.stderr);
     assert.include(result.stdout, "INVALID: Expected backup marker in gist 'wrong-gist-id'");
     assert.include(commandLog(), 'gh:gist view wrong-gist-id --raw --filename .MyConfig.md');
-    assert.notInclude(commandLog(), 'ballin_config:set backup.id wrong-gist-id');
-    assert.include(commandLog(), 'ballin_config:set backup.id returning-gist-id\n');
+    assert.equal(readRepoConfig().backup.id, 'returning-gist-id');
   });
 
   it('restores config values from an adopted backup Gist', () => {
     installConfigSources();
-    installGistConfigCommand();
     installFakeGhCommand();
     fs.copyFileSync(
       path.join(repoDir, 'config', '.defaultConfig.json'),
@@ -621,7 +576,6 @@ esac
     assert.equal(result.status, 0, result.stderr);
     assert.include(result.stdout, 'Restored ballin.config.json from your backup gist');
     assert.include(commandLog(), 'gh:gist view returning-gist-id --raw --filename ballin_config');
-    assert.include(commandLog(), 'ballin_config:set backup.id returning-gist-id\n');
     const restoredConfig = JSON.parse(fs.readFileSync(path.join(repoDir, 'ballin.config.json'), 'utf8'));
     assert.deepEqual(restoredConfig.update, {
       cleanup: 'false',
@@ -639,7 +593,6 @@ esac
 
   it('accepts an adopted backup marker without a trailing newline like Bash did', () => {
     installConfigSources();
-    installGistConfigCommand();
     installFakeGhCommand();
     fs.copyFileSync(
       path.join(repoDir, 'config', '.defaultConfig.json'),
@@ -653,33 +606,34 @@ esac
 
     assert.equal(result.status, 0, result.stderr);
     assert.include(result.stdout, 'Restored ballin.config.json from your backup gist');
-    assert.include(commandLog(), 'ballin_config:set backup.id returning-gist-id\n');
+    assert.equal(readRepoConfig().backup.id, 'returning-gist-id');
   });
 
   it('rolls back local config when a restored Gist config cannot migrate', () => {
     installConfigSources();
-    installGistConfigCommand();
     installFakeGhCommand();
     fs.writeFileSync(path.join(repoDir, 'ballin.config.json'), '{"backup":{"id":null,"host":"github.example.test"},"local":"keep"}\n');
 
     const result = runGistSetup({
-      env: { FAKE_RESTORED_CONFIG: '{"gu":' },
+      env: { FAKE_RESTORED_CONFIG: '{"backup":' },
       input: '\ny\nreturning-gist-id\n',
     });
 
     assert.equal(result.status, 1);
-    assert.equal(
-      fs.readFileSync(path.join(repoDir, 'ballin.config.json'), 'utf8'),
-      '{"backup":{"id":null,"host":"github.example.test"},"local":"keep"}\n',
-    );
-    assert.notInclude(commandLog(), 'ballin_config:set backup.id returning-gist-id');
+    assert.deepEqual(readRepoConfig(), {
+      backup: {
+        id: null,
+        host: 'github.example.test',
+      },
+      local: 'keep',
+    });
+    assert.notEqual(readRepoConfig().backup.id, 'returning-gist-id');
     assert.isFalse(fs.existsSync(path.join(repoDir, '.ballin.config.restore.tmp')));
     assert.isFalse(fs.existsSync(path.join(repoDir, '.ballin.config.restore.previous.tmp')));
   });
 
   it('keeps local defaults when an adopted Gist has no config snapshot', () => {
     installConfigSources();
-    installGistConfigCommand();
     installFakeGhCommand();
     fs.copyFileSync(
       path.join(repoDir, 'config', '.defaultConfig.json'),
@@ -693,35 +647,33 @@ esac
 
     assert.equal(result.status, 0, result.stderr);
     assert.include(result.stdout, 'No ballin_config snapshot was found in that gist');
-    assert.include(commandLog(), 'ballin_config:set backup.id returning-gist-id\n');
+    assert.equal(readRepoConfig().backup.id, 'returning-gist-id');
     assert.isFalse(fs.existsSync(path.join(repoDir, '.ballin.config.restore.tmp')));
     assert.isFalse(fs.existsSync(path.join(repoDir, '.ballin.config.restore.previous.tmp')));
   });
 
   it('creates a new secret Gist and deletes local Gist setup files', () => {
     installConfigSources();
-    installGistConfigCommand();
     installFakeGhCommand();
     fs.copyFileSync(
       path.join(repoDir, 'config', '.defaultConfig.json'),
       path.join(repoDir, 'ballin.config.json'),
     );
-    fs.mkdirSync(path.join(repoDir, '.gu-cache'));
+    fs.mkdirSync(path.join(repoDir, '.backup-cache'));
 
     const result = runGistSetup({ input: '\nn\n' });
 
     assert.equal(result.status, 0, result.stderr);
     assert.include(result.stdout, "Created a secret gist titled '.MyConfig'");
-    assert.include(result.stdout, 'Deleted existing .gu-cache folder');
+    assert.include(result.stdout, 'Deleted existing .backup-cache folder');
     assert.include(commandLog(), 'gh:gist create .MyConfig.md --desc ');
-    assert.include(commandLog(), 'ballin_config:set backup.id new-gist-id\n');
+    assert.equal(readRepoConfig().backup.id, 'new-gist-id');
     assert.isFalse(fs.existsSync(path.join(repoDir, '.MyConfig.md')));
-    assert.isFalse(fs.existsSync(path.join(repoDir, '.gu-cache')));
+    assert.isFalse(fs.existsSync(path.join(repoDir, '.backup-cache')));
   });
 
   it('runs full setup with existing Gist settings through typed orchestration', () => {
     installConfigSources();
-    installStaticConfigCommand();
     installFakeGhCommand();
     fs.writeFileSync(path.join(repoDir, 'ballin.config.json'), JSON.stringify({
       backup: { id: 'existing-gist-id', host: 'github.example.test' },
@@ -759,7 +711,6 @@ esac
 
   it('creates a new secret Gist through the setup CLI when no backup is configured', () => {
     installConfigSources();
-    installGistConfigCommand();
     installFakeGhCommand();
 
     const result = spawnSync(process.execPath, [
@@ -774,6 +725,8 @@ esac
         ...process.env,
         HOME: path.join(testDir, 'home'),
         PATH: binDir,
+        BALLIN_BACKUP_HOST: 'github.example.test',
+        FAKE_GH_HOST: 'github.example.test',
         FAKE_COMMAND_LOG: commandLogPath,
         FAKE_GH_AUTH_STATUS: '0',
         TEST_DIR: testDir,
@@ -784,7 +737,7 @@ esac
     assert.equal(result.status, 0, result.stderr);
     assert.include(result.stdout, "Created a secret gist titled '.MyConfig'");
     assert.include(commandLog(), 'gh:gist create .MyConfig.md --desc ');
-    assert.include(commandLog(), 'ballin_config:set backup.id new-gist-id\n');
+    assert.equal(readRepoConfig().backup.id, 'new-gist-id');
     assert.isFalse(fs.existsSync(path.join(repoDir, '.MyConfig.md')));
   });
 });

--- a/test/install_setup.test.ts
+++ b/test/install_setup.test.ts
@@ -234,6 +234,23 @@ esac
     assert.equal(fs.readlinkSync(path.join(binDir, 'ballin')), path.join(sourceBinDir, 'ballin'));
   });
 
+  it('removes owned stale legacy command symlinks while symlinking repository binaries', () => {
+    const ownedLegacyConfig = path.join(binDir, 'ballin_config');
+    const ownedLegacyUpdate = path.join(binDir, 'ballin_update');
+    const unrelatedLegacyUninstall = path.join(binDir, 'ballin_uninstall');
+    fs.symlinkSync(path.join(sourceBinDir, 'ballin_config'), ownedLegacyConfig);
+    fs.symlinkSync(path.join(sourceBinDir, 'ballin_update'), ownedLegacyUpdate);
+    fs.symlinkSync(path.join(testDir, 'unrelated-ballin_uninstall'), unrelatedLegacyUninstall);
+
+    const result = withoutStdout(() => symlinkBinaries(repoDir, binDir));
+
+    assert.isTrue(result);
+    assert.isTrue(fs.lstatSync(path.join(binDir, 'ballin')).isSymbolicLink());
+    assert.isFalse(fs.existsSync(ownedLegacyConfig));
+    assert.isFalse(fs.existsSync(ownedLegacyUpdate));
+    assert.isTrue(fs.lstatSync(unrelatedLegacyUninstall).isSymbolicLink());
+  });
+
   it('creates the default config through setup code', () => {
     installConfigSources();
 

--- a/test/install_setup.test.ts
+++ b/test/install_setup.test.ts
@@ -234,23 +234,6 @@ esac
     assert.equal(fs.readlinkSync(path.join(binDir, 'ballin')), path.join(sourceBinDir, 'ballin'));
   });
 
-  it('removes owned stale legacy command symlinks while symlinking repository binaries', () => {
-    const ownedLegacyConfig = path.join(binDir, 'ballin_config');
-    const ownedLegacyUpdate = path.join(binDir, 'ballin_update');
-    const unrelatedLegacyUninstall = path.join(binDir, 'ballin_uninstall');
-    fs.symlinkSync(path.join(sourceBinDir, 'ballin_config'), ownedLegacyConfig);
-    fs.symlinkSync(path.join(sourceBinDir, 'ballin_update'), ownedLegacyUpdate);
-    fs.symlinkSync(path.join(testDir, 'unrelated-ballin_uninstall'), unrelatedLegacyUninstall);
-
-    const result = withoutStdout(() => symlinkBinaries(repoDir, binDir));
-
-    assert.isTrue(result);
-    assert.isTrue(fs.lstatSync(path.join(binDir, 'ballin')).isSymbolicLink());
-    assert.isFalse(fs.existsSync(ownedLegacyConfig));
-    assert.isFalse(fs.existsSync(ownedLegacyUpdate));
-    assert.isTrue(fs.lstatSync(unrelatedLegacyUninstall).isSymbolicLink());
-  });
-
   it('creates the default config through setup code', () => {
     installConfigSources();
 

--- a/test/self_update.test.ts
+++ b/test/self_update.test.ts
@@ -4,14 +4,14 @@ const fs = require('fs');
 const os = require('os');
 const path = require('path');
 
-const updatePath = path.join(__dirname, '..', 'bin', 'ballin_update');
+const ballinPath = path.join(__dirname, '..', 'bin', 'ballin');
 const docsUrl = 'https://github.com/JBallin/ballin-scripts/blob/main/docs/README.md';
-type SpawnUpdateOverrides = Omit<
+type SpawnSelfUpdateOverrides = Omit<
   import('child_process').SpawnSyncOptionsWithStringEncoding,
   'encoding' | 'env'
 >;
 
-describe('ballin_update', () => {
+describe('ballin self-update', () => {
   let testDir: string;
   let homeDir: string;
   let repoDir: string;
@@ -33,7 +33,7 @@ describe('ballin_update', () => {
 
   const linkCommand = (name: string) => {
     const sourcePath = commandPath(name);
-    assert.exists(sourcePath, `${name} is required to run the ballin_update test harness`);
+    assert.exists(sourcePath, `${name} is required to run the ballin self-update test harness`);
     fs.symlinkSync(sourcePath, path.join(toolDir, name));
   };
 
@@ -109,16 +109,17 @@ process.exit(Number(process.env.FAKE_SETUP_STATUS || '0'));
 `);
   };
 
-  const runUpdate = (
+  const runSelfUpdate = (
     env: NodeJS.ProcessEnv = {},
-    commandPath = updatePath,
-    spawnOptions: SpawnUpdateOverrides = {},
-  ) => spawnSync(commandPath, [], {
+    commandPath = ballinPath,
+    spawnOptions: SpawnSelfUpdateOverrides = {},
+  ) => spawnSync(commandPath, ['self-update'], {
     ...spawnOptions,
     encoding: 'utf8',
     env: {
       HOME: homeDir,
       PATH: toolDir,
+      BALLIN_NO_ANALYTICS: '1',
       BALLIN_UPDATE_TEST_LOG: commandLogPath,
       FAKE_GIT_MERGE_COUNT_PATH: mergeCountPath,
       FAKE_GIT_CHECKOUT_COUNT_PATH: checkoutCountPath,
@@ -166,7 +167,7 @@ process.exit(Number(process.env.FAKE_SETUP_STATUS || '0'));
   });
 
   it('fetches, merges, then runs the setup from the installed repository', () => {
-    const result = runUpdate();
+    const result = runSelfUpdate();
 
     assert.equal(result.status, 0, result.stderr);
     assert.equal(result.stdout, '👟 getting fresh kicks...\n');
@@ -180,7 +181,7 @@ process.exit(Number(process.env.FAKE_SETUP_STATUS || '0'));
   });
 
   it('does not add a blank line before setup output', () => {
-    const result = runUpdate({
+    const result = runSelfUpdate({
       FAKE_SETUP_STDOUT: 'setup output\n',
     });
 
@@ -190,9 +191,9 @@ process.exit(Number(process.env.FAKE_SETUP_STATUS || '0'));
   });
 
   it('lets fetch use stdin and stderr while keeping stdout quiet', () => {
-    const result = runUpdate(
+    const result = runSelfUpdate(
       { FAKE_GIT_FETCH_READ_STDIN: '1' },
-      updatePath,
+      ballinPath,
       { input: 'secret-token\n' },
     );
 
@@ -210,11 +211,11 @@ process.exit(Number(process.env.FAKE_SETUP_STATUS || '0'));
 
   it('remains executable through the installed symlink model', () => {
     const installBinDir = path.join(testDir, 'installed-bin');
-    const symlinkPath = path.join(installBinDir, 'ballin_update');
+    const symlinkPath = path.join(installBinDir, 'ballin');
     fs.mkdirSync(installBinDir);
-    fs.symlinkSync(updatePath, symlinkPath);
+    fs.symlinkSync(ballinPath, symlinkPath);
 
-    const result = runUpdate({}, symlinkPath);
+    const result = runSelfUpdate({}, symlinkPath);
 
     assert.equal(result.status, 0, result.stderr);
     assert.equal(result.stdout, '👟 getting fresh kicks...\n');
@@ -228,7 +229,7 @@ process.exit(Number(process.env.FAKE_SETUP_STATUS || '0'));
   });
 
   it('returns the setup status when setup fails after a successful merge', () => {
-    const result = runUpdate({ FAKE_SETUP_STATUS: '27' });
+    const result = runSelfUpdate({ FAKE_SETUP_STATUS: '27' });
 
     assert.equal(result.status, 27);
     assert.equal(result.stdout, '👟 getting fresh kicks...\n');
@@ -244,7 +245,7 @@ process.exit(Number(process.env.FAKE_SETUP_STATUS || '0'));
   it('reports a missing setup through Node when the typed setup file is unavailable', () => {
     fs.rmSync(path.join(repoDir, 'commands', 'install_setup.ts'));
 
-    const result = runUpdate();
+    const result = runSelfUpdate();
 
     assert.equal(result.status, 1);
     assert.equal(result.stdout, '👟 getting fresh kicks...\n');
@@ -257,7 +258,7 @@ process.exit(Number(process.env.FAKE_SETUP_STATUS || '0'));
   });
 
   it('uses a shell-style signal exit status when the setup is signaled', () => {
-    const result = runUpdate({ FAKE_SETUP_SIGNAL: 'SIGTERM' });
+    const result = runSelfUpdate({ FAKE_SETUP_SIGNAL: 'SIGTERM' });
 
     assert.equal(result.status, 143);
     assert.equal(result.stdout, '👟 getting fresh kicks...\n');
@@ -271,7 +272,7 @@ process.exit(Number(process.env.FAKE_SETUP_STATUS || '0'));
   });
 
   it('stops before merge and setup when fetch fails', () => {
-    const result = runUpdate({ FAKE_GIT_FETCH_STATUS: '23' });
+    const result = runSelfUpdate({ FAKE_GIT_FETCH_STATUS: '23' });
 
     assert.equal(result.status, 1);
     assert.equal(result.stdout, '👟 getting fresh kicks...\ngit fetch origin main failed\n');
@@ -284,7 +285,7 @@ process.exit(Number(process.env.FAKE_SETUP_STATUS || '0'));
   it('stops before git commands when the installed repository is missing', () => {
     fs.rmSync(repoDir, { recursive: true, force: true });
 
-    const result = runUpdate();
+    const result = runSelfUpdate();
 
     assert.equal(result.status, 1);
     assert.equal(result.stdout, `👟 getting fresh kicks...\ninstall directory not found: ${repoDir}\n`);
@@ -296,7 +297,7 @@ process.exit(Number(process.env.FAKE_SETUP_STATUS || '0'));
     fs.rmSync(repoDir, { recursive: true, force: true });
     fs.writeFileSync(repoDir, '');
 
-    const result = runUpdate();
+    const result = runSelfUpdate();
 
     assert.equal(result.status, 1);
     assert.equal(result.stdout, `👟 getting fresh kicks...\ninstall directory not found: ${repoDir}\n`);
@@ -305,7 +306,7 @@ process.exit(Number(process.env.FAKE_SETUP_STATUS || '0'));
   });
 
   it('stashes, retries checkout main, merges, and runs setup when initial checkout is blocked', () => {
-    const result = runUpdate({ FAKE_GIT_FIRST_CHECKOUT_STATUS: '27' });
+    const result = runSelfUpdate({ FAKE_GIT_FIRST_CHECKOUT_STATUS: '27' });
 
     assert.equal(result.status, 0, result.stderr);
     assert.equal(
@@ -326,7 +327,7 @@ process.exit(Number(process.env.FAKE_SETUP_STATUS || '0'));
   });
 
   it('stops before merge and setup when checkout recovery cannot stash changes', () => {
-    const result = runUpdate({
+    const result = runSelfUpdate({
       FAKE_GIT_FIRST_CHECKOUT_STATUS: '27',
       FAKE_GIT_STASH_STATUS: '28',
     });
@@ -348,7 +349,7 @@ process.exit(Number(process.env.FAKE_SETUP_STATUS || '0'));
   });
 
   it('stops before merge and setup when checkout still fails after stashing', () => {
-    const result = runUpdate({
+    const result = runSelfUpdate({
       FAKE_GIT_FIRST_CHECKOUT_STATUS: '27',
       FAKE_GIT_RETRY_CHECKOUT_STATUS: '28',
     });
@@ -371,7 +372,7 @@ process.exit(Number(process.env.FAKE_SETUP_STATUS || '0'));
   });
 
   it('stashes, checks out main, retries merge, and runs setup after an initial merge failure', () => {
-    const result = runUpdate({ FAKE_GIT_FIRST_MERGE_STATUS: '24' });
+    const result = runSelfUpdate({ FAKE_GIT_FIRST_MERGE_STATUS: '24' });
 
     assert.equal(result.status, 0, result.stderr);
     assert.equal(
@@ -392,7 +393,7 @@ process.exit(Number(process.env.FAKE_SETUP_STATUS || '0'));
   });
 
   it('aborts an in-progress failed merge before stashing changes during recovery', () => {
-    const result = runUpdate({
+    const result = runSelfUpdate({
       FAKE_GIT_FIRST_MERGE_STATUS: '24',
       FAKE_GIT_MERGE_IN_PROGRESS: '1',
     });
@@ -417,7 +418,7 @@ process.exit(Number(process.env.FAKE_SETUP_STATUS || '0'));
   });
 
   it('stops before stashing when aborting an in-progress failed merge fails', () => {
-    const result = runUpdate({
+    const result = runSelfUpdate({
       FAKE_GIT_FIRST_MERGE_STATUS: '24',
       FAKE_GIT_MERGE_IN_PROGRESS: '1',
       FAKE_GIT_MERGE_ABORT_STATUS: '29',
@@ -441,7 +442,7 @@ process.exit(Number(process.env.FAKE_SETUP_STATUS || '0'));
   });
 
   it('stops before setup when the retry merge fails', () => {
-    const result = runUpdate({
+    const result = runSelfUpdate({
       FAKE_GIT_FIRST_MERGE_STATUS: '24',
       FAKE_GIT_RETRY_MERGE_STATUS: '25',
     });
@@ -466,7 +467,7 @@ process.exit(Number(process.env.FAKE_SETUP_STATUS || '0'));
   });
 
   it('stops before retry merge and setup when the fallback stash path fails', () => {
-    const result = runUpdate({
+    const result = runSelfUpdate({
       FAKE_GIT_FIRST_MERGE_STATUS: '24',
       FAKE_GIT_STASH_STATUS: '26',
     });
@@ -489,7 +490,7 @@ process.exit(Number(process.env.FAKE_SETUP_STATUS || '0'));
   });
 
   it('stops before retry merge and setup when the fallback checkout fails', () => {
-    const result = runUpdate({
+    const result = runSelfUpdate({
       FAKE_GIT_FIRST_MERGE_STATUS: '24',
       FAKE_GIT_RETRY_CHECKOUT_STATUS: '27',
     });

--- a/test/setup_readiness.test.ts
+++ b/test/setup_readiness.test.ts
@@ -116,13 +116,13 @@ describe('setup readiness', () => {
   });
 
   it('reports missing and non-executable command shims on PATH', () => {
-    fs.rmSync(path.join(binDir, 'ballin_update'));
+    fs.rmSync(path.join(binDir, 'ballin'));
 
     const report = collect();
     const commandCheck = checkById(report, 'commands.path');
 
     assert.equal(commandCheck.status, 'fail');
-    assert.deepEqual(commandCheck.data?.missing, ['ballin_update']);
+    assert.deepEqual(commandCheck.data?.missing, ['ballin']);
   });
 
   it('reports config readability and top-level section availability', () => {
@@ -155,7 +155,7 @@ describe('setup readiness', () => {
     assert.equal(fs.readFileSync(configPath, 'utf8'), beforeConfig);
     assert.notInclude(commandLog.join('\n'), 'gist create');
     assert.notInclude(commandLog.join('\n'), 'gist edit');
-    assert.notInclude(commandLog.join('\n'), 'ballin_config set');
+    assert.notInclude(commandLog.join('\n'), 'ballin config set');
   });
 
   it('reports unconfigured Gist ID and missing gh as non-mutating warnings', () => {

--- a/test/uninstall.test.ts
+++ b/test/uninstall.test.ts
@@ -3,15 +3,15 @@ const { spawnSync } = require('child_process');
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
-const { relocateSystemPath } = require('../commands/ballin_uninstall.ts');
+const { relocateSystemPath } = require('../commands/uninstall.ts');
 
-const uninstallPath = path.join(__dirname, '..', 'bin', 'ballin_uninstall');
+const ballinPath = path.join(__dirname, '..', 'bin', 'ballin');
 type RunUninstallOptions = {
   brewPrefix?: string;
   commandPath?: string;
 };
 
-describe('ballin_uninstall', () => {
+describe('ballin uninstall', () => {
   let testDir: string;
   let homeDir: string;
   let repoDir: string;
@@ -35,7 +35,7 @@ describe('ballin_uninstall', () => {
     return filePath;
   };
 
-  const runUninstall = ({ brewPrefix, commandPath: command = uninstallPath }: RunUninstallOptions = {}) => {
+  const runUninstall = ({ brewPrefix, commandPath: command = ballinPath }: RunUninstallOptions = {}) => {
     if (brewPrefix) {
       writeExecutable('brew', `#!/usr/bin/env bash
 if [ "$1" = '--prefix' ]; then
@@ -46,11 +46,12 @@ exit 2
 `);
     }
 
-    return spawnSync(command, [], {
+    return spawnSync(command, ['uninstall'], {
       encoding: 'utf8',
       env: {
         HOME: homeDir,
         PATH: toolDir,
+        BALLIN_NO_ANALYTICS: '1',
         BALLIN_UNINSTALL_TEST_SYSTEM_ROOT: systemRoot,
       },
     });
@@ -88,29 +89,30 @@ exit 2
   it('removes only owned user-local links, then removes the repository', () => {
     const userBin = path.join(homeDir, '.local', 'bin');
     const ballin = createCommand('ballin');
-    createCommand('gu');
-    createCommand('up');
+    const legacyConfig = createCommand('ballin_config');
     fs.symlinkSync(ballin, path.join(userBin, 'ballin'));
-    fs.writeFileSync(path.join(userBin, 'gu'), 'keep me\n');
-    fs.symlinkSync(path.join(testDir, 'unrelated'), path.join(userBin, 'up'));
+    fs.symlinkSync(legacyConfig, path.join(userBin, 'ballin_config'));
+    fs.writeFileSync(path.join(userBin, 'unrelated-file'), 'keep me\n');
+    fs.symlinkSync(path.join(testDir, 'unrelated'), path.join(userBin, 'unrelated-link'));
 
     const result = runUninstall();
 
     assert.equal(result.status, 0, result.stderr);
     assert.equal(result.stdout, "\nIt's been real...\nDeleted symlinked binaries\nPEACE! You still ballin tho...\n\n");
     assert.isFalse(fs.existsSync(path.join(userBin, 'ballin')));
-    assert.isTrue(fs.statSync(path.join(userBin, 'gu')).isFile());
-    assert.isTrue(fs.lstatSync(path.join(userBin, 'up')).isSymbolicLink());
+    assert.isFalse(fs.existsSync(path.join(userBin, 'ballin_config')));
+    assert.isTrue(fs.statSync(path.join(userBin, 'unrelated-file')).isFile());
+    assert.isTrue(fs.lstatSync(path.join(userBin, 'unrelated-link')).isSymbolicLink());
     assert.isFalse(fs.existsSync(repoDir));
   });
 
   it('remains executable through the installed symlink model', () => {
     const installBinDir = path.join(testDir, 'installed-bin');
-    const symlinkPath = path.join(installBinDir, 'ballin_uninstall');
+    const symlinkPath = path.join(installBinDir, 'ballin');
     const userBin = path.join(homeDir, '.local', 'bin');
     const ballin = createCommand('ballin');
     fs.mkdirSync(installBinDir);
-    fs.symlinkSync(uninstallPath, symlinkPath);
+    fs.symlinkSync(ballinPath, symlinkPath);
     fs.symlinkSync(ballin, path.join(userBin, 'ballin'));
 
     const result = runUninstall({ commandPath: symlinkPath });

--- a/test/uninstall.test.ts
+++ b/test/uninstall.test.ts
@@ -89,9 +89,7 @@ exit 2
   it('removes only owned user-local links, then removes the repository', () => {
     const userBin = path.join(homeDir, '.local', 'bin');
     const ballin = createCommand('ballin');
-    const legacyConfig = createCommand('ballin_config');
     fs.symlinkSync(ballin, path.join(userBin, 'ballin'));
-    fs.symlinkSync(legacyConfig, path.join(userBin, 'ballin_config'));
     fs.writeFileSync(path.join(userBin, 'unrelated-file'), 'keep me\n');
     fs.symlinkSync(path.join(testDir, 'unrelated'), path.join(userBin, 'unrelated-link'));
 
@@ -100,7 +98,6 @@ exit 2
     assert.equal(result.status, 0, result.stderr);
     assert.equal(result.stdout, "\nIt's been real...\nDeleted symlinked binaries\nPEACE! You still ballin tho...\n\n");
     assert.isFalse(fs.existsSync(path.join(userBin, 'ballin')));
-    assert.isFalse(fs.existsSync(path.join(userBin, 'ballin_config')));
     assert.isTrue(fs.statSync(path.join(userBin, 'unrelated-file')).isFile());
     assert.isTrue(fs.lstatSync(path.join(userBin, 'unrelated-link')).isSymbolicLink());
     assert.isFalse(fs.existsSync(repoDir));

--- a/test/update.test.ts
+++ b/test/update.test.ts
@@ -14,7 +14,7 @@ type InstallCommandStubOptions = {
   directory?: string;
 };
 
-describe('up', () => {
+describe('ballin update', () => {
   let tempDir: string;
   let binDir: string;
   let configPath: string;
@@ -29,7 +29,7 @@ describe('up', () => {
     { output = '', status = 0, directory = binDir }: InstallCommandStubOptions = {},
   ) => {
     fs.writeFileSync(path.join(directory, name), `#!/usr/bin/env bash
-printf '%s|%s|%s\\n' "${name}" "$HOMEBREW_NO_ENV_HINTS,$HOMEBREW_NO_ASK" "$*" >> "$UP_TEST_LOG"
+printf '%s|%s|%s\\n' "${name}" "$HOMEBREW_NO_ENV_HINTS,$HOMEBREW_NO_ASK" "$*" >> "$UPDATE_TEST_LOG"
 ${output ? `printf '%s\\n' '${output}'` : ''}
 exit ${status}
 `, { mode: 0o755 });
@@ -49,26 +49,22 @@ exit ${status}
   };
 
   beforeEach(() => {
-    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ballin-up-'));
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ballin-update-'));
     binDir = path.join(tempDir, 'bin');
     configPath = path.join(tempDir, 'ballin.config.json');
     logPath = path.join(tempDir, 'commands.log');
     fs.mkdirSync(binDir);
     fs.symlinkSync('/bin/bash', path.join(binDir, 'bash'));
     fs.symlinkSync(process.execPath, path.join(binDir, 'node'));
-    writeTestExecutable('ballin_config', `#!/usr/bin/env bash
-case "$2" in
-  update.cleanup) printf '%s\\n' "\${TEST_UP_CLEANUP:-false}" ;;
-  update.nvm) printf '%s\\n' "\${TEST_UP_NVM:-false}" ;;
-  update.npm) printf '%s\\n' "\${TEST_UP_NPM:-false}" ;;
-  update.softwareupdate) printf '%s\\n' "\${TEST_UP_SOFTWAREUPDATE:-false}" ;;
-  update.selfUpdate) printf '%s\\n' "\${TEST_UP_BALLIN:-false}" ;;
-  update.backup) printf '%s\\n' "\${TEST_UP_GU:-false}" ;;
-  *) printf '%s\\n' 'false' ;;
-esac
-`);
     writeConfig({
-      update: {},
+      update: {
+        cleanup: 'false',
+        nvm: 'true',
+        npm: 'false',
+        softwareupdate: 'false',
+        selfUpdate: 'false',
+        backup: 'false',
+      },
       backup: {
         id: 'test-gist-id',
         host: 'example.test',
@@ -83,18 +79,42 @@ esac
     fs.rmSync(tempDir, { recursive: true, force: true });
   });
 
-  const runUp = (env: NodeJS.ProcessEnv = {}) => spawnSync(ballinPath, ['update'], {
-    encoding: 'utf8',
-    env: {
-      HOME: tempDir,
-      PATH: binDir,
-      NVM_TEST_LOG: logPath,
-      UP_TEST_LOG: logPath,
-      BALLIN_TEST_CONFIG_PATH: configPath,
-      TEST_UP_NVM: 'true',
-      ...env,
-    },
-  });
+  const writeUpdateConfig = (env: NodeJS.ProcessEnv = {}) => {
+    writeConfig({
+      update: {
+        cleanup: env.TEST_UPDATE_CLEANUP ?? 'false',
+        nvm: env.TEST_UPDATE_NVM ?? 'true',
+        npm: env.TEST_UPDATE_NPM ?? 'false',
+        softwareupdate: env.TEST_UPDATE_SOFTWAREUPDATE ?? 'false',
+        selfUpdate: env.TEST_UPDATE_BALLIN ?? 'false',
+        backup: env.TEST_UPDATE_BACKUP ?? 'false',
+      },
+      backup: {
+        id: 'test-gist-id',
+        host: 'example.test',
+      },
+      analytics: {
+        enabled: 'false',
+      },
+    });
+  };
+
+  const runUpdate = (env: NodeJS.ProcessEnv = {}) => {
+    writeUpdateConfig(env);
+    return spawnSync(ballinPath, ['update'], {
+      encoding: 'utf8',
+      env: {
+        HOME: tempDir,
+        PATH: binDir,
+        NVM_TEST_LOG: logPath,
+        UPDATE_TEST_LOG: logPath,
+        BALLIN_NO_ANALYTICS: '1',
+        BALLIN_TEST_CONFIG_PATH: configPath,
+        BALLIN_TEST_BALLIN_PATH: path.join(binDir, 'ballin'),
+        ...env,
+      },
+    });
+  };
 
   const installNvmStub = (nvmDir: string) => {
     fs.mkdirSync(nvmDir, { recursive: true });
@@ -128,14 +148,16 @@ esac
     const symlinkPath = path.join(installBinDir, 'ballin');
     fs.mkdirSync(installBinDir);
     fs.symlinkSync(ballinPath, symlinkPath);
+    writeUpdateConfig({ TEST_UPDATE_NVM: 'false' });
 
     const result = spawnSync(symlinkPath, ['update'], {
       encoding: 'utf8',
       env: {
         HOME: tempDir,
         PATH: binDir,
-        TEST_UP_NVM: 'false',
-        UP_TEST_LOG: logPath,
+        BALLIN_NO_ANALYTICS: '1',
+        BALLIN_TEST_CONFIG_PATH: configPath,
+        UPDATE_TEST_LOG: logPath,
       },
     });
 
@@ -147,7 +169,7 @@ esac
   it('sets Homebrew flags, preserves output, cleans conditionally, and runs doctor', () => {
     installCommandStub('brew', { output: 'visible Homebrew output' });
 
-    const result = runUp({ TEST_UP_NVM: 'false', TEST_UP_CLEANUP: 'true' });
+    const result = runUpdate({ TEST_UPDATE_NVM: 'false', TEST_UPDATE_CLEANUP: 'true' });
 
     assert.equal(result.status, 0);
     assert.include(result.stdout, 'visible Homebrew output');
@@ -162,20 +184,20 @@ esac
 
   it('reports a Homebrew substep failure after running later integrations', () => {
     writeTestExecutable('brew', `#!/usr/bin/env bash
-printf 'brew|%s|%s\\n' "$HOMEBREW_NO_ENV_HINTS,$HOMEBREW_NO_ASK" "$*" >> "$UP_TEST_LOG"
+printf 'brew|%s|%s\\n' "$HOMEBREW_NO_ENV_HINTS,$HOMEBREW_NO_ASK" "$*" >> "$UPDATE_TEST_LOG"
 if [ "$1" = 'cleanup' ]; then
   printf '%s\\n' 'simulated cleanup failure'
   exit 42
 fi
 exit 0
 `);
-    installCommandStub('ballin_update');
+    installCommandStub('ballin');
     installHealthyReadinessCommands();
 
-    const result = runUp({
-      TEST_UP_NVM: 'false',
-      TEST_UP_CLEANUP: 'true',
-      TEST_UP_BALLIN: 'true',
+    const result = runUpdate({
+      TEST_UPDATE_NVM: 'false',
+      TEST_UPDATE_CLEANUP: 'true',
+      TEST_UPDATE_BALLIN: 'true',
     });
 
     assert.equal(result.status, 42);
@@ -187,26 +209,26 @@ exit 0
       'brew|1,1|upgrade',
       'brew|1,1|cleanup',
       'brew|1,1|doctor',
-      'ballin_update|1,1|',
+      'ballin|1,1|self-update',
       'gh|1,1|auth status --hostname example.test',
     ]);
   });
 
   it('passes exported Homebrew flags to later integrations', () => {
     installCommandStub('brew');
-    installCommandStub('ballin_update');
+    installCommandStub('ballin');
     installHealthyReadinessCommands();
 
-    const result = runUp({
-      TEST_UP_NVM: 'false',
-      TEST_UP_BALLIN: 'true',
+    const result = runUpdate({
+      TEST_UPDATE_NVM: 'false',
+      TEST_UPDATE_BALLIN: 'true',
     });
 
     assert.equal(result.status, 0);
     assert.deepEqual(commandLog(), [
       'brew|1,1|upgrade',
       'brew|1,1|doctor',
-      'ballin_update|1,1|',
+      'ballin|1,1|self-update',
       'gh|1,1|auth status --hostname example.test',
     ]);
   });
@@ -214,7 +236,7 @@ exit 0
   it('skips cleanup when disabled while preserving upgrade and doctor output', () => {
     installCommandStub('brew', { output: 'brew command output' });
 
-    const result = runUp({ TEST_UP_NVM: 'false' });
+    const result = runUpdate({ TEST_UPDATE_NVM: 'false' });
 
     assert.equal(result.status, 0);
     assert.notInclude(result.stdout, 'Cleaning up Homebrew packages');
@@ -226,37 +248,37 @@ exit 0
   });
 
   it('runs enabled npm, macOS update, ballin update, and backup integrations', () => {
-    ['npm', 'softwareupdate', 'ballin_update'].forEach((command) => {
+    ['npm', 'softwareupdate'].forEach((command) => {
       installCommandStub(command);
     });
     installCommandStub('ballin');
     installHealthyReadinessCommands();
 
-    const result = runUp({
-      TEST_UP_NVM: 'false',
-      TEST_UP_NPM: 'true',
-      TEST_UP_SOFTWAREUPDATE: 'true',
-      TEST_UP_BALLIN: 'true',
-      TEST_UP_GU: 'true',
+    const result = runUpdate({
+      TEST_UPDATE_NVM: 'false',
+      TEST_UPDATE_NPM: 'true',
+      TEST_UPDATE_SOFTWAREUPDATE: 'true',
+      TEST_UPDATE_BALLIN: 'true',
+      TEST_UPDATE_BACKUP: 'true',
     });
 
     assert.equal(result.status, 0);
     assert.deepEqual(commandLog(), [
       'npm|,|update -g',
       'softwareupdate|,|-ia',
-      'ballin_update|,|',
+      'ballin|,|self-update',
       'gh|,|auth status --hostname example.test',
       'ballin|,|backup',
     ]);
   });
 
   it('checks Ballin readiness after a successful ballin update', () => {
-    installCommandStub('ballin_update', { output: 'updated ballin-scripts' });
+    installCommandStub('ballin', { output: 'updated ballin-scripts' });
     installHealthyReadinessCommands();
 
-    const result = runUp({
-      TEST_UP_NVM: 'false',
-      TEST_UP_BALLIN: 'true',
+    const result = runUpdate({
+      TEST_UPDATE_NVM: 'false',
+      TEST_UPDATE_BALLIN: 'true',
     });
 
     assert.equal(result.status, 0);
@@ -265,7 +287,7 @@ exit 0
     assert.include(result.stdout, 'Checking Ballin readiness');
     assert.include(result.stdout, 'Your Ballin-managed environment is healthy.');
     assert.deepEqual(commandLog(), [
-      'ballin_update|,|',
+      'ballin|,|self-update',
       'gh|,|auth status --hostname example.test',
     ]);
   });
@@ -276,7 +298,7 @@ exit 0
     fs.mkdirSync(nvmBinDir);
     installPathUpdatingNvmStub(nvmDir, nvmBinDir);
     writeTestExecutable('node', `#!/usr/bin/env bash
-printf 'node|%s|%s\\n' "$HOMEBREW_NO_ENV_HINTS,$HOMEBREW_NO_ASK" "$*" >> "$UP_TEST_LOG"
+printf 'node|%s|%s\\n' "$HOMEBREW_NO_ENV_HINTS,$HOMEBREW_NO_ASK" "$*" >> "$UPDATE_TEST_LOG"
 if [ "$*" = '-p process.versions.node' ]; then
   printf '%s\\n' '99.0.0'
   exit 0
@@ -289,9 +311,9 @@ exit 2
 `, nvmBinDir);
     installHealthyReadinessCommands();
 
-    const result = runUp({
+    const result = runUpdate({
       NVM_DIR: nvmDir,
-      TEST_UP_BALLIN: 'true',
+      TEST_UPDATE_BALLIN: 'true',
     });
 
     assert.equal(result.status, 0);
@@ -299,40 +321,45 @@ exit 2
     assert.include(result.stdout, 'Your Ballin-managed environment is healthy.');
     assert.deepEqual(commandLog().slice(1), [
       'node|,|-e process.stdout.write(JSON.stringify(process.env))',
-      'ballin_update|,|',
+      'ballin|,|self-update',
       'node|,|-p process.versions.node',
       'gh|,|auth status --hostname example.test',
     ]);
   });
 
   it('keeps Ballin readiness failures informational after update', () => {
-    installCommandStub('ballin_update');
+    const selfUpdatePath = path.join(tempDir, 'self-update-ballin');
+    fs.writeFileSync(selfUpdatePath, `#!/usr/bin/env bash
+printf '%s|%s|%s\\n' "ballin" "$HOMEBREW_NO_ENV_HINTS,$HOMEBREW_NO_ASK" "$*" >> "$UPDATE_TEST_LOG"
+exit 0
+`, { mode: 0o755 });
     installHealthyReadinessCommands();
-    fs.rmSync(path.join(binDir, 'ballin_uninstall'));
+    fs.rmSync(path.join(binDir, 'ballin'));
 
-    const result = runUp({
-      TEST_UP_NVM: 'false',
-      TEST_UP_BALLIN: 'true',
+    const result = runUpdate({
+      TEST_UPDATE_NVM: 'false',
+      TEST_UPDATE_BALLIN: 'true',
+      BALLIN_TEST_BALLIN_PATH: selfUpdatePath,
     });
 
     assert.equal(result.status, 0);
     assert.include(result.stdout, 'Checking Ballin readiness');
-    assert.include(result.stdout, 'ERROR Command shims on PATH: Missing command shims on PATH: ballin_uninstall.');
+    assert.include(result.stdout, 'ERROR Command shims on PATH: Missing command shims on PATH: ballin.');
     assert.include(result.stdout, 'Next: Run the installer again or add the Ballin command directory to PATH.');
     assert.notInclude(result.stdout, 'Your Ballin-managed environment is healthy.');
     assert.deepEqual(commandLog(), [
-      'ballin_update|,|',
+      'ballin|,|self-update',
       'gh|,|auth status --hostname example.test',
     ]);
   });
 
   it('skips Ballin readiness when ballin update fails', () => {
-    installCommandStub('ballin_update', { output: 'simulated update failure', status: 23 });
+    installCommandStub('ballin', { output: 'simulated update failure', status: 23 });
     installHealthyReadinessCommands();
 
-    const result = runUp({
-      TEST_UP_NVM: 'false',
-      TEST_UP_BALLIN: 'true',
+    const result = runUpdate({
+      TEST_UPDATE_NVM: 'false',
+      TEST_UPDATE_BALLIN: 'true',
     });
 
     assert.equal(result.status, 23);
@@ -340,16 +367,16 @@ exit 2
     assert.notInclude(result.stdout, 'Checking Ballin readiness');
     assert.notInclude(result.stdout, 'Your Ballin-managed environment is healthy.');
     assert.deepEqual(commandLog(), [
-      'ballin_update|,|',
+      'ballin|,|self-update',
     ]);
   });
 
   it('does not run disabled optional integrations even when commands exist', () => {
-    ['npm', 'softwareupdate', 'ballin_update', 'ballin'].forEach((command) => {
+    ['npm', 'softwareupdate', 'ballin'].forEach((command) => {
       installCommandStub(command);
     });
 
-    const result = runUp({ TEST_UP_NVM: 'false' });
+    const result = runUpdate({ TEST_UPDATE_NVM: 'false' });
 
     assert.equal(result.status, 0);
     assert.deepEqual(commandLog(), []);
@@ -361,43 +388,49 @@ exit 2
 
   it('keeps later integrations isolated when an optional command fails', () => {
     installCommandStub('npm', { output: 'simulated npm failure', status: 23 });
-    installCommandStub('ballin_update');
+    installCommandStub('ballin');
     installCommandStub('ballin');
     installHealthyReadinessCommands();
 
-    const result = runUp({
-      TEST_UP_NVM: 'false',
-      TEST_UP_NPM: 'true',
-      TEST_UP_BALLIN: 'true',
-      TEST_UP_GU: 'true',
+    const result = runUpdate({
+      TEST_UPDATE_NVM: 'false',
+      TEST_UPDATE_NPM: 'true',
+      TEST_UPDATE_BALLIN: 'true',
+      TEST_UPDATE_BACKUP: 'true',
     });
 
     assert.equal(result.status, 23);
     assert.include(result.stdout, 'simulated npm failure');
     assert.deepEqual(commandLog(), [
       'npm|,|update -g',
-      'ballin_update|,|',
+      'ballin|,|self-update',
       'gh|,|auth status --hostname example.test',
       'ballin|,|backup',
     ]);
   });
 
   it('still uses final backup status after informational Ballin readiness', () => {
-    installCommandStub('ballin_update');
-    installCommandStub('ballin', { output: 'simulated backup failure', status: 17 });
+    writeTestExecutable('ballin', `#!/usr/bin/env bash
+printf '%s|%s|%s\\n' "ballin" "$HOMEBREW_NO_ENV_HINTS,$HOMEBREW_NO_ASK" "$*" >> "$UPDATE_TEST_LOG"
+if [ "$1" = 'backup' ]; then
+  printf '%s\\n' 'simulated backup failure'
+  exit 17
+fi
+exit 0
+`);
     installHealthyReadinessCommands();
 
-    const result = runUp({
-      TEST_UP_NVM: 'false',
-      TEST_UP_BALLIN: 'true',
-      TEST_UP_GU: 'true',
+    const result = runUpdate({
+      TEST_UPDATE_NVM: 'false',
+      TEST_UPDATE_BALLIN: 'true',
+      TEST_UPDATE_BACKUP: 'true',
     });
 
     assert.equal(result.status, 17);
     assert.include(result.stdout, 'Your Ballin-managed environment is healthy.');
     assert.include(result.stdout, 'simulated backup failure');
     assert.deepEqual(commandLog(), [
-      'ballin_update|,|',
+      'ballin|,|self-update',
       'gh|,|auth status --hostname example.test',
       'ballin|,|backup',
     ]);
@@ -406,9 +439,9 @@ exit 2
   it('uses backup as the final exit status when backup is enabled', () => {
     installCommandStub('ballin', { output: 'simulated backup failure', status: 17 });
 
-    const result = runUp({
-      TEST_UP_NVM: 'false',
-      TEST_UP_GU: 'true',
+    const result = runUpdate({
+      TEST_UPDATE_NVM: 'false',
+      TEST_UPDATE_BACKUP: 'true',
     });
 
     assert.equal(result.status, 17);
@@ -423,9 +456,9 @@ exit 2
 kill -TERM "$$"
 `);
 
-    const result = runUp({
-      TEST_UP_NVM: 'false',
-      TEST_UP_GU: 'true',
+    const result = runUpdate({
+      TEST_UPDATE_NVM: 'false',
+      TEST_UPDATE_BACKUP: 'true',
     });
 
     assert.equal(result.status, 143);
@@ -436,7 +469,7 @@ kill -TERM "$$"
     const nvmDir = path.join(tempDir, 'custom-nvm');
     installNvmStub(nvmDir);
 
-    const result = runUp({ NVM_DIR: nvmDir });
+    const result = runUpdate({ NVM_DIR: nvmDir });
 
     assert.equal(result.status, 0);
     assert.include(result.stdout, 'Updating Node.js LTS');
@@ -455,12 +488,12 @@ kill -TERM "$$"
 `,
     );
     writeTestExecutable('ballin', `#!/usr/bin/env bash
-printf '%s\\n' 'backup still ran' >> "$UP_TEST_LOG"
+printf '%s\\n' 'backup still ran' >> "$UPDATE_TEST_LOG"
 `);
 
-    const result = runUp({
+    const result = runUpdate({
       NVM_DIR: nvmDir,
-      TEST_UP_GU: 'true',
+      TEST_UPDATE_BACKUP: 'true',
     });
 
     assert.equal(result.status, 24);
@@ -477,9 +510,9 @@ printf '%s\\n' 'backup still ran' >> "$UP_TEST_LOG"
     installPathUpdatingNvmStub(nvmDir, nvmBinDir);
     installCommandStub('npm', { directory: nvmBinDir });
 
-    const result = runUp({
+    const result = runUpdate({
       NVM_DIR: nvmDir,
-      TEST_UP_NPM: 'true',
+      TEST_UPDATE_NPM: 'true',
     });
 
     assert.equal(result.status, 0);
@@ -500,12 +533,12 @@ printf '%s\\n' 'backup still ran' >> "$UP_TEST_LOG"
     installCommandStub('npm', { directory: nvmBinDir });
     writeTestExecutable('ballin', `#!/usr/bin/env bash
 if [ "$*" != 'backup' ]; then exit 2; fi
-printf 'backup-npm|%s\\n' "$(command -v npm)" >> "$UP_TEST_LOG"
+printf 'backup-npm|%s\\n' "$(command -v npm)" >> "$UPDATE_TEST_LOG"
 `);
 
-    const result = runUp({
+    const result = runUpdate({
       NVM_DIR: nvmDir,
-      TEST_UP_GU: 'true',
+      TEST_UPDATE_BACKUP: 'true',
     });
 
     assert.equal(result.status, 0);
@@ -524,12 +557,12 @@ printf 'backup-npm|%s\\n' "$(command -v npm)" >> "$UP_TEST_LOG"
 exit 42
 `, { mode: 0o755 });
     writeTestExecutable('ballin', `#!/usr/bin/env bash
-printf '%s\\n' 'backup still ran' >> "$UP_TEST_LOG"
+printf '%s\\n' 'backup still ran' >> "$UPDATE_TEST_LOG"
 `);
 
-    const result = runUp({
+    const result = runUpdate({
       NVM_DIR: nvmDir,
-      TEST_UP_GU: 'true',
+      TEST_UPDATE_BACKUP: 'true',
     });
 
     assert.equal(result.status, 0);
@@ -540,13 +573,13 @@ printf '%s\\n' 'backup still ran' >> "$UP_TEST_LOG"
   });
 
   it('warns when nvm is enabled but cannot be loaded', () => {
-    const result = runUp();
+    const result = runUpdate();
 
     assert.equal(result.status, 0);
     assert.include(result.stdout, 'Updating Node.js LTS');
     assert.include(result.stderr, 'unable to load nvm');
     assert.include(result.stderr, 'Set NVM_DIR');
-    assert.include(result.stderr, 'ballin_config set update.nvm false');
+    assert.include(result.stderr, 'ballin config set update.nvm false');
     assert.isFalse(fs.existsSync(logPath));
   });
 
@@ -554,7 +587,7 @@ printf '%s\\n' 'backup still ran' >> "$UP_TEST_LOG"
     const nvmDir = path.join(tempDir, 'custom-nvm');
     installNvmStub(nvmDir);
 
-    const result = runUp({ NVM_DIR: nvmDir, TEST_UP_NVM: 'false' });
+    const result = runUpdate({ NVM_DIR: nvmDir, TEST_UPDATE_NVM: 'false' });
 
     assert.equal(result.status, 0);
     assert.notInclude(result.stdout, 'Updating Node.js LTS');
@@ -562,26 +595,39 @@ printf '%s\\n' 'backup still ran' >> "$UP_TEST_LOG"
     assert.isFalse(fs.existsSync(logPath));
   });
 
-  it('surfaces ballin_config stderr when config reads fail', () => {
-    writeTestExecutable('ballin_config', `#!/usr/bin/env bash
-printf '%s\\n' 'broken config' >&2
-exit 42
-`);
+  it('surfaces config read failures', () => {
+    fs.writeFileSync(configPath, '{not json\n');
 
-    const result = runUp();
+    const result = spawnSync(ballinPath, ['update'], {
+      encoding: 'utf8',
+      env: {
+        HOME: tempDir,
+        PATH: binDir,
+        BALLIN_NO_ANALYTICS: '1',
+        BALLIN_TEST_CONFIG_PATH: configPath,
+      },
+    });
 
     assert.equal(result.status, 0);
-    assert.include(result.stderr, 'broken config');
+    assert.isNotEmpty(result.stderr);
     assert.deepEqual(commandLog(), []);
   });
 
-  it('reports missing ballin_config reads like the shell did', () => {
-    fs.rmSync(path.join(binDir, 'ballin_config'));
+  it('reports missing config reads', () => {
+    fs.rmSync(configPath);
 
-    const result = runUp();
+    const result = spawnSync(ballinPath, ['update'], {
+      encoding: 'utf8',
+      env: {
+        HOME: tempDir,
+        PATH: binDir,
+        BALLIN_NO_ANALYTICS: '1',
+        BALLIN_TEST_CONFIG_PATH: configPath,
+      },
+    });
 
     assert.equal(result.status, 0);
-    assert.include(result.stderr, 'ballin_config: command not found');
+    assert.include(result.stderr, 'Unable to read');
     assert.deepEqual(commandLog(), []);
   });
 });


### PR DESCRIPTION
Closes #226

## Summary
- remove legacy public ballin_* shims so bin/ only exposes ballin
- rename update, backup, self-update, and uninstall implementations/tests to canonical names
- route update/backup/config/self-update/uninstall through canonical ballin subcommands and direct typed helpers
- update readiness checks, docs, and analytics allowlists for the canonical command surface
- keep the existing backup snapshot filename ballin_config without retaining legacy command cleanup logic

## Validation
- npm test