### PR TITLE
Document Ballin design system

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -3,7 +3,7 @@
 Start here when setting up or auditing what `ballin-scripts` manages.
 
 - [Design system](design-system.md): Ballin identity, product messaging,
-  visual guidance, and brand asset conventions.
+  visual guidance, and brand source/export conventions.
 - [Optional capabilities](optional-capabilities.md): Node.js setup, optional
   tool setup, analytics opt-out, and configurable `ballin update` settings.
 - [Analytics](analytics.md): analytics consent, payload, opt-out, and retention.

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,6 +2,8 @@
 
 Start here when setting up or auditing what `ballin-scripts` manages.
 
+- [Design system](design-system.md): Ballin identity, product messaging,
+  visual guidance, and brand asset conventions.
 - [Optional capabilities](optional-capabilities.md): Node.js setup, optional
   tool setup, analytics opt-out, and configurable `ballin update` settings.
 - [Analytics](analytics.md): analytics consent, payload, opt-out, and retention.

--- a/docs/README.md
+++ b/docs/README.md
@@ -3,7 +3,7 @@
 Start here when setting up or auditing what `ballin-scripts` manages.
 
 - [Design system](design-system.md): Ballin identity, product messaging,
-  visual guidance, and brand source/export conventions.
+  visual guidance, and brand asset conventions.
 - [Optional capabilities](optional-capabilities.md): Node.js setup, optional
   tool setup, analytics opt-out, and configurable `ballin update` settings.
 - [Analytics](analytics.md): analytics consent, payload, opt-out, and retention.

--- a/docs/assets/brand/README.md
+++ b/docs/assets/brand/README.md
@@ -1,24 +1,25 @@
 # Brand assets
 
-This folder stores editable brand sources and exported assets for Ballin.
+This folder stores editable brand source files and generated image files for
+Ballin.
 Use the [design system](../../design-system.md) for product identity, messaging,
 visual principles, and copy guidance. This README only documents the assets in
-this folder and the steps for refreshing exports.
+this folder and the steps for regenerating image files from editable sources.
 
 ## GitHub social preview
 
 - Source: `social-preview.svg`
-- Export: `social-preview.png`
+- Generated image: `social-preview.png`
 - Size: `1280x640`
 - Primary identity: lowercase `ballin`
 - Supporting copy: `Back up your dotfiles and update your macOS development environment`
 
 Keep the SVG editable. Treat the PNG as the GitHub upload artifact.
 
-The social preview follows the wordmark-led direction from issue #196. README
-hero work in issue #193 can reuse the matte graphite background, off-white type,
-and subtle green accent without adding a larger brand kit yet.
+The social preview follows the wordmark-led direction documented in the design
+system. README hero work can reuse the matte graphite background, off-white
+type, and subtle green accent without adding a larger brand kit.
 
-When refreshing the export, render the SVG at exactly `1280x640` and overwrite
-`social-preview.png`. Avoid thumbnail exporters that pad or crop the source
+When refreshing the PNG, render the SVG at exactly `1280x640` and overwrite
+`social-preview.png`. Avoid thumbnail rendering tools that pad or crop the source
 artwork.

--- a/docs/assets/brand/README.md
+++ b/docs/assets/brand/README.md
@@ -1,6 +1,8 @@
 # Brand assets
 
 This folder stores editable brand sources and exported assets for Ballin.
+Use the [design system](../../design-system.md) for product identity, messaging,
+visual principles, and copy guidance. Use this file for source/export mechanics.
 
 ## GitHub social preview
 

--- a/docs/assets/brand/README.md
+++ b/docs/assets/brand/README.md
@@ -2,7 +2,8 @@
 
 This folder stores editable brand sources and exported assets for Ballin.
 Use the [design system](../../design-system.md) for product identity, messaging,
-visual principles, and copy guidance. Use this file for source/export mechanics.
+visual principles, and copy guidance. This file only documents the files in this
+folder and how to refresh exported assets.
 
 ## GitHub social preview
 

--- a/docs/assets/brand/README.md
+++ b/docs/assets/brand/README.md
@@ -17,8 +17,8 @@ this folder and the steps for regenerating image files from editable sources.
 Keep the SVG editable. Treat the PNG as the GitHub upload artifact.
 
 The social preview follows the wordmark-led direction documented in the design
-system. README hero work can reuse the matte graphite background, off-white
-type, and subtle green accent without adding a larger brand kit.
+system. README hero assets use the same identity system, including matte
+graphite backgrounds, off-white type, and subtle green accents.
 
 When refreshing the PNG, render the SVG at exactly `1280x640` and overwrite
 `social-preview.png`. Avoid thumbnail rendering tools that pad or crop the source

--- a/docs/assets/brand/README.md
+++ b/docs/assets/brand/README.md
@@ -2,8 +2,8 @@
 
 This folder stores editable brand sources and exported assets for Ballin.
 Use the [design system](../../design-system.md) for product identity, messaging,
-visual principles, and copy guidance. This file only documents the files in this
-folder and how to refresh exported assets.
+visual principles, and copy guidance. This README only documents the assets in
+this folder and the steps for refreshing exports.
 
 ## GitHub social preview
 

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -5,12 +5,16 @@ messaging, visual direction, and brand asset guidance. It is meant to guide
 future README, docs, CLI help, social preview, hero, website, and profile copy
 work without reopening broad visual exploration.
 
-Use this document to decide what Ballin should say and feel like. Use the
-downstream issue for each surface to decide how that guidance gets applied:
+Use this document to decide what Ballin should say and feel like. README,
+CLI help, brand assets, website copy, and profile copy should apply this
+guidance while preserving the job of each surface:
 
-- README onboarding and install flow: issue #219
-- README hero/banner asset: issue #193
-- Restore, replay, and bootstrap language: issue #197
+- README onboarding and install flow should prioritize practical first-run
+  clarity.
+- README hero/banner assets should prioritize legitimacy, trust, and workflow
+  fit.
+- Restore, replay, and bootstrap language should stay conservative until those
+  capabilities exist.
 
 ## Naming
 
@@ -143,14 +147,12 @@ Different assets have different jobs:
 - README and docs: explanation. Detailed product behavior belongs in text, not
   inside image assets.
 
-The current social preview is the completed identity-first asset. The README
-hero remains future work and should consume this guidance rather than reopen
-the full design exploration.
+The social preview is the identity-first asset. README hero work should consume
+this guidance rather than reopen broad visual exploration.
 
-README onboarding and top-copy improvements remain separate from this asset
-hierarchy. Issue #219 should use the copy system here when evaluating whether to
-adjust the README opening, prerequisites, installation wording, documentation
-links, or troubleshooting pointers.
+README onboarding and top-copy changes should use the copy system here when
+evaluating the README opening, prerequisites, installation wording,
+documentation links, or troubleshooting pointers.
 
 ## README hero guidance
 
@@ -194,9 +196,9 @@ from the hero.
 
 If removing the strip makes the hero calmer and stronger, remove it.
 
-## Source and export conventions
+## Source and generated image conventions
 
-Editable sources and exported brand assets live under:
+Editable source files and generated brand images live under:
 
 ```text
 docs/assets/brand/
@@ -217,8 +219,9 @@ docs/assets/brand/readme-hero.png
 ```
 
 Treat editable source files as canonical. Treat PNGs as generated, shareable,
-or upload-ready exports. Keep asset file lists and export steps in
-`docs/assets/brand/README.md`; keep identity and copy guidance here.
+or upload-ready images derived from those sources. Keep asset file lists and
+regeneration steps in `docs/assets/brand/README.md`; keep identity and copy
+guidance here.
 
 ## Claim guardrails
 

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -5,6 +5,13 @@ messaging, visual direction, and brand asset guidance. It is meant to guide
 future README, docs, CLI help, social preview, hero, website, and profile-copy
 work without reopening broad visual exploration.
 
+Use this document to decide what Ballin should say and feel like. Use downstream
+issues to decide how a specific surface should apply it:
+
+- README onboarding and install flow: issue #219
+- README hero/banner asset: issue #193
+- Restore, replay, and bootstrap language: issue #197
+
 ## Naming
 
 - Repository and package identity: `ballin-scripts`
@@ -41,10 +48,23 @@ Canonical copy:
 - Product truth: `Ballin keeps a macOS development environment backed up and current.`
 - Capability tagline: `Back up your dotfiles and update your macOS development environment.`
 - Short hero line: `Back up dotfiles. Keep your tools current.`
+- Elevator pitch: Ballin backs up development-environment state and automates
+  routine macOS developer-tool updates.
 
 The capability tagline is currently used by the `ballin` help/overview output.
 Treat CLI help as a downstream product surface that should stay aligned with
 this document.
+
+Surface guidance:
+
+- CLI help/overview should make the product purpose clear before listing
+  commands.
+- README opening copy should apply the product truth while adding enough
+  implementation detail for first-time readers.
+- README onboarding work should prefer practical clarity, such as prerequisites
+  and install expectations, over a more promotional tagline.
+- Resume, LinkedIn, website, blog, and talk descriptions should derive from the
+  product truth rather than introducing a new position.
 
 Broader explanatory copy can discuss repeatable rebuilds and auditable setup
 with nuance. Visual assets and short hero copy should stay concrete and avoid
@@ -57,6 +77,28 @@ Useful product/help-output candidates that are not canonical yet:
 
 Do not promote these candidates without intentionally updating the relevant
 downstream surfaces.
+
+## Voice
+
+Ballin copy should be direct, concrete, and calm. Prefer plain capability
+language over marketing claims. Explain benefits through what the tool actually
+does: backing up development-environment state, automating routine updates, and
+making rebuilds more repeatable and auditable.
+
+Prefer:
+
+- backed up and current
+- private backups
+- routine updates
+- Ballin-managed environment
+- repeatable and auditable, when there is room for nuance
+
+Avoid:
+
+- hype-first claims
+- vague "magic" language
+- "sync" language that implies cross-device or bidirectional behavior
+- restore/replay language before that behavior exists
 
 ## Visual identity
 
@@ -104,6 +146,11 @@ Different assets have different jobs:
 The current social preview is the completed identity-first asset. The README
 hero remains future work and should consume this guidance rather than reopen
 the full design exploration.
+
+README onboarding and top-copy improvements remain separate from this asset
+hierarchy. Issue #219 should use the copy system here when evaluating whether to
+adjust the README opening, prerequisites, installation wording, documentation
+links, or troubleshooting pointers.
 
 ## README hero guidance
 

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -74,7 +74,7 @@ Broader explanatory copy can discuss repeatable rebuilds and auditable setup
 with nuance. Visual assets and short hero copy should stay concrete and avoid
 future-state restore claims.
 
-Useful product/help-output candidates that are not canonical yet:
+Non-canonical product/help-output candidates:
 
 - `Keep your macOS development environment backed up and current.`
 - `Preserve, update, and verify your macOS development environment.`
@@ -133,7 +133,7 @@ Avoid:
 - workflow diagrams and architecture illustrations as primary visuals
 - generic SaaS visuals
 - feature overload
-- Apple hardware advertising
+- Apple hardware advertising or product-glamour-shot compositions
 - mascot-first branding
 
 ## Asset hierarchy
@@ -143,7 +143,7 @@ Different assets have different jobs:
 - Social preview: recognition and first impression. Keep it simple, polished,
   and identity-first.
 - README hero: legitimacy, trust, and workflow fit. It can be more atmospheric
-  than the social preview, but should remain quiet and documentation-supporting.
+  than the social preview, but should be quieter and support the documentation.
 - README and docs: explanation. Detailed product behavior belongs in text, not
   inside image assets.
 
@@ -160,6 +160,9 @@ The README hero should optimize for the feeling that a macOS development
 environment is quietly handled and ready to work in. Copy explains what Ballin
 does; the visual should create trust, atmosphere, and workflow fit.
 
+The README hero supports the written README. It should not replace the README's
+explanation or try to show Ballin's internal product state.
+
 A calm macOS developer workspace is an appropriate direction because Ballin is
 macOS-specific. The failure mode is making Apple hardware the hero instead of
 Ballin.
@@ -169,8 +172,12 @@ If workspace imagery is used:
 - keep Ballin as the identity anchor
 - use macOS developer cues as context, not as product advertising
 - avoid cluttered desk scenes
-- avoid fake UI, dashboards, status cards, or workflow diagrams
+- avoid raw CLI output, fake UI, dashboards, status cards, checklists, or
+  workflow diagrams
 - avoid dense terminal screenshots and feature overload
+- avoid command-name-centered artwork
+- avoid literal product-state cards such as "development environment under
+  control"
 - avoid making a symbolic object the focal point if it competes with the
   wordmark or makes the viewer ask what the object is
 
@@ -218,6 +225,8 @@ docs/assets/brand/readme-hero.svg
 docs/assets/brand/readme-hero.png
 ```
 
+README hero images should use a wide `1600x400` format.
+
 Treat editable source files as canonical. Treat PNGs as generated, shareable,
 or upload-ready images derived from those sources. Keep asset file lists and
 regeneration steps in `docs/assets/brand/README.md`; keep identity and copy
@@ -238,8 +247,8 @@ Avoid short copy or visuals that imply:
 - universal reproducibility
 - automatic restore/replay behavior that does not exist yet
 
-Future restore, replay, or bootstrap capabilities should be documented only
-after the product supports them, and short brand copy should remain more
+Restore, replay, or bootstrap capabilities belong in short brand copy only
+after the product supports them. Short brand copy should remain more
 conservative than long-form docs.
 
 ## Rejected and non-canonical directions
@@ -253,7 +262,7 @@ identity without a new decision:
 - fake dashboards or fake product UI
 - workflow diagrams and architecture illustrations
 - abstract maintenance objects as the core identity
-- symbolic focal objects that compete with `>_ ballin`
+- symbolic focal objects that compete with the Ballin identity
 - mascot-first branding
 - feature-heavy hero graphics
 - generated identicon/avatar systems as the primary brand

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -24,6 +24,10 @@ guidance while preserving the job of each surface:
 - Primary visual wordmark: lowercase `ballin`
 - Signature/contextual lockup: `>_ ballin`
 
+For repository-specific assets, `>_ ballin-scripts` may be used when the asset
+is explicitly representing the repository or package rather than the product
+identity alone.
+
 Use Ballin for user-facing product language. Use `ballin-scripts` when precision
 matters for the repository, package, local checkout, install paths, or
 self-update behavior.
@@ -43,8 +47,7 @@ Brand principles
   -> Tagline
   -> Elevator pitch
   -> README opening
-  -> Resume / LinkedIn
-  -> Website / blog / talks
+  -> Profiles / website / talks
 ```
 
 Canonical copy:
@@ -67,8 +70,8 @@ Surface guidance:
   implementation detail for first-time readers.
 - README onboarding should prefer practical clarity, such as prerequisites
   and install expectations, over a more promotional tagline.
-- Resume, LinkedIn, website, blog, and talk descriptions should derive from the
-  product truth rather than introducing a new position.
+- Profile, website, blog, and talk descriptions should derive from the product
+  truth rather than introducing a new position.
 
 Broader explanatory copy can discuss repeatable rebuilds and auditable setup
 with nuance. Visual assets and short hero copy should stay concrete and avoid
@@ -79,8 +82,9 @@ Non-canonical product/help-output candidates:
 - `Keep your macOS development environment backed up and current.`
 - `Preserve, update, and verify your macOS development environment.`
 
-Do not promote these candidates without intentionally updating the relevant
-downstream surfaces.
+Keep these available for copy review, but do not promote them without
+intentionally updating the relevant downstream surfaces. The current capability
+tagline remains more concrete and action-oriented.
 
 ## Voice
 
@@ -225,12 +229,23 @@ docs/assets/brand/readme-hero.svg
 docs/assets/brand/readme-hero.png
 ```
 
-README hero images should use a wide `1600x400` format.
+README hero images should use a wide format. The current default target is
+`1600x400` unless a surface requires a different aspect ratio.
 
 Treat editable source files as canonical. Treat PNGs as generated, shareable,
 or upload-ready images derived from those sources. Keep asset file lists and
 regeneration steps in `docs/assets/brand/README.md`; keep identity and copy
 guidance here.
+
+## Accessibility and rendering
+
+Brand assets should remain readable in the contexts where they appear.
+
+- Use sufficient contrast for text and key visual elements.
+- Avoid relying on tiny text as the main design element.
+- Include useful alt text when adding README images.
+- Check README assets in GitHub rendering before merging.
+- Prefer simple compositions that still work when scaled down.
 
 ## Claim guardrails
 

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -2,7 +2,7 @@
 
 This document is the durable source of truth for Ballin identity, product
 messaging, visual direction, and brand asset guidance. It is meant to guide
-future README, docs, CLI help, social preview, hero, website, and profile copy
+README, docs, CLI help, social preview, hero, website, and profile copy
 work without reopening broad visual exploration.
 
 Use this document to decide what Ballin should say and feel like. README,
@@ -65,7 +65,7 @@ Surface guidance:
   commands.
 - README opening copy should apply the product truth while adding enough
   implementation detail for first-time readers.
-- README onboarding work should prefer practical clarity, such as prerequisites
+- README onboarding should prefer practical clarity, such as prerequisites
   and install expectations, over a more promotional tagline.
 - Resume, LinkedIn, website, blog, and talk descriptions should derive from the
   product truth rather than introducing a new position.
@@ -147,8 +147,8 @@ Different assets have different jobs:
 - README and docs: explanation. Detailed product behavior belongs in text, not
   inside image assets.
 
-The social preview is the identity-first asset. README hero work should consume
-this guidance rather than reopen broad visual exploration.
+The social preview is the identity-first asset. The README hero is informed by
+this guidance rather than broad visual exploration.
 
 README onboarding and top-copy changes should use the copy system here when
 evaluating the README opening, prerequisites, installation wording,
@@ -211,7 +211,7 @@ docs/assets/brand/social-preview.svg
 docs/assets/brand/social-preview.png
 ```
 
-Future README hero assets may use:
+README hero assets use the same folder:
 
 ```text
 docs/assets/brand/readme-hero.svg

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -2,11 +2,11 @@
 
 This document is the durable source of truth for Ballin identity, product
 messaging, visual direction, and brand asset guidance. It is meant to guide
-future README, docs, CLI help, social preview, hero, website, and profile-copy
+future README, docs, CLI help, social preview, hero, website, and profile copy
 work without reopening broad visual exploration.
 
-Use this document to decide what Ballin should say and feel like. Use downstream
-issues to decide how a specific surface should apply it:
+Use this document to decide what Ballin should say and feel like. Use the
+downstream issue for each surface to decide how that guidance gets applied:
 
 - README onboarding and install flow: issue #219
 - README hero/banner asset: issue #193
@@ -49,7 +49,7 @@ Canonical copy:
 - Capability tagline: `Back up your dotfiles and update your macOS development environment.`
 - Short hero line: `Back up dotfiles. Keep your tools current.`
 - Elevator pitch: Ballin backs up development-environment state and automates
-  routine macOS developer-tool updates.
+  routine updates for macOS developer tools.
 
 The capability tagline is currently used by the `ballin` help/overview output.
 Treat CLI help as a downstream product surface that should stay aligned with
@@ -217,7 +217,7 @@ docs/assets/brand/readme-hero.png
 ```
 
 Treat editable source files as canonical. Treat PNGs as generated, shareable,
-or upload-ready exports. Keep source/export mechanics in
+or upload-ready exports. Keep asset file lists and export steps in
 `docs/assets/brand/README.md`; keep identity and copy guidance here.
 
 ## Claim guardrails

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -1,0 +1,235 @@
+# Ballin design system
+
+This document is the durable source of truth for Ballin identity, product
+messaging, visual direction, and brand asset guidance. It is meant to guide
+future README, docs, CLI help, social preview, hero, website, and profile-copy
+work without reopening broad visual exploration.
+
+## Naming
+
+- Repository and package identity: `ballin-scripts`
+- Product name in prose: Ballin
+- CLI identity: `ballin`
+- Primary visual wordmark: lowercase `ballin`
+- Signature/contextual lockup: `>_ ballin`
+
+Use Ballin for user-facing product language. Use `ballin-scripts` when precision
+matters for the repository, package, local checkout, install paths, or
+self-update behavior.
+
+Prompt and cursor motifs are useful accents, but they do not need to appear in
+every asset. Avoid mascot-first, badge-first, or complex logo-first branding for
+now.
+
+## Copy system
+
+Downstream copy should derive from upstream guidance instead of inventing new
+positioning for each surface:
+
+```text
+Brand principles
+  -> Product truth
+  -> Tagline
+  -> Elevator pitch
+  -> README opening
+  -> Resume / LinkedIn
+  -> Website / blog / talks
+```
+
+Canonical copy:
+
+- Product truth: `Ballin keeps a macOS development environment backed up and current.`
+- Capability tagline: `Back up your dotfiles and update your macOS development environment.`
+- Short hero line: `Back up dotfiles. Keep your tools current.`
+
+The capability tagline is currently used by the `ballin` help/overview output.
+Treat CLI help as a downstream product surface that should stay aligned with
+this document.
+
+Broader explanatory copy can discuss repeatable rebuilds and auditable setup
+with nuance. Visual assets and short hero copy should stay concrete and avoid
+future-state restore claims.
+
+Useful product/help-output candidates that are not canonical yet:
+
+- `Keep your macOS development environment backed up and current.`
+- `Preserve, update, and verify your macOS development environment.`
+
+Do not promote these candidates without intentionally updating the relevant
+downstream surfaces.
+
+## Visual identity
+
+Ballin should feel premium, calm, restrained, developer-native, macOS-first,
+quietly reliable, crafted, approachable, and technically serious.
+
+Prefer:
+
+- confidence over excitement
+- craftsmanship over marketing
+- clarity over cleverness
+- a wordmark-led identity
+- dark graphite or slate backgrounds
+- off-white typography
+- restrained green accents
+- generous negative space
+- subtle texture and premium material feel
+- terminal-inspired details, not terminal-dominated layouts
+
+The visual identity should feel closer to thoughtful macOS developer tooling
+than hacker, cyberpunk, or generic SaaS art.
+
+Avoid:
+
+- cyberpunk or neon overload
+- fake dashboards or fake product UI
+- dense terminal screenshots or help-output art
+- workflow diagrams and architecture illustrations as primary visuals
+- generic SaaS visuals
+- feature overload
+- Apple hardware advertising
+- mascot-first branding
+
+## Asset hierarchy
+
+Different assets have different jobs:
+
+- Social preview: recognition and first impression. Keep it simple, polished,
+  and identity-first.
+- README hero: legitimacy, trust, and workflow fit. It can be more atmospheric
+  than the social preview, but should remain quiet and documentation-supporting.
+- README and docs: explanation. Detailed product behavior belongs in text, not
+  inside image assets.
+
+The current social preview is the completed identity-first asset. The README
+hero remains future work and should consume this guidance rather than reopen
+the full design exploration.
+
+## README hero guidance
+
+The README hero should optimize for the feeling that a macOS development
+environment is quietly handled and ready to work in. Copy explains what Ballin
+does; the visual should create trust, atmosphere, and workflow fit.
+
+A calm macOS developer workspace is an appropriate direction because Ballin is
+macOS-specific. The failure mode is making Apple hardware the hero instead of
+Ballin.
+
+If workspace imagery is used:
+
+- keep Ballin as the identity anchor
+- use macOS developer cues as context, not as product advertising
+- avoid cluttered desk scenes
+- avoid fake UI, dashboards, status cards, or workflow diagrams
+- avoid dense terminal screenshots and feature overload
+- avoid making a symbolic object the focal point if it competes with the
+  wordmark or makes the viewer ask what the object is
+
+Do not include installation commands in README hero artwork.
+
+### Feature strips
+
+A README hero may include a very small feature strip if it improves the
+composition, but it is optional.
+
+If used, prefer short capability-level labels only. Avoid descriptions, install
+commands, or future-state claims.
+
+Preferred v1 labels:
+
+```text
+CLI first · Private backups · Routine updates · macOS native
+```
+
+Avoid labels such as `Always current`, `Restore-ready`, `Rebuild anywhere`, or
+`Install in 60 seconds` because they can overstate current behavior or distract
+from the hero.
+
+If removing the strip makes the hero calmer and stronger, remove it.
+
+## Source and export conventions
+
+Editable sources and exported brand assets live under:
+
+```text
+docs/assets/brand/
+```
+
+Current social preview assets:
+
+```text
+docs/assets/brand/social-preview.svg
+docs/assets/brand/social-preview.png
+```
+
+Future README hero assets may use:
+
+```text
+docs/assets/brand/readme-hero.svg
+docs/assets/brand/readme-hero.png
+```
+
+Treat editable source files as canonical. Treat PNGs as generated, shareable,
+or upload-ready exports. Keep source/export mechanics in
+`docs/assets/brand/README.md`; keep identity and copy guidance here.
+
+## Claim guardrails
+
+Ballin is currently a backup and update toolkit. It is not a full one-command
+machine restore system.
+
+Avoid short copy or visuals that imply:
+
+- one-click restore
+- recreate anywhere
+- same environment everywhere
+- full machine restore
+- restore everything
+- universal reproducibility
+- automatic restore/replay behavior that does not exist yet
+
+Future restore, replay, or bootstrap capabilities should be documented only
+after the product supports them, and short brand copy should remain more
+conservative than long-form docs.
+
+## Rejected and non-canonical directions
+
+These directions were useful exploration paths but should not become the core
+identity without a new decision:
+
+- "collection of scripts" positioning
+- cyberpunk terminal art
+- dense CLI help screenshots
+- fake dashboards or fake product UI
+- workflow diagrams and architecture illustrations
+- abstract maintenance objects as the core identity
+- symbolic focal objects that compete with `>_ ballin`
+- mascot-first branding
+- feature-heavy hero graphics
+- generated identicon/avatar systems as the primary brand
+- a top-level `BRAND.md`
+- `/assets` as the brand asset location
+- teal/cyan plus orange color tokens as the primary palette
+- a lowercase `b` mark as the primary identity
+- immediate generated favicon, avatar, or icon assets
+- generated exploration images as a committed archive
+
+The stable direction is calmer, more premium, more macOS-developer-native, and
+wordmark-led.
+
+## North star
+
+Optimize for this reaction:
+
+```text
+This feels like a premium macOS developer tool.
+```
+
+Not:
+
+```text
+This has impressive graphics.
+```
+
+Every design decision should reinforce the feeling that Ballin quietly handles
+development-environment maintenance so the developer can focus on building.


### PR DESCRIPTION
## Summary

Closes #217.
Closes #196.

- Adds docs/design-system.md as the canonical Ballin design, copy, voice, visual identity, asset, accessibility, and claim-guardrail reference.
- Codifies the stable wordmark-led visual identity direction from #196.
- Captures durable guidance for downstream surfaces, including README onboarding, README hero assets, CLI help, website/profile copy, and restore/replay language.
- Links the design system from docs/README.md.
- Points docs/assets/brand/README.md to the design system for identity and messaging guidance while keeping asset-file and generated-image instructions in the brand asset folder.

## Scope notes

- No README rewrite, CLI behavior/help changes, generated image additions, social preview changes, favicon/avatar/icon assets, or asset moves.
- README hero assets, social-preview reevaluation, compact-mark exploration, and README onboarding should consume this guidance in their own focused work.
- The permanent docs avoid issue-number/todo language and define stable guidance instead.
- The PR intentionally keeps the current concrete capability tagline.

## Validation

- Skipped local validation per docs-only repo instructions.
- Ran git diff --check for the docs diff.
- Verified ballin update / ballin backup are the current canonical command references in the repo.
- Manually reviewed the diff for link paths, issue-scope boundaries, downstream README guidance, concise/professional tone, evergreen wording, generated-image wording, accessibility guidance, and unsupported restore/replay claims.
- External review found no further requested edits.
- GitHub checks passed on the latest pushed commit.