### PR TITLE
Extract path-scoped config store

### DIFF
--- a/commands/install_setup.ts
+++ b/commands/install_setup.ts
@@ -4,6 +4,9 @@ const {
   ensureAnalyticsInstallId,
 } = require('./analytics.ts');
 const {
+  createConfigStore,
+} = require('../config/store.ts');
+const {
   commandExists,
   readCommandOutput,
   runCommand,
@@ -87,55 +90,6 @@ const readJsonObject = (filePath: string): ConfigObject | null => {
   }
 };
 
-// Installer setup can target an arbitrary checkout, while config/index.ts binds
-// its config path at module load. Keep these repoDir-scoped helpers local.
-const getNestedConfigValue = (config: ConfigObject, keyPath: string): ConfigValue | undefined => {
-  const keys = keyPath.split('.');
-  let value: ConfigValue = config;
-
-  for (const key of keys) {
-    if (value === null || typeof value !== 'object' || !Object.prototype.hasOwnProperty.call(value, key)) {
-      return undefined;
-    }
-    value = value[key];
-  }
-
-  return value;
-};
-
-const setNestedConfigValue = (config: ConfigObject, keyPath: string, value: ConfigLeaf): boolean => {
-  const keys = keyPath.split('.');
-  const keyToSet = keys.pop();
-  let container: ConfigValue = config;
-
-  if (!keyToSet) {
-    return false;
-  }
-
-  for (const key of keys) {
-    if (
-      container === null
-      || typeof container !== 'object'
-      || !Object.prototype.hasOwnProperty.call(container, key)
-    ) {
-      return false;
-    }
-    container = container[key];
-  }
-
-  if (
-    container === null
-    || typeof container !== 'object'
-    || !Object.prototype.hasOwnProperty.call(container, keyToSet)
-    || (typeof container[keyToSet] === 'object' && container[keyToSet] !== null)
-  ) {
-    return false;
-  }
-
-  container[keyToSet] = value;
-  return true;
-};
-
 const configHasBackupHost = (repoDir: string): boolean => {
   const config = readJsonObject(configPathFor(repoDir));
   return isConfigObject(config?.backup) && Object.prototype.hasOwnProperty.call(config.backup, 'host');
@@ -186,23 +140,17 @@ const configure = (repoDir: string, docsUrl: string): boolean => {
 };
 
 const configValue = (configPath: string, key: string): string | null => {
-  const config = readJsonObject(configPath);
-  if (!config) {
-    return null;
-  }
-  const value = getNestedConfigValue(config, key);
-  if (value === undefined || (typeof value === 'object' && value !== null)) {
+  const value = createConfigStore({ configPath }).readLeafValue(key);
+  if (value === undefined) {
     return null;
   }
   return value === null ? 'null' : String(value);
 };
 
 const setConfigValue = (configPath: string, key: string, value: string): boolean => {
-  const config = readJsonObject(configPath);
-  if (!config || !setNestedConfigValue(config, key, value)) {
+  if (!createConfigStore({ configPath }).writeLeafValue(key, value)) {
     return false;
   }
-  fs.writeFileSync(configPath, JSON.stringify(config, null, 2), 'utf8');
   process.stdout.write(`"${key}" set to: ${JSON.stringify(value)}\n`);
   return true;
 };

--- a/config/index.ts
+++ b/config/index.ts
@@ -1,3 +1,4 @@
+const { exec } = require('child_process');
 const path = require('path');
 const {
   configMessages,
@@ -10,11 +11,23 @@ const configPath = process.env.BALLIN_TEST_CONFIG_PATH || userConfigPath;
 const defaultConfigPath = path.join(__dirname, '.defaultConfig.json');
 const store = createConfigStore({ configPath, defaultConfigPath });
 const {
-  configAction,
   fetchConfig,
   getConfig,
+  resetConfig,
   setConfig,
 } = store;
+
+const configAction = (request?: string, keys?: string, value?: string, other?: string[]) => {
+  if (request === 'reset') return resetConfig();
+  // Send full config when no explicit request is provided.
+  if (request === 'get' || !request) return getConfig(keys, value);
+  if (request === 'set') return setConfig(keys, value, other);
+  if (process.env.NODE_ENV !== 'test') {
+    // exec() is async, so actionErr is returned before the help output is printed.
+    exec('ballin', (error: Error | null, stdout: string) => console.log(stdout)); // eslint-disable-line no-console
+  }
+  return configMessages.actionErr;
+};
 
 module.exports = {
   getConfig,

--- a/config/index.ts
+++ b/config/index.ts
@@ -1,133 +1,20 @@
-const fs = require('fs');
-const { exec } = require('child_process');
 const path = require('path');
-
-type ConfigLeaf = string | number | boolean | null;
-type ConfigObject = { [key: string]: ConfigValue };
-type ConfigValue = ConfigLeaf | ConfigObject;
-type NestedValueResult = {
-  value?: ConfigValue;
-  missingKeys?: string;
-};
-type ResetPreviousConfigResult = {
-  display: string;
-};
+const {
+  configMessages,
+  createConfigStore,
+  stringify,
+} = require('./store.ts');
 
 const userConfigPath = path.join(__dirname, '..', 'ballin.config.json');
 const configPath = process.env.BALLIN_TEST_CONFIG_PATH || userConfigPath;
 const defaultConfigPath = path.join(__dirname, '.defaultConfig.json');
-const stringify = (obj: ConfigObject) => JSON.stringify(obj, null, 2);
-// Only JSON-owned keys count; inherited properties are not config entries.
-const hasOwn = (obj: ConfigObject, key: string) => Object.prototype.hasOwnProperty.call(obj, key);
-
-const configMessages = {
-  actionErr: 'INVALID: ballin config accepts "", "get", "set", or "reset"',
-  getKeysDneErr: (keys: string) => `INVALID: "${keys}" doesn't exist in config`,
-  reset: (prevConfig: ConfigValue, defaultConfig: string) => (
-    `Config has been reset...\nFROM:\n${prevConfig}TO:\n${defaultConfig}`
-  ),
-  set: (keys: string, newConfig: ConfigValue) => `"${keys}" set to: ${JSON.stringify(newConfig)}`,
-  setArgsErr: 'INVALID: setConfig takes two arguments: "key(s)" and "value"',
-  getArgsErr: 'INVALID: getConfig takes one argument: "key(s)"',
-  setDneErr: (keys: string) => `INVALID: "${keys}" doesn't exist in config`,
-  setObjErr: (keys: string, prevVal: ConfigValue) => (
-    `INVALID: "${keys}" is not a bottom-level value, it returns ${JSON.stringify(prevVal)}.`
-  ),
-};
-
-const fetchConfig = () => {
-  const configJSON = fs.readFileSync(configPath, 'utf8');
-  const configObj = JSON.parse(configJSON) as ConfigObject;
-  return { configObj, configJSON };
-};
-
-const readPreviousConfigForReset = (): ResetPreviousConfigResult => {
-  try {
-    return { display: fs.readFileSync(configPath, 'utf8') };
-  } catch {
-    return { display: `Unable to read ${configPath}.\n` };
-  }
-};
-
-// Return the value, or the first path prefix that cannot be resolved.
-const getNestedValue = (configObj: ConfigObject, keys: string): NestedValueResult => {
-  const keysArr = keys.split('.');
-  let value: ConfigValue = configObj;
-
-  for (let index = 0; index < keysArr.length; index += 1) {
-    const key = keysArr[index];
-    const resolvedKeys = keysArr.slice(0, index + 1).join('.');
-    if (value === null || typeof value !== 'object' || !hasOwn(value, key)) {
-      return { missingKeys: resolvedKeys };
-    }
-    value = value[key];
-  }
-
-  return { value };
-};
-
-const getConfig = (keys?: string, val?: string): ConfigValue | string => {
-  if (val) return configMessages.getArgsErr;
-  const { configObj, configJSON } = fetchConfig();
-  if (keys !== undefined) {
-    const { value, missingKeys } = getNestedValue(configObj, keys);
-    return missingKeys === undefined
-      ? value as ConfigValue
-      : configMessages.getKeysDneErr(missingKeys);
-  }
-  return configJSON;
-};
-
-const resetConfig = () => {
-  const { display: prevConfig } = readPreviousConfigForReset();
-  const defaultConfig = fs.readFileSync(defaultConfigPath, 'utf8');
-  fs.writeFileSync(configPath, defaultConfig, 'utf8');
-  return configMessages.reset(prevConfig, defaultConfig);
-};
-
-const setConfig = (keys?: string, val?: ConfigValue, other?: string[]) => {
-  const { configObj } = fetchConfig();
-  if ((other && other.length) || !keys || val === undefined) {
-    return configMessages.setArgsErr;
-  }
-  const keysArr = keys.split('.');
-  const keyToSet = keysArr.pop() as string;
-  const parentKeys = keysArr;
-  // Resolve the parent first: setConfig updates existing leaves and never creates paths.
-  const { value: nestedObj, missingKeys } = parentKeys.length
-    ? getNestedValue(configObj, parentKeys.join('.'))
-    : { value: configObj };
-  if (missingKeys !== undefined) {
-    return configMessages.setDneErr(missingKeys);
-  }
-  if (nestedObj === null || typeof nestedObj !== 'object') {
-    return configMessages.setDneErr(keys);
-  }
-  if (!hasOwn(nestedObj, keyToSet)) {
-    return configMessages.setDneErr(keys);
-  }
-  const prevVal = nestedObj[keyToSet];
-
-  // Objects are containers, but null is a valid leaf value (for example, backup.id).
-  if (typeof prevVal === 'object' && prevVal !== null) {
-    return configMessages.setObjErr(keys, prevVal);
-  }
-  nestedObj[keyToSet] = val;
-  fs.writeFileSync(configPath, stringify(configObj), 'utf8');
-  return configMessages.set(keys, getConfig(keys));
-};
-
-const configAction = (request?: string, keys?: string, value?: string, other?: string[]) => {
-  if (request === 'reset') return resetConfig();
-  // Send full config when no explicit request is provided.
-  if (request === 'get' || !request) return getConfig(keys, value);
-  if (request === 'set') return setConfig(keys, value, other);
-  if (process.env.NODE_ENV !== 'test') {
-    // exec() is async, so actionErr is returned before the help output is printed.
-    exec('ballin', (error: Error | null, stdout: string) => console.log(stdout)); // eslint-disable-line no-console
-  }
-  return configMessages.actionErr;
-};
+const store = createConfigStore({ configPath, defaultConfigPath });
+const {
+  configAction,
+  fetchConfig,
+  getConfig,
+  setConfig,
+} = store;
 
 module.exports = {
   getConfig,

--- a/config/store.ts
+++ b/config/store.ts
@@ -1,5 +1,4 @@
 const fs = require('fs');
-const { exec } = require('child_process');
 const path = require('path');
 
 type ConfigLeaf = string | number | boolean | null;
@@ -145,20 +144,7 @@ const createConfigStore = ({
     }
   };
 
-  const configAction = (request?: string, keys?: string, value?: string, other?: string[]) => {
-    if (request === 'reset') return resetConfig();
-    // Send full config when no explicit request is provided.
-    if (request === 'get' || !request) return getConfig(keys, value);
-    if (request === 'set') return setConfig(keys, value, other);
-    if (process.env.NODE_ENV !== 'test') {
-      // exec() is async, so actionErr is returned before the help output is printed.
-      exec('ballin', (error: Error | null, stdout: string) => console.log(stdout)); // eslint-disable-line no-console
-    }
-    return configMessages.actionErr;
-  };
-
   return {
-    configAction,
     configPath,
     fetchConfig,
     getConfig,

--- a/config/store.ts
+++ b/config/store.ts
@@ -1,0 +1,176 @@
+const fs = require('fs');
+const { exec } = require('child_process');
+const path = require('path');
+
+type ConfigLeaf = string | number | boolean | null;
+type ConfigObject = { [key: string]: ConfigValue };
+type ConfigValue = ConfigLeaf | ConfigObject;
+type NestedValueResult = {
+  value?: ConfigValue;
+  missingKeys?: string;
+};
+type ResetPreviousConfigResult = {
+  display: string;
+};
+type ConfigStoreOptions = {
+  configPath: string;
+  defaultConfigPath?: string;
+};
+
+const stringify = (obj: ConfigObject) => JSON.stringify(obj, null, 2);
+
+// Only JSON-owned keys count; inherited properties are not config entries.
+const hasOwn = (obj: ConfigObject, key: string) => Object.prototype.hasOwnProperty.call(obj, key);
+
+const configMessages = {
+  actionErr: 'INVALID: ballin config accepts "", "get", "set", or "reset"',
+  getKeysDneErr: (keys: string) => `INVALID: "${keys}" doesn't exist in config`,
+  reset: (prevConfig: ConfigValue, defaultConfig: string) => (
+    `Config has been reset...\nFROM:\n${prevConfig}TO:\n${defaultConfig}`
+  ),
+  set: (keys: string, newConfig: ConfigValue) => `"${keys}" set to: ${JSON.stringify(newConfig)}`,
+  setArgsErr: 'INVALID: setConfig takes two arguments: "key(s)" and "value"',
+  getArgsErr: 'INVALID: getConfig takes one argument: "key(s)"',
+  setDneErr: (keys: string) => `INVALID: "${keys}" doesn't exist in config`,
+  setObjErr: (keys: string, prevVal: ConfigValue) => (
+    `INVALID: "${keys}" is not a bottom-level value, it returns ${JSON.stringify(prevVal)}.`
+  ),
+};
+
+// Return the value, or the first path prefix that cannot be resolved.
+const getNestedValue = (configObj: ConfigObject, keys: string): NestedValueResult => {
+  const keysArr = keys.split('.');
+  let value: ConfigValue = configObj;
+
+  for (let index = 0; index < keysArr.length; index += 1) {
+    const key = keysArr[index];
+    const resolvedKeys = keysArr.slice(0, index + 1).join('.');
+    if (value === null || typeof value !== 'object' || !hasOwn(value, key)) {
+      return { missingKeys: resolvedKeys };
+    }
+    value = value[key];
+  }
+
+  return { value };
+};
+
+const createConfigStore = ({
+  configPath,
+  defaultConfigPath = path.join(__dirname, '.defaultConfig.json'),
+}: ConfigStoreOptions) => {
+  const fetchConfig = () => {
+    const configJSON = fs.readFileSync(configPath, 'utf8');
+    const configObj = JSON.parse(configJSON) as ConfigObject;
+    return { configObj, configJSON };
+  };
+
+  const readPreviousConfigForReset = (): ResetPreviousConfigResult => {
+    try {
+      return { display: fs.readFileSync(configPath, 'utf8') };
+    } catch {
+      return { display: `Unable to read ${configPath}.\n` };
+    }
+  };
+
+  const getConfig = (keys?: string, val?: string): ConfigValue | string => {
+    if (val) return configMessages.getArgsErr;
+    const { configObj, configJSON } = fetchConfig();
+    if (keys !== undefined) {
+      const { value, missingKeys } = getNestedValue(configObj, keys);
+      return missingKeys === undefined
+        ? value as ConfigValue
+        : configMessages.getKeysDneErr(missingKeys);
+    }
+    return configJSON;
+  };
+
+  const resetConfig = () => {
+    const { display: prevConfig } = readPreviousConfigForReset();
+    const defaultConfig = fs.readFileSync(defaultConfigPath, 'utf8');
+    fs.writeFileSync(configPath, defaultConfig, 'utf8');
+    return configMessages.reset(prevConfig, defaultConfig);
+  };
+
+  const setConfig = (keys?: string, val?: ConfigValue, other?: string[]) => {
+    const { configObj } = fetchConfig();
+    if ((other && other.length) || !keys || val === undefined) {
+      return configMessages.setArgsErr;
+    }
+    const keysArr = keys.split('.');
+    const keyToSet = keysArr.pop() as string;
+    const parentKeys = keysArr;
+    // Resolve the parent first: setConfig updates existing leaves and never creates paths.
+    const { value: nestedObj, missingKeys } = parentKeys.length
+      ? getNestedValue(configObj, parentKeys.join('.'))
+      : { value: configObj };
+    if (missingKeys !== undefined) {
+      return configMessages.setDneErr(missingKeys);
+    }
+    if (nestedObj === null || typeof nestedObj !== 'object') {
+      return configMessages.setDneErr(keys);
+    }
+    if (!hasOwn(nestedObj, keyToSet)) {
+      return configMessages.setDneErr(keys);
+    }
+    const prevVal = nestedObj[keyToSet];
+
+    // Objects are containers, but null is a valid leaf value (for example, backup.id).
+    if (typeof prevVal === 'object' && prevVal !== null) {
+      return configMessages.setObjErr(keys, prevVal);
+    }
+    nestedObj[keyToSet] = val;
+    fs.writeFileSync(configPath, stringify(configObj), 'utf8');
+    return configMessages.set(keys, getConfig(keys));
+  };
+
+  const readLeafValue = (keys: string): ConfigLeaf | undefined => {
+    try {
+      const { configObj } = fetchConfig();
+      const { value, missingKeys } = getNestedValue(configObj, keys);
+      if (missingKeys !== undefined || (typeof value === 'object' && value !== null)) {
+        return undefined;
+      }
+      return value as ConfigLeaf;
+    } catch {
+      return undefined;
+    }
+  };
+
+  const writeLeafValue = (keys: string, value: ConfigLeaf): boolean => {
+    try {
+      const result = setConfig(keys, value);
+      return result === configMessages.set(keys, value);
+    } catch {
+      return false;
+    }
+  };
+
+  const configAction = (request?: string, keys?: string, value?: string, other?: string[]) => {
+    if (request === 'reset') return resetConfig();
+    // Send full config when no explicit request is provided.
+    if (request === 'get' || !request) return getConfig(keys, value);
+    if (request === 'set') return setConfig(keys, value, other);
+    if (process.env.NODE_ENV !== 'test') {
+      // exec() is async, so actionErr is returned before the help output is printed.
+      exec('ballin', (error: Error | null, stdout: string) => console.log(stdout)); // eslint-disable-line no-console
+    }
+    return configMessages.actionErr;
+  };
+
+  return {
+    configAction,
+    configPath,
+    fetchConfig,
+    getConfig,
+    readLeafValue,
+    resetConfig,
+    setConfig,
+    writeLeafValue,
+  };
+};
+
+module.exports = {
+  configMessages,
+  createConfigStore,
+  stringify,
+};

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -5,6 +5,9 @@ const os = require('os');
 const path = require('path');
 const defaultConfig = require('../config/.defaultConfig.json');
 const configModule = require('../config/index.ts');
+const {
+  createConfigStore,
+} = require('../config/store.ts');
 
 const {
   getConfig,
@@ -13,6 +16,7 @@ const {
   configPath,
   fetchConfig,
   configMessages,
+  stringify,
 } = configModule;
 
 type SpawnArgs = string[];
@@ -85,6 +89,73 @@ describe('config', () => {
   });
   afterEach('Reset config', () => {
     fs.writeFileSync(configPath, savedConfig, 'utf8');
+  });
+
+  describe('path-scoped config store', () => {
+    let tempDir: string;
+    let explicitConfigPath: string;
+    const explicitDefaultConfigPath = path.join(__dirname, '..', 'config', '.defaultConfig.json');
+
+    beforeEach(() => {
+      tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ballin-config-store-'));
+      explicitConfigPath = path.join(tempDir, 'ballin.config.json');
+    });
+
+    afterEach(() => {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    });
+
+    const writeExplicitConfig = (config: unknown) => {
+      fs.writeFileSync(explicitConfigPath, stringify(config), 'utf8');
+      return createConfigStore({
+        configPath: explicitConfigPath,
+        defaultConfigPath: explicitDefaultConfigPath,
+      });
+    };
+
+    it('reads and writes an explicit config path independently from the default fixture', () => {
+      const store = writeExplicitConfig({
+        ...defaultConfig,
+        backup: {
+          ...defaultConfig.backup,
+          id: 'explicit-gist-id',
+        },
+      });
+
+      assert.notEqual(explicitConfigPath, configPath);
+      assert.equal(store.readLeafValue('backup.id'), 'explicit-gist-id');
+      assert.isNull(getConfig('backup.id'));
+      assert.isTrue(store.writeLeafValue('backup.host', 'github.explicit.test'));
+      assert.equal(JSON.parse(fs.readFileSync(explicitConfigPath, 'utf8')).backup.host, 'github.explicit.test');
+      assert.equal(getConfig('backup.host'), 'github.com');
+    });
+
+    it('preserves nested path validation for explicit-path reads and writes', () => {
+      const store = writeExplicitConfig(defaultConfig);
+      const configBeforeWrite = fs.readFileSync(explicitConfigPath, 'utf8');
+
+      assert.isUndefined(store.readLeafValue('missing'));
+      assert.isUndefined(store.readLeafValue('constructor'));
+      assert.isUndefined(store.readLeafValue('__proto__.nested'));
+      assert.isUndefined(store.readLeafValue('update'));
+      assert.isFalse(store.writeLeafValue('missing', 'value'));
+      assert.isFalse(store.writeLeafValue('constructor', 'value'));
+      assert.isFalse(store.writeLeafValue('__proto__.nested', 'value'));
+      assert.isFalse(store.writeLeafValue('update', 'value'));
+      assert.equal(fs.readFileSync(explicitConfigPath, 'utf8'), configBeforeWrite);
+    });
+
+    it('returns leaf values and rejects malformed explicit config files without mutating them', () => {
+      const store = writeExplicitConfig(defaultConfig);
+
+      assert.isNull(store.readLeafValue('backup.id'));
+      assert.equal(store.readLeafValue('backup.host'), 'github.com');
+
+      fs.writeFileSync(explicitConfigPath, '{not json\n', 'utf8');
+      assert.isUndefined(store.readLeafValue('backup.host'));
+      assert.isFalse(store.writeLeafValue('backup.host', 'github.example.test'));
+      assert.equal(fs.readFileSync(explicitConfigPath, 'utf8'), '{not json\n');
+    });
   });
 
   describe('getConfig', () => {

--- a/test/install_setup.test.ts
+++ b/test/install_setup.test.ts
@@ -109,7 +109,7 @@ describe('install setup', () => {
 
   const installConfigSources = () => {
     fs.mkdirSync(path.join(repoDir, 'config'), { recursive: true });
-    ['.defaultConfig.json', 'index.ts', 'updateConfig.ts'].forEach((fileName) => {
+    ['.defaultConfig.json', 'index.ts', 'store.ts', 'updateConfig.ts'].forEach((fileName) => {
       fs.copyFileSync(
         path.join(repoRoot, 'config', fileName),
         path.join(repoDir, 'config', fileName),


### PR DESCRIPTION
Closes #233

## Summary
- add a path-scoped config store for explicit config paths
- keep config/index.ts as the default-path adapter and config CLI action dispatcher
- update installer setup to use the shared explicit-path helpers instead of local nested config helpers

## Validation
- npx mocha test/config.test.ts test/install_setup.test.ts
- npm test