### PR TITLE
Check Git before installer preparation

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -17,6 +17,13 @@ if [ ! -d "$repo_dir" ]; then
   repo_existed=false
 fi
 
+if [ ! -x "$(command -v git)" ]; then
+  printf '\n⚠️  ERROR: Git is required before install can continue.\n'
+  printf '\nInstall Git or accept the macOS Command Line Tools setup prompt.'
+  printf '\nThen run this installer again.\n'
+  exit 1
+fi
+
 if ! (
   cd "$HOME" || exit
   if [ "$repo_existed" = false ]; then

--- a/install.sh
+++ b/install.sh
@@ -17,7 +17,7 @@ if [ ! -d "$repo_dir" ]; then
   repo_existed=false
 fi
 
-if [ ! -x "$(command -v git)" ]; then
+if ! command -v git >/dev/null 2>&1 || ! git --version >/dev/null 2>&1; then
   printf '\n⚠️  ERROR: Git is required before install can continue.\n'
   printf '\nInstall Git or accept the macOS Command Line Tools setup prompt.'
   printf '\nThen run this installer again.\n'

--- a/install.sh
+++ b/install.sh
@@ -19,8 +19,7 @@ fi
 
 if ! command -v git >/dev/null 2>&1 || ! git --version >/dev/null 2>&1; then
   printf '\n⚠️  ERROR: Git is required before install can continue.\n'
-  printf '\nInstall Git or accept the macOS Command Line Tools setup prompt.'
-  printf '\nThen run this installer again.\n'
+  printf '\nInstall Git, then run this installer again.\n'
   exit 1
 fi
 

--- a/test/install.test.ts
+++ b/test/install.test.ts
@@ -47,9 +47,12 @@ describe('install', () => {
 
   const installGitStub = () => {
     writeExecutable('git', `#!/usr/bin/env bash
-printf 'git:%s\\n' "$*" >> "$FAKE_COMMAND_LOG"
 case "$1" in
+  --version)
+    exit "$FAKE_GIT_VERSION_STATUS"
+    ;;
   clone)
+    printf 'git:%s\\n' "$*" >> "$FAKE_COMMAND_LOG"
     if [ "$2:$3" != 'https://github.com/JBallin/ballin-scripts.git:.ballin-scripts' ]; then
       exit 2
     fi
@@ -59,12 +62,15 @@ case "$1" in
     exit "$FAKE_GIT_CLONE_STATUS"
     ;;
   fetch)
+    printf 'git:%s\\n' "$*" >> "$FAKE_COMMAND_LOG"
     exit "$FAKE_GIT_FETCH_STATUS"
     ;;
   checkout)
+    printf 'git:%s\\n' "$*" >> "$FAKE_COMMAND_LOG"
     exit "$FAKE_GIT_CHECKOUT_STATUS"
     ;;
   merge)
+    printf 'git:%s\\n' "$*" >> "$FAKE_COMMAND_LOG"
     if [ "$FAKE_GIT_MERGE_STATUS" = '0' ]; then
       mkdir -p "$HOME/.ballin-scripts/commands"
       : > "$HOME/.ballin-scripts/commands/repo_update.ts"
@@ -115,6 +121,7 @@ esac
       HOME: homeDir,
       PATH: toolDir,
       FAKE_COMMAND_LOG: commandLogPath,
+      FAKE_GIT_VERSION_STATUS: '0',
       FAKE_GIT_CLONE_STATUS: '0',
       FAKE_GIT_FETCH_STATUS: '0',
       FAKE_GIT_CHECKOUT_STATUS: '0',
@@ -222,6 +229,20 @@ esac
     writeCurrentCheckout();
 
     const result = runInstall();
+
+    assert.equal(result.status, 1);
+    assert.include(result.stdout, 'Git is required before install can continue');
+    assert.include(result.stdout, 'macOS Command Line Tools');
+    assert.include(result.stdout, 'run this installer again');
+    assert.deepEqual(commandLog(), []);
+  });
+
+  it('stops with guidance before clone or update when Git cannot run', () => {
+    linkCommand('bash');
+    installGitStub();
+    writeCurrentCheckout();
+
+    const result = runInstall({ env: { FAKE_GIT_VERSION_STATUS: '69' } });
 
     assert.equal(result.status, 1);
     assert.include(result.stdout, 'Git is required before install can continue');

--- a/test/install.test.ts
+++ b/test/install.test.ts
@@ -232,7 +232,7 @@ esac
 
     assert.equal(result.status, 1);
     assert.include(result.stdout, 'Git is required before install can continue');
-    assert.include(result.stdout, 'macOS Command Line Tools');
+    assert.include(result.stdout, 'Install Git, then run this installer again');
     assert.include(result.stdout, 'run this installer again');
     assert.deepEqual(commandLog(), []);
   });
@@ -246,7 +246,7 @@ esac
 
     assert.equal(result.status, 1);
     assert.include(result.stdout, 'Git is required before install can continue');
-    assert.include(result.stdout, 'macOS Command Line Tools');
+    assert.include(result.stdout, 'Install Git, then run this installer again');
     assert.include(result.stdout, 'run this installer again');
     assert.deepEqual(commandLog(), []);
   });

--- a/test/install.test.ts
+++ b/test/install.test.ts
@@ -203,6 +203,7 @@ esac
 
   it('stops with guidance when Node.js is unavailable', () => {
     linkCommand('bash');
+    installGitStub();
     writeCurrentCheckout();
 
     const result = runInstall();
@@ -212,6 +213,19 @@ esac
     assert.include(result.stdout, 'Node.js 24.12 or newer with nvm');
     assert.include(result.stdout, 'docs/README.md');
     assert.include(result.stdout, 'brew install node');
+    assert.include(result.stdout, 'run this installer again');
+    assert.deepEqual(commandLog(), []);
+  });
+
+  it('stops with guidance before clone or update when Git is unavailable', () => {
+    linkCommand('bash');
+    writeCurrentCheckout();
+
+    const result = runInstall();
+
+    assert.equal(result.status, 1);
+    assert.include(result.stdout, 'Git is required before install can continue');
+    assert.include(result.stdout, 'macOS Command Line Tools');
     assert.include(result.stdout, 'run this installer again');
     assert.deepEqual(commandLog(), []);
   });


### PR DESCRIPTION
## Summary
- add an early installer prerequisite check for Git before clone/update preparation
- print concise recovery guidance for macOS Command Line Tools or Git setup
- cover the missing-Git path in the isolated installer test harness while preserving existing clone/update behavior

## Validation
- npx mocha test/install.test.ts
- npm test

Closes #241