### PR TITLE
Document compact mark guidance

### DIFF
--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -36,14 +36,12 @@ Prompt and cursor motifs are useful accents, but they do not need to appear in
 every asset. Avoid mascot-first, badge-first, or complex logo-first branding for
 now.
 
-Compact avatar, favicon, and icon-mark assets should wait until there is a real
-small-size consumer, such as a website favicon, docs-site icon, app icon,
-profile/avatar surface, or repeated square-mark use case. If a compact mark is
-needed later, start from a secondary custom mark derived from the wordmark-led
-system: likely a restrained lowercase `b` or `b_` cursor motif using the
-graphite, off-white, and green accent palette. The compact mark should identify
-Ballin only where the full wordmark does not fit; it should not replace or
-compete with the lowercase `ballin` wordmark.
+Compact avatar, favicon, and icon-mark assets should start from a secondary
+custom mark derived from the wordmark-led system: likely a restrained lowercase
+`b` or `b_` cursor motif using the graphite, off-white, and green accent
+palette. The compact mark should identify Ballin only where the full wordmark
+does not fit; it should not replace or compete with the lowercase `ballin`
+wordmark.
 
 ## Copy system
 

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -36,6 +36,15 @@ Prompt and cursor motifs are useful accents, but they do not need to appear in
 every asset. Avoid mascot-first, badge-first, or complex logo-first branding for
 now.
 
+Compact avatar, favicon, and icon-mark assets should wait until there is a real
+small-size consumer, such as a website favicon, docs-site icon, app icon,
+profile/avatar surface, or repeated square-mark use case. If a compact mark is
+needed later, start from a secondary custom mark derived from the wordmark-led
+system: likely a restrained lowercase `b` or `b_` cursor motif using the
+graphite, off-white, and green accent palette. The compact mark should identify
+Ballin only where the full wordmark does not fit; it should not replace or
+compete with the lowercase `ballin` wordmark.
+
 ## Copy system
 
 Downstream copy should derive from upstream guidance instead of inventing new


### PR DESCRIPTION
## Summary

- Adds a short design-system note for future compact avatar/favicon/icon-mark work.
- Documents that compact marks should wait for a real small-size consumer.
- Captures the preferred future direction: a secondary custom lowercase `b` or `b_` cursor motif that does not compete with the primary lowercase `ballin` wordmark.

## Validation

- Ran `git diff --check`.
- Skipped `npm test` because this is a docs-only change.