### PR TITLE
Remove obsolete npmrc placeholder

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-; registry=https://registry.npmjs.org/


### PR DESCRIPTION
## Summary
- Remove the tracked .npmrc file that only contained a commented-out default registry line
- Leave npm registry selection to npm defaults or each developer's environment-specific config

## Rationale
The line was originally added to pin https://registry.npmjs.org/, then immediately commented out to avoid overriding custom registries outside development. While commented out, it has no effect on install, package-manager behavior, publishing, or developer setup, so keeping it only creates ambiguity.

Closes #222

## Validation
- npm test