### PR TITLE
Add analytics reset utility

### DIFF
--- a/analytics-worker/README.md
+++ b/analytics-worker/README.md
@@ -196,11 +196,14 @@ It does not add telemetry fields or expose feature-level events, command
 arguments, local paths, Gist details, package/editor data, raw errors,
 environment variables, arbitrary config values, IP storage, or raw install IDs.
 
-## Canonical Command Reset
+## Resetting Aggregates
 
-After the Ballin 2 CLI rename, analytics should use a clean canonical-command
-baseline instead of mixing historical `up` / `gu` rows with `ballin <command>`
-rows. The reset clears all aggregate analytics tables:
+`npm run analytics:reset` clears the aggregate analytics tables when an
+operator wants a fresh reporting baseline. The first expected use is the Ballin
+2 CLI rename, where a clean canonical-command baseline is more useful than
+mixing historical `up` / `gu` rows with `ballin <command>` rows.
+
+The reset clears all aggregate analytics tables:
 
 - `install_days`
 - `command_events_daily`
@@ -214,13 +217,14 @@ Preview the current production row counts before deleting anything:
 npm run analytics:reset -- --dry-run
 ```
 
-Reset the production aggregates only after confirming the Ballin 2 baseline:
+Reset the production aggregates only after confirming that historical aggregate
+data is no longer needed:
 
 ```shell
-npm run analytics:reset -- --confirm RESET_ANALYTICS_AFTER_CLI_RENAME
+npm run analytics:reset -- --confirm RESET_ANALYTICS_AGGREGATES
 ```
 
-Verify that the report no longer shows stale historical command rows:
+Verify the fresh reporting baseline:
 
 ```shell
 npm run analytics:report
@@ -229,6 +233,3 @@ npm run analytics:report
 The reset command uses local Wrangler authentication and the ignored
 `analytics-worker/wrangler.toml` file, like the report command. If Wrangler is
 not installed globally, the script falls back to `npx wrangler`.
-
-Production reset date: not yet performed. When the production reset is run,
-replace this sentence with the UTC date and operator note for the cleanup.

--- a/analytics-worker/README.md
+++ b/analytics-worker/README.md
@@ -195,3 +195,40 @@ Reporting stays within the existing aggregate schema:
 It does not add telemetry fields or expose feature-level events, command
 arguments, local paths, Gist details, package/editor data, raw errors,
 environment variables, arbitrary config values, IP storage, or raw install IDs.
+
+## Canonical Command Reset
+
+After the Ballin 2 CLI rename, analytics should use a clean canonical-command
+baseline instead of mixing historical `up` / `gu` rows with `ballin <command>`
+rows. The reset clears all aggregate analytics tables:
+
+- `install_days`
+- `command_events_daily`
+- `version_events_daily`
+
+There is no raw event table.
+
+Preview the current production row counts before deleting anything:
+
+```shell
+npm run analytics:reset -- --dry-run
+```
+
+Reset the production aggregates only after confirming the Ballin 2 baseline:
+
+```shell
+npm run analytics:reset -- --confirm RESET_ANALYTICS_AFTER_CLI_RENAME
+```
+
+Verify that the report no longer shows stale historical command rows:
+
+```shell
+npm run analytics:report
+```
+
+The reset command uses local Wrangler authentication and the ignored
+`analytics-worker/wrangler.toml` file, like the report command. If Wrangler is
+not installed globally, the script falls back to `npx wrangler`.
+
+Production reset date: not yet performed. When the production reset is run,
+replace this sentence with the UTC date and operator note for the cleanup.

--- a/analytics-worker/README.md
+++ b/analytics-worker/README.md
@@ -230,10 +230,11 @@ environment variables, arbitrary config values, IP storage, or raw install IDs.
 
 ## Resetting Aggregates
 
-`npm run analytics:reset` clears the aggregate analytics tables when an
-operator wants a fresh reporting baseline. The first expected use is the Ballin
-2 CLI rename, where a clean canonical-command baseline is more useful than
-mixing historical `up` / `gu` rows with `ballin <command>` rows.
+`analytics-worker/reset.ts` clears the aggregate analytics tables when an
+operator wants a fresh reporting baseline. It is a rare maintenance utility,
+not a normal project workflow. The first expected use is the Ballin 2 CLI
+rename, where a clean canonical-command baseline is more useful than mixing
+historical `up` / `gu` rows with `ballin <command>` rows.
 
 The reset clears all aggregate analytics tables:
 
@@ -246,14 +247,14 @@ There is no raw event table.
 Preview the current production row counts before deleting anything:
 
 ```shell
-npm run analytics:reset -- --dry-run
+node analytics-worker/reset.ts --dry-run
 ```
 
 Reset the production aggregates only after confirming that historical aggregate
 data is no longer needed:
 
 ```shell
-npm run analytics:reset -- --confirm RESET_ANALYTICS_AGGREGATES
+node analytics-worker/reset.ts --confirm RESET_ANALYTICS_AGGREGATES
 ```
 
 Verify the fresh reporting baseline:

--- a/analytics-worker/reset.ts
+++ b/analytics-worker/reset.ts
@@ -21,7 +21,7 @@ type SpawnRunner = (
 ) => SpawnSyncReturns<string>;
 
 const defaultDatabase = 'ballin-scripts-analytics';
-const confirmationPhrase = 'RESET_ANALYTICS_AFTER_CLI_RENAME';
+const confirmationPhrase = 'RESET_ANALYTICS_AGGREGATES';
 const aggregateTables = [
   'install_days',
   'command_events_daily',

--- a/analytics-worker/reset.ts
+++ b/analytics-worker/reset.ts
@@ -90,11 +90,9 @@ const countSql = aggregateTables.map((tableName) => (
   `SELECT '${tableName}' AS table_name, count(*) AS rows FROM ${tableName}`
 )).join('\nUNION ALL\n');
 
-const resetSql = [
-  'BEGIN TRANSACTION;',
-  ...aggregateTables.map((tableName) => `DELETE FROM ${tableName};`),
-  'COMMIT;',
-].join('\n');
+const resetSql = aggregateTables
+  .map((tableName) => `DELETE FROM ${tableName};`)
+  .join('\n');
 
 const wranglerArgsFor = (sql: string, options: ResetOptions): string[] => {
   const rootDir = options.rootDir ?? path.join(__dirname, '..');

--- a/analytics-worker/reset.ts
+++ b/analytics-worker/reset.ts
@@ -1,0 +1,270 @@
+const fs = require('fs');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+import type { SpawnSyncReturns } from 'child_process';
+
+type ResetOptions = {
+  confirm?: string;
+  database: string;
+  dryRun: boolean;
+  help: boolean;
+  rootDir?: string;
+};
+
+type D1Row = Record<string, unknown>;
+type D1Runner = (sql: string, options: ResetOptions) => D1Row[];
+type SpawnRunner = (
+  command: string,
+  args: string[],
+  options: { cwd: string; encoding: 'utf8' },
+) => SpawnSyncReturns<string>;
+
+const defaultDatabase = 'ballin-scripts-analytics';
+const confirmationPhrase = 'RESET_ANALYTICS_AFTER_CLI_RENAME';
+const aggregateTables = [
+  'install_days',
+  'command_events_daily',
+  'version_events_daily',
+] as const;
+
+const usage = [
+  'Usage: npm run analytics:reset -- --dry-run [--database NAME]',
+  `       npm run analytics:reset -- --confirm ${confirmationPhrase} [--database NAME]`,
+  '',
+  'Prints row counts or clears the production analytics aggregate tables.',
+].join('\n');
+
+const requiredOptionValue = (value: string | undefined, option: string): string => {
+  if (!value || value.startsWith('--')) {
+    throw new Error(`${option} requires a value`);
+  }
+  return value;
+};
+
+const parseArgs = (args: string[]): ResetOptions => {
+  const parsed: ResetOptions = {
+    database: defaultDatabase,
+    dryRun: false,
+    help: false,
+  };
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (arg === '--help' || arg === '-h') {
+      parsed.help = true;
+    } else if (arg === '--dry-run') {
+      parsed.dryRun = true;
+    } else if (arg === '--confirm') {
+      index += 1;
+      parsed.confirm = requiredOptionValue(args[index], arg);
+    } else if (arg === '--database') {
+      index += 1;
+      parsed.database = requiredOptionValue(args[index], arg);
+    } else {
+      throw new Error(`Unknown analytics reset option: ${arg}`);
+    }
+  }
+
+  if (!parsed.database) {
+    throw new Error('--database must not be empty');
+  }
+  if (parsed.help) {
+    return parsed;
+  }
+  if (parsed.dryRun && parsed.confirm) {
+    throw new Error('Choose either --dry-run or --confirm, not both');
+  }
+  if (!parsed.dryRun && parsed.confirm !== confirmationPhrase) {
+    throw new Error(`Refusing to reset analytics without --confirm ${confirmationPhrase}`);
+  }
+
+  return parsed;
+};
+
+const wranglerConfigPath = (rootDir: string): string => (
+  path.join(rootDir, 'analytics-worker', 'wrangler.toml')
+);
+
+const countSql = aggregateTables.map((tableName) => (
+  `SELECT '${tableName}' AS table_name, count(*) AS rows FROM ${tableName}`
+)).join('\nUNION ALL\n');
+
+const resetSql = [
+  'BEGIN TRANSACTION;',
+  ...aggregateTables.map((tableName) => `DELETE FROM ${tableName};`),
+  'COMMIT;',
+].join('\n');
+
+const wranglerArgsFor = (sql: string, options: ResetOptions): string[] => {
+  const rootDir = options.rootDir ?? path.join(__dirname, '..');
+  return [
+    '--config',
+    wranglerConfigPath(rootDir),
+    'd1',
+    'execute',
+    options.database,
+    '--remote',
+    '--json',
+    '--command',
+    sql,
+  ];
+};
+
+const isObject = (value: unknown): value is Record<string, unknown> => (
+  typeof value === 'object' && value !== null && !Array.isArray(value)
+);
+
+const rowsFromD1Json = (value: unknown): D1Row[] => {
+  if (Array.isArray(value)) {
+    if (
+      value.every(isObject)
+      && value.some((item) => (
+        Array.isArray(item.results)
+        || Array.isArray(item.result)
+        || item.success === false
+      ))
+    ) {
+      return value.flatMap((item) => rowsFromD1Json(item));
+    }
+    return value.filter(isObject);
+  }
+  if (!isObject(value)) {
+    return [];
+  }
+  if (value.success === false) {
+    throw new Error('Wrangler D1 query failed');
+  }
+  if (Array.isArray(value.results)) {
+    return value.results.filter(isObject);
+  }
+  if (Array.isArray(value.result)) {
+    return rowsFromD1Json(value.result);
+  }
+  return [];
+};
+
+const parseD1Json = (stdout: string): D1Row[] => {
+  try {
+    return rowsFromD1Json(JSON.parse(stdout));
+  } catch (error) {
+    if (error instanceof SyntaxError) {
+      throw new Error('Wrangler returned invalid JSON');
+    }
+    throw error;
+  }
+};
+
+const runWrangler = (
+  sql: string,
+  options: ResetOptions,
+  spawnRunner: SpawnRunner = spawnSync,
+): D1Row[] => {
+  const rootDir = options.rootDir ?? path.join(__dirname, '..');
+  const configPath = wranglerConfigPath(rootDir);
+  if (!fs.existsSync(configPath)) {
+    throw new Error([
+      `Missing analytics Worker config: ${configPath}`,
+      'Copy analytics-worker/wrangler.toml.example to analytics-worker/wrangler.toml,',
+      'fill in the D1 database_id, and make sure Wrangler is authenticated.',
+    ].join('\n'));
+  }
+
+  const wranglerArgs = wranglerArgsFor(sql, options);
+  let result = spawnRunner('wrangler', wranglerArgs, {
+    cwd: rootDir,
+    encoding: 'utf8',
+  });
+
+  if (result.error && 'code' in result.error && result.error.code === 'ENOENT') {
+    result = spawnRunner('npx', ['wrangler', ...wranglerArgs], {
+      cwd: rootDir,
+      encoding: 'utf8',
+    });
+  }
+
+  if (result.error) {
+    throw result.error;
+  }
+  if (result.status !== 0) {
+    const message = result.stderr.trim() || result.stdout.trim() || 'Wrangler D1 query failed';
+    throw new Error(message);
+  }
+
+  return parseD1Json(result.stdout);
+};
+
+const numberValue = (value: unknown): number => (
+  typeof value === 'number' && Number.isFinite(value) ? value : Number(value) || 0
+);
+
+const stringValue = (value: unknown): string => (
+  typeof value === 'string' && value.length > 0 ? value : 'unknown'
+);
+
+const formatCounts = (rows: D1Row[]): string => {
+  const counts = new Map(rows.map((row) => [
+    stringValue(row.table_name),
+    numberValue(row.rows),
+  ]));
+  return aggregateTables
+    .map((tableName) => `${tableName}: ${counts.get(tableName) ?? 0}`)
+    .join('\n');
+};
+
+const resetAnalytics = (options: ResetOptions, runner: D1Runner = runWrangler): string => {
+  const beforeRows = runner(countSql, options);
+  if (options.dryRun) {
+    return [
+      'Analytics aggregate rows',
+      formatCounts(beforeRows),
+      '',
+    ].join('\n');
+  }
+
+  runner(resetSql, options);
+  const afterRows = runner(countSql, options);
+  return [
+    'Analytics aggregate rows before reset',
+    formatCounts(beforeRows),
+    '',
+    'Analytics aggregate rows after reset',
+    formatCounts(afterRows),
+    '',
+  ].join('\n');
+};
+
+const runCli = (args = process.argv.slice(2)): number => {
+  try {
+    const options = parseArgs(args);
+    if (options.help) {
+      process.stdout.write(`${usage}\n`);
+      return 0;
+    }
+    process.stdout.write(resetAnalytics(options));
+    return 0;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    process.stderr.write(`analytics reset: ${message}\n`);
+    return 1;
+  }
+};
+
+if (require.main === module) {
+  process.exitCode = runCli();
+}
+
+module.exports = {
+  aggregateTables,
+  confirmationPhrase,
+  countSql,
+  defaultDatabase,
+  parseArgs,
+  parseD1Json,
+  resetAnalytics,
+  resetSql,
+  runCli,
+  runWrangler,
+  usage,
+  wranglerArgsFor,
+};

--- a/analytics-worker/reset.ts
+++ b/analytics-worker/reset.ts
@@ -29,8 +29,8 @@ const aggregateTables = [
 ] as const;
 
 const usage = [
-  'Usage: npm run analytics:reset -- --dry-run [--database NAME]',
-  `       npm run analytics:reset -- --confirm ${confirmationPhrase} [--database NAME]`,
+  'Usage: node analytics-worker/reset.ts --dry-run [--database NAME]',
+  `       node analytics-worker/reset.ts --confirm ${confirmationPhrase} [--database NAME]`,
   '',
   'Prints row counts or clears the production analytics aggregate tables.',
 ].join('\n');

--- a/docs/analytics-backend.md
+++ b/docs/analytics-backend.md
@@ -69,6 +69,41 @@ telemetry fields or report feature-level events, command arguments, local paths,
 Gist details, package/editor data, raw errors, environment variables,
 arbitrary config values, IPs, or raw install IDs.
 
+## Ballin 2 Command Baseline Reset
+
+For the Ballin 2 canonical CLI rename, the chosen cleanup path is a clean reset
+instead of mapping old `up` / `gu` rows into reports. This keeps analytics
+reports focused on the current `ballin <command>` model.
+
+The reset scope is the full aggregate schema:
+
+- `install_days`
+- `command_events_daily`
+- `version_events_daily`
+
+There is no raw event table to preserve or delete.
+
+Preview production row counts:
+
+```shell
+npm run analytics:reset -- --dry-run
+```
+
+Clear production aggregate rows:
+
+```shell
+npm run analytics:reset -- --confirm RESET_ANALYTICS_AFTER_CLI_RENAME
+```
+
+Confirm the canonical baseline after reset:
+
+```shell
+npm run analytics:report
+```
+
+Production reset date: not yet performed. After the production reset runs,
+record the UTC date here with a short operator note.
+
 ## Abuse Controls
 
 The skeleton requires an ingest token before accepting events, rejects oversized

--- a/docs/analytics-backend.md
+++ b/docs/analytics-backend.md
@@ -69,11 +69,12 @@ telemetry fields or report feature-level events, command arguments, local paths,
 Gist details, package/editor data, raw errors, environment variables,
 arbitrary config values, IPs, or raw install IDs.
 
-## Ballin 2 Command Baseline Reset
+## Resetting Aggregates
 
-For the Ballin 2 canonical CLI rename, the chosen cleanup path is a clean reset
-instead of mapping old `up` / `gu` rows into reports. This keeps analytics
-reports focused on the current `ballin <command>` model.
+Use `npm run analytics:reset` when production analytics should start from a
+fresh reporting baseline. The first expected use is the Ballin 2 canonical CLI
+rename, where the chosen cleanup path is a clean reset instead of mapping old
+`up` / `gu` rows into reports.
 
 The reset scope is the full aggregate schema:
 
@@ -92,17 +93,14 @@ npm run analytics:reset -- --dry-run
 Clear production aggregate rows:
 
 ```shell
-npm run analytics:reset -- --confirm RESET_ANALYTICS_AFTER_CLI_RENAME
+npm run analytics:reset -- --confirm RESET_ANALYTICS_AGGREGATES
 ```
 
-Confirm the canonical baseline after reset:
+Confirm the fresh reporting baseline after reset:
 
 ```shell
 npm run analytics:report
 ```
-
-Production reset date: not yet performed. After the production reset runs,
-record the UTC date here with a short operator note.
 
 ## Abuse Controls
 

--- a/docs/analytics-backend.md
+++ b/docs/analytics-backend.md
@@ -73,10 +73,11 @@ arbitrary config values, IPs, or raw install IDs.
 
 ## Resetting Aggregates
 
-Use `npm run analytics:reset` when production analytics should start from a
-fresh reporting baseline. The first expected use is the Ballin 2 canonical CLI
-rename, where the chosen cleanup path is a clean reset instead of mapping old
-`up` / `gu` rows into reports.
+Use `analytics-worker/reset.ts` when production analytics should start from a
+fresh reporting baseline. It is a rare maintenance utility, not a normal
+project workflow. The first expected use is the Ballin 2 canonical CLI rename,
+where the chosen cleanup path is a clean reset instead of mapping old `up` /
+`gu` rows into reports.
 
 The reset scope is the full aggregate schema:
 
@@ -89,13 +90,13 @@ There is no raw event table to preserve or delete.
 Preview production row counts:
 
 ```shell
-npm run analytics:reset -- --dry-run
+node analytics-worker/reset.ts --dry-run
 ```
 
 Clear production aggregate rows:
 
 ```shell
-npm run analytics:reset -- --confirm RESET_ANALYTICS_AGGREGATES
+node analytics-worker/reset.ts --confirm RESET_ANALYTICS_AGGREGATES
 ```
 
 Confirm the fresh reporting baseline after reset:

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -11,7 +11,13 @@ const jsRules = {
   ...js.configs.recommended.rules,
   'no-console': 'error',
 };
-const tsFiles = ['analytics-worker/report.ts', 'commands/**/*.ts', 'config/**/*.ts', 'test/**/*.ts'];
+const tsFiles = [
+  'analytics-worker/report.ts',
+  'analytics-worker/reset.ts',
+  'commands/**/*.ts',
+  'config/**/*.ts',
+  'test/**/*.ts',
+];
 
 export default tseslint.config(
   {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "lint": "eslint .",
     "analytics:report": "node analytics-worker/report.ts",
-    "analytics:reset": "node analytics-worker/reset.ts",
     "typecheck": "tsc --noEmit",
     "typecheck:analytics-worker": "tsc --noEmit --strict --target ES2023 --module ESNext --lib ES2023,WebWorker --ignoreConfig analytics-worker/src/index.ts",
     "test:unit": "mocha",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "lint": "eslint .",
     "analytics:report": "node analytics-worker/report.ts",
+    "analytics:reset": "node analytics-worker/reset.ts",
     "typecheck": "tsc --noEmit",
     "typecheck:analytics-worker": "tsc --noEmit --strict --target ES2023 --module ESNext --lib ES2023,WebWorker --ignoreConfig analytics-worker/src/index.ts",
     "test:unit": "mocha",

--- a/test/analytics_reset.test.ts
+++ b/test/analytics_reset.test.ts
@@ -1,0 +1,193 @@
+const { assert } = require('chai');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const {
+  aggregateTables,
+  confirmationPhrase,
+  countSql,
+  defaultDatabase,
+  parseArgs,
+  resetAnalytics,
+  resetSql,
+  runWrangler,
+  wranglerArgsFor,
+} = require('../analytics-worker/reset.ts');
+
+type D1Row = Record<string, unknown>;
+type SpawnCall = {
+  args: string[];
+  command: string;
+};
+
+const d1Success = (rows: D1Row[] = []) => ({
+  error: undefined,
+  output: [],
+  pid: 1,
+  signal: null,
+  status: 0,
+  stderr: '',
+  stdout: JSON.stringify([{ results: rows, success: true }]),
+});
+
+describe('analytics D1 reset', () => {
+  it('parses dry-run, confirmation, and custom database options', () => {
+    assert.deepEqual(parseArgs(['--dry-run']), {
+      database: defaultDatabase,
+      dryRun: true,
+      help: false,
+    });
+
+    assert.deepEqual(parseArgs([
+      '--confirm',
+      confirmationPhrase,
+      '--database',
+      'custom-db',
+    ]), {
+      confirm: confirmationPhrase,
+      database: 'custom-db',
+      dryRun: false,
+      help: false,
+    });
+  });
+
+  it('requires explicit confirmation before deleting analytics aggregates', () => {
+    assert.throws(() => parseArgs([]), `Refusing to reset analytics without --confirm ${confirmationPhrase}`);
+    assert.throws(() => parseArgs(['--confirm', 'DELETE']), `Refusing to reset analytics without --confirm ${confirmationPhrase}`);
+    assert.throws(() => parseArgs(['--dry-run', '--confirm', confirmationPhrase]), 'Choose either --dry-run or --confirm, not both');
+  });
+
+  it('rejects missing option values and unknown options', () => {
+    assert.throws(() => parseArgs(['--database']), '--database requires a value');
+    assert.throws(() => parseArgs(['--confirm']), '--confirm requires a value');
+    assert.throws(() => parseArgs(['--dry-run', '--unknown']), 'Unknown analytics reset option: --unknown');
+  });
+
+  it('prints help without requiring dry-run or confirmation', () => {
+    assert.deepEqual(parseArgs(['--help']), {
+      database: defaultDatabase,
+      dryRun: false,
+      help: true,
+    });
+  });
+
+  it('prints aggregate counts without deleting during dry-run', () => {
+    const sqlStatements: string[] = [];
+    const output = resetAnalytics({
+      database: defaultDatabase,
+      dryRun: true,
+      help: false,
+    }, (sql: string): D1Row[] => {
+      sqlStatements.push(sql);
+      return [
+        { rows: 2, table_name: 'install_days' },
+        { rows: 3, table_name: 'command_events_daily' },
+        { rows: 4, table_name: 'version_events_daily' },
+      ];
+    });
+
+    assert.deepEqual(sqlStatements, [countSql]);
+    assert.include(output, 'Analytics aggregate rows');
+    assert.include(output, 'install_days: 2');
+    assert.include(output, 'command_events_daily: 3');
+    assert.include(output, 'version_events_daily: 4');
+  });
+
+  it('deletes only the known aggregate tables after confirmation', () => {
+    const sqlStatements: string[] = [];
+    const output = resetAnalytics({
+      confirm: confirmationPhrase,
+      database: defaultDatabase,
+      dryRun: false,
+      help: false,
+    }, (sql: string): D1Row[] => {
+      sqlStatements.push(sql);
+      if (sql === countSql && sqlStatements.length === 1) {
+        return [
+          { rows: 2, table_name: 'install_days' },
+          { rows: 3, table_name: 'command_events_daily' },
+          { rows: 4, table_name: 'version_events_daily' },
+        ];
+      }
+      return aggregateTables.map((tableName: string) => ({
+        rows: 0,
+        table_name: tableName,
+      }));
+    });
+
+    assert.deepEqual(sqlStatements, [countSql, resetSql, countSql]);
+    assert.include(resetSql, 'DELETE FROM install_days;');
+    assert.include(resetSql, 'DELETE FROM command_events_daily;');
+    assert.include(resetSql, 'DELETE FROM version_events_daily;');
+    assert.notMatch(resetSql, /\bDROP\b/i);
+    assert.include(output, 'Analytics aggregate rows before reset');
+    assert.include(output, 'install_days: 2');
+    assert.include(output, 'Analytics aggregate rows after reset');
+    assert.include(output, 'version_events_daily: 0');
+  });
+
+  it('builds remote JSON Wrangler D1 execute arguments', () => {
+    const args = wranglerArgsFor('SELECT 1', {
+      database: 'example-db',
+      dryRun: true,
+      help: false,
+      rootDir: '/repo',
+    });
+
+    assert.deepEqual(args, [
+      '--config',
+      '/repo/analytics-worker/wrangler.toml',
+      'd1',
+      'execute',
+      'example-db',
+      '--remote',
+      '--json',
+      '--command',
+      'SELECT 1',
+    ]);
+  });
+
+  it('explains the required local Wrangler config before running commands', () => {
+    const calls: SpawnCall[] = [];
+
+    assert.throws(() => {
+      runWrangler('SELECT 1', {
+        database: defaultDatabase,
+        dryRun: true,
+        help: false,
+        rootDir: '/repo',
+      }, (command: string, args: string[]) => {
+        calls.push({ args, command });
+        return d1Success();
+      });
+    }, 'Missing analytics Worker config: /repo/analytics-worker/wrangler.toml');
+
+    assert.deepEqual(calls, []);
+  });
+
+  it('falls back to npx wrangler when wrangler is unavailable', () => {
+    const calls: SpawnCall[] = [];
+    const rootDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ballin-analytics-reset-'));
+    fs.mkdirSync(path.join(rootDir, 'analytics-worker'));
+    fs.writeFileSync(path.join(rootDir, 'analytics-worker', 'wrangler.toml'), '');
+
+    const rows = runWrangler('SELECT 1', {
+      database: defaultDatabase,
+      dryRun: true,
+      help: false,
+      rootDir,
+    }, (command: string, args: string[]) => {
+      calls.push({ args, command });
+      if (command === 'wrangler') {
+        return {
+          ...d1Success(),
+          error: Object.assign(new Error('missing wrangler'), { code: 'ENOENT' }),
+        };
+      }
+      return d1Success([{ rows: 1, table_name: 'install_days' }]);
+    });
+
+    assert.deepEqual(calls.map((call) => call.command), ['wrangler', 'npx']);
+    assert.deepEqual(rows, [{ rows: 1, table_name: 'install_days' }]);
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,6 +15,7 @@
   },
   "include": [
     "analytics-worker/report.ts",
+    "analytics-worker/reset.ts",
     "commands/**/*.ts",
     "config/**/*.ts",
     "test/**/*.ts"


### PR DESCRIPTION
## Summary

Refs #227.

- Adds `analytics-worker/reset.ts` as a guarded rare-maintenance utility for starting analytics aggregates from a fresh reporting baseline.
- Keeps the reset off the package-level npm script surface; operators call it directly with `node analytics-worker/reset.ts`.
- Supports a safe dry run for aggregate row counts and requires `--confirm RESET_ANALYTICS_AGGREGATES` before deleting rows.
- Documents the Ballin 2 CLI rename as the first expected use case, while keeping the reset utility reusable for future aggregate resets.

## Validation

- `npm test` (`276 passing`)
- `node analytics-worker/reset.ts --help`
- `node analytics-worker/reset.ts --dry-run` (confirmed it stops before Wrangler when local `analytics-worker/wrangler.toml` is missing)

## Scope notes

- The production D1 reset was not run; issue #227 should stay open until the reset is run and the post-reset report is verified.
- The reset scope is the existing aggregate tables only: `install_days`, `command_events_daily`, and `version_events_daily`.
- No analytics payload fields, Worker ingest behavior, or command allowlists changed.