### PR TITLE
ci: add actionlint workflow check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
             | xargs -0 -r shellcheck
 
       - name: Run actionlint
-        run: docker run --rm -v "${PWD}:/repo" --workdir /repo rhysd/actionlint:1.7.12 -color .github/workflows/*.yml
+        run: docker run --rm -v "${PWD}:/repo:ro" --workdir /repo rhysd/actionlint:1.7.12 -color .github/workflows/*.yml
 
       - name: Set up Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,9 @@ jobs:
           git grep -Ilz '^#!.*bash' -- . \
             | xargs -0 -r shellcheck
 
+      - name: Run actionlint
+        run: docker run --rm -v "${PWD}:/repo" --workdir /repo rhysd/actionlint:1.7.12 -color .github/workflows/*.yml
+
       - name: Set up Node.js
         uses: actions/setup-node@v6
         with:


### PR DESCRIPTION
## Summary

- add a CI actionlint check for `.github/workflows/*.yml`
- run actionlint through the pinned `rhysd/actionlint:1.7.12` Docker image so workflow syntax and embedded `run:` shell blocks are checked before merge
- keep the change scoped to the existing CI workflow

Closes #232

## Validation

- `git diff --check`
- `docker run --rm -v "${PWD}:/repo:ro" --workdir /repo rhysd/actionlint:1.7.12 -color .github/workflows/*.yml`
- skipped `npm test` because this is workflow-only per repo instructions
