### PR TITLE
Document backup Gist visibility tradeoffs

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,9 @@ packages, nvm settings, editor settings, editor extensions, bash completions,
 and Mac App Store apps when the supporting tools are installed.
 
 See the [supported capabilities reference](docs/capabilities.md) for the full
-list of backup snapshots.
+list of backup snapshots, and the
+[optional capabilities guide](docs/optional-capabilities.md#gist-backups) for
+Gist visibility tradeoffs.
 
 ```shell
 ballin backup

--- a/README.md
+++ b/README.md
@@ -147,9 +147,7 @@ packages, nvm settings, editor settings, editor extensions, bash completions,
 and Mac App Store apps when the supporting tools are installed.
 
 See the [supported capabilities reference](docs/capabilities.md) for the full
-list of backup snapshots, and the
-[optional capabilities guide](docs/optional-capabilities.md#gist-backups) for
-Gist visibility tradeoffs.
+list of backup snapshots.
 
 ```shell
 ballin backup

--- a/docs/optional-capabilities.md
+++ b/docs/optional-capabilities.md
@@ -81,10 +81,9 @@ that host, and either adopts an existing backup Gist or creates a new one. When
 an adopted backup includes a saved `ballin_config` snapshot, the installer restores
 them before continuing.
 
-New backup Gists are created as secret Gists. If you want to share your dotfiles
-publicly, GitHub lets you make a secret Gist public later. Review the contents
-first: public backups can expose paths, usernames, tool choices, package lists,
-and other local config, and public Gists cannot be converted back to secret.
+Setup creates backup Gists as secret. To share one publicly, make it public in
+GitHub after reviewing it: public backups can expose paths, usernames, tool
+choices, package lists, and other local config, and cannot be made secret again.
 
 ## Readiness checks
 

--- a/docs/optional-capabilities.md
+++ b/docs/optional-capabilities.md
@@ -81,6 +81,13 @@ that host, and either adopts an existing backup Gist or creates a new one. When
 an adopted backup includes a saved `ballin_config` snapshot, the installer restores
 them before continuing.
 
+New backup Gists are created as secret Gists by default. If you intentionally
+want to share your dotfiles, GitHub lets you make a secret Gist public later by
+editing the Gist visibility. Review the contents first: public backup Gists may
+expose personal paths, usernames, tool choices, editor settings, package lists,
+and other local configuration details. Public Gists cannot be converted back to
+secret.
+
 ## Readiness checks
 
 Use `ballin doctor` to check whether the Ballin-managed environment is healthy,

--- a/docs/optional-capabilities.md
+++ b/docs/optional-capabilities.md
@@ -81,12 +81,10 @@ that host, and either adopts an existing backup Gist or creates a new one. When
 an adopted backup includes a saved `ballin_config` snapshot, the installer restores
 them before continuing.
 
-New backup Gists are created as secret Gists by default. If you intentionally
-want to share your dotfiles, GitHub lets you make a secret Gist public later by
-editing the Gist visibility. Review the contents first: public backup Gists may
-expose personal paths, usernames, tool choices, editor settings, package lists,
-and other local configuration details. Public Gists cannot be converted back to
-secret.
+New backup Gists are created as secret Gists. If you want to share your dotfiles
+publicly, GitHub lets you make a secret Gist public later. Review the contents
+first: public backups can expose paths, usernames, tool choices, package lists,
+and other local config, and public Gists cannot be converted back to secret.
 
 ## Readiness checks
 


### PR DESCRIPTION
## Summary

- Document that backup Gists remain secret by default
- Explain that users can make a secret Gist public later in GitHub
- Warn that public backup Gists can expose local configuration details and cannot be converted back to secret

Closes #220

## Validation

- Not run (docs-only change; repo instructions say CI is enough for README/guide edits).