### PR TITLE
Clarify README install expectations

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,12 +60,11 @@ and auditable.
 ## Before you install
 
 The installer is interactive and stops with setup guidance if something required
-is missing. A typical first run assumes macOS with Git, a supported Node.js,
-and GitHub CLI available for private backup Gist setup.
+is missing. A typical first run assumes macOS with Git, Node.js LTS, and
+GitHub CLI available for private backup Gist setup.
 
-Homebrew gives Ballin the standard command location and full `ballin update`
-Homebrew behavior. Without Homebrew, keep `~/.local/bin` on your shell `PATH`
-for installed commands.
+Homebrew is recommended for the standard command location and full
+`ballin update` Homebrew behavior.
 
 Optional integrations and setup tradeoffs are covered in the
 [optional capabilities guide](docs/optional-capabilities.md).

--- a/README.md
+++ b/README.md
@@ -60,8 +60,8 @@ and auditable.
 ## Before you install
 
 The installer is interactive and guides you through missing setup. Before
-running it, use macOS with Git installed, current Node.js LTS, authenticated
-GitHub CLI, and Homebrew available.
+running it, use macOS with current Node.js LTS, authenticated GitHub CLI, and
+Homebrew available.
 
 Optional integrations and setup tradeoffs are covered in the
 [optional capabilities guide](docs/optional-capabilities.md).

--- a/README.md
+++ b/README.md
@@ -57,6 +57,21 @@ This is currently a backup and update toolkit, not a full one-command
 machine restore system. The backed-up snapshots make rebuilds more repeatable
 and auditable.
 
+## Before you install
+
+The installer is interactive and stops with setup guidance if something required
+is missing. Before running it, expect to have:
+
+- macOS, a shell that can run the Bash installer, and Node.js available on your
+  shell `PATH`.
+- GitHub CLI installed and authenticated for the GitHub host that should hold
+  your private backup Gist.
+- Homebrew installed if you want the standard command location and full
+  `ballin update` Homebrew behavior.
+
+Optional integrations and setup tradeoffs are covered in the
+[optional capabilities guide](docs/optional-capabilities.md).
+
 ## Installation
 
 Install with:

--- a/README.md
+++ b/README.md
@@ -62,12 +62,13 @@ and auditable.
 The installer is interactive and stops with setup guidance if something required
 is missing. Before running it, expect to have:
 
-- macOS, a shell that can run the Bash installer, and Node.js available on your
-  shell `PATH`.
+- macOS, a shell that can run the Bash installer, and Git plus Node.js 24.12
+  or newer available on your shell `PATH`.
 - GitHub CLI installed and authenticated for the GitHub host that should hold
   your private backup Gist.
 - Homebrew installed if you want the standard command location and full
-  `ballin update` Homebrew behavior.
+  `ballin update` Homebrew behavior. Without Homebrew, `~/.local/bin` must
+  already be on your shell `PATH`.
 
 Optional integrations and setup tradeoffs are covered in the
 [optional capabilities guide](docs/optional-capabilities.md).

--- a/README.md
+++ b/README.md
@@ -59,9 +59,9 @@ and auditable.
 
 ## Before you install
 
-The installer is interactive and guides you through missing setup. Before
-running it, use macOS with current Node.js LTS, authenticated GitHub CLI, and
-Homebrew available.
+The installer is interactive and guides you through missing setup. For the
+smoothest first run, use macOS with current Node.js LTS, authenticated GitHub
+CLI, and Homebrew available.
 
 Optional integrations and setup tradeoffs are covered in the
 [optional capabilities guide](docs/optional-capabilities.md).

--- a/README.md
+++ b/README.md
@@ -59,9 +59,9 @@ and auditable.
 
 ## Before you install
 
-The installer is interactive and guides you through missing setup. For the
-smoothest first run, use macOS with Git, Node.js LTS, GitHub CLI, and Homebrew
-available.
+The installer is interactive and guides you through missing setup. Before
+running it, use macOS with Git installed, current Node.js LTS, authenticated
+GitHub CLI, and Homebrew available.
 
 Optional integrations and setup tradeoffs are covered in the
 [optional capabilities guide](docs/optional-capabilities.md).

--- a/README.md
+++ b/README.md
@@ -60,15 +60,13 @@ and auditable.
 ## Before you install
 
 The installer is interactive and stops with setup guidance if something required
-is missing. Before running it, expect to have:
+is missing. Before running it, have the main pieces ready:
 
-- macOS, a shell that can run the Bash installer, and Git plus Node.js 24.12
-  or newer available on your shell `PATH`.
-- GitHub CLI installed and authenticated for the GitHub host that should hold
-  your private backup Gist.
-- Homebrew installed if you want the standard command location and full
-  `ballin update` Homebrew behavior. Without Homebrew, `~/.local/bin` must
-  already be on your shell `PATH`.
+- macOS with Git and Node.js 24.12 or newer on your shell `PATH`.
+- GitHub CLI authenticated for the host that should hold your private backup
+  Gist.
+- Homebrew, unless you already keep `~/.local/bin` on your shell `PATH` for
+  installed commands.
 
 Optional integrations and setup tradeoffs are covered in the
 [optional capabilities guide](docs/optional-capabilities.md).

--- a/README.md
+++ b/README.md
@@ -59,12 +59,9 @@ and auditable.
 
 ## Before you install
 
-The installer is interactive and stops with setup guidance if something required
-is missing. A typical first run assumes macOS with Git, Node.js LTS, and
-GitHub CLI available for private backup Gist setup.
-
-Homebrew is recommended for the standard command location and full
-`ballin update` Homebrew behavior.
+The installer is interactive and guides you through missing setup. For the
+smoothest first run, use macOS with Git, Node.js LTS, GitHub CLI, and Homebrew
+available.
 
 Optional integrations and setup tradeoffs are covered in the
 [optional capabilities guide](docs/optional-capabilities.md).

--- a/README.md
+++ b/README.md
@@ -60,13 +60,12 @@ and auditable.
 ## Before you install
 
 The installer is interactive and stops with setup guidance if something required
-is missing. Before running it, have the main pieces ready:
+is missing. A typical first run assumes macOS with Git, a supported Node.js,
+and GitHub CLI available for private backup Gist setup.
 
-- macOS with Git and Node.js 24.12 or newer on your shell `PATH`.
-- GitHub CLI authenticated for the host that should hold your private backup
-  Gist.
-- Homebrew, unless you already keep `~/.local/bin` on your shell `PATH` for
-  installed commands.
+Homebrew gives Ballin the standard command location and full `ballin update`
+Homebrew behavior. Without Homebrew, keep `~/.local/bin` on your shell `PATH`
+for installed commands.
 
 Optional integrations and setup tradeoffs are covered in the
 [optional capabilities guide](docs/optional-capabilities.md).


### PR DESCRIPTION
## Summary

Closes #219.

- Adds a short "Before you install" heads-up before the README installer command.
- Calls out the happy-path setup: macOS, current Node.js LTS, authenticated GitHub CLI for private backup Gists, and Homebrew.
- Leaves the existing tagline, install command, command naming, CLI behavior, and broader README structure unchanged.

## Validation

- Skipped local tests per docs-only repo guidance.
- Ran `git diff --check`.
- Manually reviewed the README link, canonical `ballin update` naming, and copy guardrails around unsupported restore/replay or install-duration claims.
