### PR TITLE
Show new-file icon for populated backup snapshots

### DIFF
--- a/commands/backup.ts
+++ b/commands/backup.ts
@@ -400,11 +400,12 @@ const classifySnapshotResult = (
   isNew: boolean,
   isChanged: boolean,
   isEmpty: boolean,
+  wasEmpty: boolean,
 ): SnapshotResultState => {
   if (!isChanged) {
     return 'unchanged';
   }
-  if (isNew) {
+  if (isNew || wasEmpty) {
     return 'created';
   }
   if (isEmpty) {
@@ -456,7 +457,8 @@ const updateSnapshot = (
     }
 
     isEmpty = snapshotIsEmpty(inputFile);
-    resultState = classifySnapshotResult(isNew, isChanged, isEmpty);
+    const wasEmpty = !isNew && fileExists(cacheFile) && snapshotIsEmpty(cacheFile);
+    resultState = classifySnapshotResult(isNew, isChanged, isEmpty, wasEmpty);
 
     if (isChanged) {
       const uploadFile = createSnapshotUploadFile(inputFile, snapshot.fileName);

--- a/test/backup.test.ts
+++ b/test/backup.test.ts
@@ -1126,14 +1126,14 @@ printf '%*s\\n' 1048577 '' >&2
     assert.deepEqual(gistUploads(), []);
   });
 
-  it('preserves the current changed icon when empty becomes non-empty', () => {
+  it('uses the new-file icon when empty becomes non-empty', () => {
     writeSnapshot('restored\n');
     seedBackupCache('empty\n');
 
     const result = runBackup();
 
     assertBackupSucceeded(result);
-    assert.equal(result.stdout, '✚ zshrc\n');
+    assert.equal(result.stdout, '💾 zshrc\n');
     assert.deepEqual(gistUploads(), [snapshotFileName]);
   });
 


### PR DESCRIPTION
## Summary

- Treat a cached empty snapshot becoming populated as newly meaningful backup output.
- Keep the existing new-file icon for that transition while preserving the rest of the backup status matrix.
- Update the focused backup test expectation for the empty-to-populated case.

Closes #77

## Validation

- npm test