### PR TITLE
Harden public analytics ingest

### DIFF
--- a/analytics-worker/README.md
+++ b/analytics-worker/README.md
@@ -40,12 +40,6 @@ The worker must not store:
 
 `POST /v1/events`
 
-Required header:
-
-```text
-X-Ballin-Analytics-Token: <configured ingest token>
-```
-
 Example payload:
 
 ```json
@@ -67,7 +61,7 @@ Responses:
 
 - `204` when the event is accepted
 - `400` for invalid JSON or invalid event fields
-- `401` when the ingest token is missing or invalid
+- `429` when rate limits are exceeded
 - `404` for unknown paths
 - `405` for unsupported methods
 
@@ -86,9 +80,13 @@ The worker should ignore request IP for analytics purposes. Cloudflare may still
 process request metadata operationally before the worker runs; the application
 schema does not read or persist it.
 
-The ingest token is a public client gate once it is shipped in the CLI, not a
-secret abuse solution for a distributed CLI. The Worker also uses a Cloudflare
-Workers rate limiting binding for `POST /v1/events`.
+The endpoint accepts public client telemetry. Valid events can be spoofed, so
+aggregate analytics are directional and not security-trustworthy. The Worker
+limits abuse with strict schema validation, low-cardinality fields, body-size and
+date-skew checks, server-side install ID hashing, and Cloudflare Workers rate
+limits. Request source metadata is used only as a transient rate-limit key and is
+not stored, queried, logged, or reported by the application. Older clients may
+still send `X-Ballin-Analytics-Token`; the Worker ignores that legacy header.
 
 ## Production Setup
 
@@ -114,19 +112,13 @@ globally, use `npx wrangler` in place of `wrangler`.
    wrangler secret put INSTALL_ID_HASH_SECRET
    ```
 
-5. Set the ingest token:
-
-   ```shell
-   wrangler secret put INGEST_TOKEN
-   ```
-
-6. Apply migrations:
+5. Apply migrations:
 
    ```shell
    wrangler d1 migrations apply ballin-scripts-analytics --remote
    ```
 
-7. Create the `analytics-worker-production` GitHub deployment environment, allow
+6. Create the `analytics-worker-production` GitHub deployment environment, allow
    deployments only from `main`, and add these environment secrets:
 
    - `CLOUDFLARE_API_TOKEN`, from a Cloudflare Account API Token created with
@@ -134,7 +126,7 @@ globally, use `npx wrangler` in place of `wrangler`.
    - `CLOUDFLARE_ACCOUNT_ID`
    - `CLOUDFLARE_D1_DATABASE_ID`
 
-8. Confirm the `Deploy Analytics Worker` GitHub Actions workflow completes
+7. Confirm the `Deploy Analytics Worker` GitHub Actions workflow completes
    after Worker-impacting changes land on `main`.
 
 ## Automatic Deploys
@@ -142,8 +134,8 @@ globally, use `npx wrangler` in place of `wrangler`.
 The deploy workflow runs `npm test`, creates an ignored runner-local
 `wrangler.toml` from `wrangler.toml.example`, fills in the D1 database ID from
 `CLOUDFLARE_D1_DATABASE_ID`, and runs `wrangler deploy` from this directory. It
-does not set or rotate the existing Cloudflare Worker secrets
-`INSTALL_ID_HASH_SECRET` or `INGEST_TOKEN`.
+does not set or rotate the existing Cloudflare Worker hash secret
+`INSTALL_ID_HASH_SECRET`.
 
 Keep the Cloudflare values as environment secrets rather than repository
 secrets. The workflow runs automatically on Worker-impacting pushes to `main`
@@ -202,6 +194,9 @@ The report uses local Wrangler authentication and
 - top-level command usage
 - command success, failure, and unknown counts
 - runtime/version trends from existing aggregate rows
+
+Reports are directional maintenance signals. Because ingestion is public client
+telemetry, aggregate counts are not security-trustworthy.
 
 On a machine where this repository has not been configured for Worker access,
 create the ignored local config first:

--- a/analytics-worker/report.ts
+++ b/analytics-worker/report.ts
@@ -48,6 +48,7 @@ const usage = [
   '',
   'Prints a read-only production D1 report from the existing analytics aggregates.',
 ].join('\n');
+const publicTelemetryCaveat = 'Caveat: analytics are public client telemetry; aggregate counts are directional and not security-trustworthy.';
 
 const dateBucket = (date: Date): string => date.toISOString().slice(0, 10);
 
@@ -360,6 +361,7 @@ const formatRuntimeTrends = (rows: D1Row[]): string => {
 
 const renderReport = (rows: ReportRows, options: ReportOptions): string => [
   `Analytics report (${options.from} to ${options.to})`,
+  publicTelemetryCaveat,
   '',
   formatActiveInstalls(rows.activeInstalls, options),
   '',

--- a/analytics-worker/src/index.ts
+++ b/analytics-worker/src/index.ts
@@ -25,7 +25,6 @@ type Env = {
   ANALYTICS_DB: D1Database;
   ANALYTICS_RATE_LIMITER: RateLimit;
   INSTALL_ID_HASH_SECRET: string;
-  INGEST_TOKEN: string;
 };
 
 type AnalyticsEvent = {
@@ -71,14 +70,15 @@ const allowedDurations = new Set(['unknown', '<1s', '1-10s', '10-60s', '1-10m', 
 const allowedOs = new Set(['darwin', 'linux', 'win32', 'unknown']);
 const installIdPattern = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
 const dateBucketPattern = /^\d{4}-\d{2}-\d{2}$/;
-const versionPattern = /^[0-9]+(?:\.[0-9]+){0,2}$/;
-const majorVersionPattern = /^[0-9]+$/;
-const coarseOsVersionPattern = /^[0-9]+(?:\.[0-9]+)?$|^unknown$/;
-const ingestTokenHeader = 'x-ballin-analytics-token';
+const versionPattern = /^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$/;
+const majorVersionPattern = /^[0-9]{1,3}$/;
+const coarseOsVersionPattern = /^[0-9]{1,3}(?:\.[0-9]{1,3})?$|^unknown$/;
 const maxBodyBytes = 2048;
 const retentionDays = 395;
 const allowedDateSkewDays = 1;
-const eventRateLimitKey = 'v1-events';
+const globalEventRateLimitKey = 'v1-events:global';
+const sourceEventRateLimitKeyPrefix = 'v1-events:source';
+const installEventRateLimitKeyPrefix = 'v1-events:install';
 
 const jsonResponse = (status: number, body: { error: string }): Response => (
   new Response(JSON.stringify(body), {
@@ -110,6 +110,34 @@ const hasOnlyAllowedPayloadKeys = (payload: Record<string, unknown>): boolean =>
 const stringField = (payload: Record<string, unknown>, key: string): string | null => {
   const value = payload[key];
   return typeof value === 'string' && value.length > 0 ? value : null;
+};
+
+const boundedRateLimitKeyPart = (value: string | null): string => {
+  const trimmed = value?.trim();
+  if (!trimmed) {
+    return 'unknown';
+  }
+  return trimmed.toLowerCase().replace(/[^a-z0-9.:_-]/g, '_').slice(0, 128);
+};
+
+const sourceRateLimitKey = (request: Request): string => {
+  const forwardedFor = request.headers.get('x-forwarded-for')?.split(',')[0] ?? null;
+  const source = request.headers.get('cf-connecting-ip') ?? forwardedFor;
+  return `${sourceEventRateLimitKeyPrefix}:${boundedRateLimitKeyPart(source)}`;
+};
+
+const installRateLimitKey = (installIdHash: string): string => (
+  `${installEventRateLimitKeyPrefix}:${installIdHash}`
+);
+
+const contentLengthExceedsLimit = (request: Request): boolean => {
+  const contentLength = request.headers.get('content-length');
+  if (!contentLength) {
+    return false;
+  }
+
+  const byteLength = Number(contentLength);
+  return Number.isFinite(byteLength) && byteLength > maxBodyBytes;
 };
 
 const validateDateBucket = (dateBucket: string): boolean => {
@@ -208,9 +236,7 @@ const hashInstallId = async (installId: string, secret: string): Promise<string>
     .join('');
 };
 
-const storeAnalyticsEvent = async (env: Env, event: AnalyticsEvent): Promise<void> => {
-  const installIdHash = await hashInstallId(event.installId, env.INSTALL_ID_HASH_SECRET);
-
+const storeAnalyticsEvent = async (env: Env, event: AnalyticsEvent, installIdHash: string): Promise<void> => {
   await env.ANALYTICS_DB.batch([
     env.ANALYTICS_DB.prepare(`
       INSERT OR IGNORE INTO install_days (date_bucket, install_id_hash)
@@ -246,9 +272,14 @@ const storeAnalyticsEvent = async (env: Env, event: AnalyticsEvent): Promise<voi
   ]);
 };
 
-const rateLimitEventRequest = async (env: Env): Promise<Response | null> => {
-  const { success } = await env.ANALYTICS_RATE_LIMITER.limit({ key: eventRateLimitKey });
-  return success ? null : emptyResponse(429);
+const rateLimitEventRequest = async (env: Env, keys: string[]): Promise<Response | null> => {
+  for (const key of keys) {
+    const { success } = await env.ANALYTICS_RATE_LIMITER.limit({ key });
+    if (!success) {
+      return emptyResponse(429);
+    }
+  }
+  return null;
 };
 
 const handleEventRequest = async (request: Request, env: Env): Promise<Response> => {
@@ -261,13 +292,13 @@ const handleEventRequest = async (request: Request, env: Env): Promise<Response>
   if (!env.INSTALL_ID_HASH_SECRET) {
     return jsonResponse(500, { error: 'analytics backend is not configured' });
   }
-  if (!env.INGEST_TOKEN) {
-    return jsonResponse(500, { error: 'analytics ingest gate is not configured' });
+  if (contentLengthExceedsLimit(request)) {
+    return jsonResponse(400, { error: 'request body is too large' });
   }
-  if (request.headers.get(ingestTokenHeader) !== env.INGEST_TOKEN) {
-    return emptyResponse(401);
-  }
-  const rateLimitedResponse = await rateLimitEventRequest(env);
+  const rateLimitedResponse = await rateLimitEventRequest(env, [
+    globalEventRateLimitKey,
+    sourceRateLimitKey(request),
+  ]);
   if (rateLimitedResponse) {
     return rateLimitedResponse;
   }
@@ -288,7 +319,15 @@ const handleEventRequest = async (request: Request, env: Env): Promise<Response>
     return jsonResponse(400, { error: event });
   }
 
-  await storeAnalyticsEvent(env, event);
+  const installIdHash = await hashInstallId(event.installId, env.INSTALL_ID_HASH_SECRET);
+  const installRateLimitedResponse = await rateLimitEventRequest(env, [
+    installRateLimitKey(installIdHash),
+  ]);
+  if (installRateLimitedResponse) {
+    return installRateLimitedResponse;
+  }
+
+  await storeAnalyticsEvent(env, event, installIdHash);
   return emptyResponse(204);
 };
 

--- a/commands/analytics.ts
+++ b/commands/analytics.ts
@@ -34,7 +34,6 @@ type AnalyticsRecordInput = {
 
 type SenderOptions = {
   endpoint?: string;
-  ingestToken?: string;
   timeoutMs?: number;
 };
 
@@ -83,7 +82,6 @@ const allowedOs = new Set(['darwin', 'linux', 'win32']);
 const installIdPattern = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
 const defaultAnalyticsDocsUrl = 'https://github.com/JBallin/ballin-scripts/blob/main/docs/analytics.md';
 const productionAnalyticsEndpoint = 'https://ballin-scripts-analytics.jballin.workers.dev/v1/events';
-const productionAnalyticsIngestToken = '6jC_OqsMynyQc3FKXgUN7aP3bbDQ_H_DMhGDrw7t6RE';
 const analyticsNoticeFor = (docsUrl = defaultAnalyticsDocsUrl): string => [
   'ballin-scripts collects minimal anonymous usage analytics after this notice.',
   'Disable: ballin config set analytics.enabled false',
@@ -223,7 +221,7 @@ const buildAnalyticsPayload = (
   osVersion: coarseOsVersion(),
 });
 
-const requestOptions = (endpoint: string, ingestToken: string): RequestOptions => {
+const requestOptions = (endpoint: string): RequestOptions => {
   const url = new URL(endpoint);
   return {
     method: 'POST',
@@ -233,7 +231,6 @@ const requestOptions = (endpoint: string, ingestToken: string): RequestOptions =
     path: `${url.pathname}${url.search}`,
     headers: {
       'content-type': 'application/json',
-      'x-ballin-analytics-token': ingestToken,
     },
   };
 };
@@ -251,14 +248,14 @@ const sendAnalyticsPayload: AnalyticsSender = (payload, options) => new Promise(
     }
   };
 
-  if (!options.endpoint || !options.ingestToken) {
+  if (!options.endpoint) {
     settle();
     return;
   }
 
   try {
     const body = JSON.stringify(payload);
-    const optionsWithHeaders = requestOptions(options.endpoint, options.ingestToken);
+    const optionsWithHeaders = requestOptions(options.endpoint);
     const timeoutMs = options.timeoutMs ?? defaultTimeoutMs;
     let destroyRequest = () => {};
     wallClockTimeout = setTimeout(() => {
@@ -327,7 +324,6 @@ const recordAnalyticsEvent = async (input: AnalyticsRecordInput, runtime: Analyt
     }, installId, runtime.appVersion);
     await (runtime.sender ?? sendAnalyticsPayload)(payload, {
       endpoint: runtime.endpoint ?? productionAnalyticsEndpoint,
-      ingestToken: runtime.ingestToken ?? productionAnalyticsIngestToken,
       timeoutMs: runtime.timeoutMs ?? defaultTimeoutMs,
     });
   } catch {

--- a/docs/analytics-backend.md
+++ b/docs/analytics-backend.md
@@ -15,8 +15,9 @@ Production sends use the deployed workers.dev endpoint:
 https://ballin-scripts-analytics.jballin.workers.dev/v1/events
 ```
 
-The Worker has a D1 binding, scheduled retention cleanup, two Cloudflare
-secrets, and an `ANALYTICS_RATE_LIMITER` binding for `POST /v1/events`.
+The Worker has a D1 binding, scheduled retention cleanup, an
+`INSTALL_ID_HASH_SECRET`, and an `ANALYTICS_RATE_LIMITER` binding for
+`POST /v1/events`.
 Worker-impacting changes deploy from `main` through the `Deploy Analytics
 Worker` GitHub Actions workflow.
 
@@ -28,7 +29,7 @@ Worker` GitHub Actions workflow.
 - The CLI does not need a runtime analytics SDK.
 - Retention is controlled by the Worker and D1 schema.
 - The deployment can stay tiny: one Worker, one D1 database, one rate-limit
-  binding, and two secrets.
+  binding, and one hash secret.
 
 ## Alternatives Considered
 
@@ -64,6 +65,10 @@ local Wrangler authentication and the ignored local
 active installs, top-level command usage, command success/failure counts, and
 runtime/version trends. It does not require, accept, or print Cloudflare secret
 values.
+
+Analytics ingestion is public client telemetry. Valid events can be spoofed, so
+reports are directional maintenance signals rather than security-trustworthy
+counts.
 
 The report only reads the existing aggregate tables: `install_days`,
 `command_events_daily`, and `version_events_daily`. It does not introduce new
@@ -107,10 +112,13 @@ npm run analytics:report
 
 ## Abuse Controls
 
-The skeleton requires an ingest token before accepting events, rejects oversized
-payloads, and applies a Workers rate-limit binding to `POST /v1/events`. A
-distributed CLI cannot keep a token truly secret, so the token is only one part
-of the production abuse story.
+The Worker accepts public client events and relies on layered abuse controls
+instead of a client-shipped secret. It rejects oversized payloads and unsupported
+fields, validates dates and low-cardinality runtime values, hashes install IDs
+before storage, applies global/source rate limits before parsing, and applies an
+install-hash rate limit before D1 writes. Request source metadata is used only as
+a transient Cloudflare rate-limit key; it is not stored, queried, logged, or
+reported by the application.
 
 ## Production Checklist
 
@@ -121,15 +129,14 @@ For production setup or recreation:
   `analytics-worker/wrangler.toml`
 - set the D1 database ID in local `analytics-worker/wrangler.toml`
 - set `INSTALL_ID_HASH_SECRET`
-- set `INGEST_TOKEN`
 - create the `analytics-worker-production` GitHub deployment environment with a
   `main` branch rule and environment secrets `CLOUDFLARE_API_TOKEN`,
   `CLOUDFLARE_ACCOUNT_ID`, and `CLOUDFLARE_D1_DATABASE_ID`
 - apply `analytics-worker/migrations/0001_initial.sql` with `--remote`
 - confirm the `Deploy Analytics Worker` workflow completed after the relevant
   change landed on `main`
-- confirm the deployed Worker returns `204` for a valid event, `401` for a
-  missing or bad token, and `400` for unsupported fields or invalid enums
+- confirm the deployed Worker returns `204` for a valid event, `400` for
+  unsupported fields or invalid enums, and `429` when rate limits are exceeded
 - query D1 to confirm only hashed install/day rows and aggregate counts are
   stored
 

--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -62,6 +62,8 @@ backend hashes install IDs before storage, stores daily install rows plus
 aggregate command/version/Node/OS counts, and deletes rows older than 395 days.
 
 Events are sent only when analytics are enabled and the CLI is configured with
-the production analytics endpoint and public client token.
+the production analytics endpoint. The endpoint accepts public client telemetry,
+so valid events can be spoofed; aggregate analytics are directional and not
+security-trustworthy.
 
 For deployment details, see [Analytics backend](analytics-backend.md).

--- a/test/analytics.test.ts
+++ b/test/analytics.test.ts
@@ -29,7 +29,6 @@ type AnalyticsPayload = {
 
 type SenderOptions = {
   endpoint?: string;
-  ingestToken?: string;
   timeoutMs?: number;
 };
 
@@ -85,7 +84,6 @@ const recordWithSender = (
 
   return recordAnalyticsEvent(input, {
     endpoint: 'https://analytics.example.test/v1/events',
-    ingestToken: 'test-token',
     env: {},
     installIdPath: testInstallIdPath,
     sender: async (payload: AnalyticsPayload) => {
@@ -182,7 +180,7 @@ describe('analytics client', () => {
     });
   });
 
-  it('uses production endpoint and token defaults when runtime overrides are absent', async () => {
+  it('uses the production endpoint default without a bundled ingest token', async () => {
     setAnalyticsConfig({
       enabled: 'true',
     });
@@ -202,8 +200,8 @@ describe('analytics client', () => {
 
     assert.deepInclude(senderOptions[0], {
       endpoint: 'https://ballin-scripts-analytics.jballin.workers.dev/v1/events',
-      ingestToken: '6jC_OqsMynyQc3FKXgUN7aP3bbDQ_H_DMhGDrw7t6RE',
     });
+    assert.notProperty(senderOptions[0], 'ingestToken');
   });
 
   it('skips sending when the local install ID is missing', async () => {
@@ -347,7 +345,6 @@ describe('analytics client', () => {
         currentNow = 10_800;
       }, {
         endpoint: 'https://analytics.example.test/v1/events',
-        ingestToken: 'test-token',
         env: {},
         installIdPath: testInstallIdPath,
         nowMs: () => currentNow,
@@ -396,7 +393,6 @@ describe('analytics client', () => {
         process.exitCode = 17;
       }, {
         endpoint: 'https://analytics.example.test/v1/events',
-        ingestToken: 'test-token',
         env: {},
         installIdPath: testInstallIdPath,
         nowMs: () => currentNow,
@@ -431,7 +427,6 @@ describe('analytics client', () => {
       fs.rmSync(testInstallIdPath, { force: true });
     }, {
       endpoint: 'https://analytics.example.test/v1/events',
-      ingestToken: 'test-token',
       env: {},
       installIdPath: testInstallIdPath,
       preserveLocalState: true,
@@ -460,7 +455,6 @@ describe('analytics client', () => {
     try {
       await runWithCommandAnalytics('ballin self-update', () => {}, {
         endpoint: 'https://analytics.example.test/v1/events',
-        ingestToken: 'test-token',
         env: {},
         installIdPath: testInstallIdPath,
         nowMs: () => 1000,
@@ -497,7 +491,6 @@ describe('analytics client', () => {
       throw new Error('simulated command failure');
     }, {
       endpoint: 'https://analytics.example.test/v1/events',
-      ingestToken: 'test-token',
       env: {},
       installIdPath: testInstallIdPath,
       nowMs: () => currentNow,
@@ -594,7 +587,6 @@ describe('analytics client', () => {
         osVersion: '15',
       }, {
         endpoint: 'https://analytics.example.test/v1/events',
-        ingestToken: 'test-token',
         timeoutMs: 25,
       });
     } finally {
@@ -613,8 +605,8 @@ describe('analytics client', () => {
     });
     assert.deepInclude(options.headers, {
       'content-type': 'application/json',
-      'x-ballin-analytics-token': 'test-token',
     });
+    assert.notProperty(options.headers, 'x-ballin-analytics-token');
   });
 
   it('bounds https sends with a wall-clock timeout and swallows request failures', async () => {
@@ -652,7 +644,6 @@ describe('analytics client', () => {
         osVersion: '15',
       }, {
         endpoint: 'https://analytics.example.test/v1/events',
-        ingestToken: 'test-token',
         timeoutMs: 1,
       });
       await analyticsDone;

--- a/test/analytics_report.test.ts
+++ b/test/analytics_report.test.ts
@@ -97,6 +97,7 @@ describe('analytics D1 report', () => {
     });
 
     assert.include(output, 'Analytics report (2026-06-01 to 2026-06-03)');
+    assert.include(output, 'Caveat: analytics are public client telemetry; aggregate counts are directional and not security-trustworthy.');
     assert.include(output, '2026-06-02  0');
     assert.include(output, 'ballin update  5      3        1        1        20.0%');
     assert.include(output, '2026-06-01  1.0.0        24          darwin  15          5');

--- a/test/analytics_worker.test.ts
+++ b/test/analytics_worker.test.ts
@@ -5,6 +5,17 @@ type StatementRun = {
   values: unknown[];
 };
 
+type MakeEnvOptions = {
+  hashSecret?: string;
+  rateLimitFailure?: (key: string) => boolean;
+};
+
+type EventRequestOptions = {
+  headers?: Record<string, string>;
+  legacyToken?: boolean;
+  sourceIp?: string;
+};
+
 class TestStatement {
   query: string;
   values: unknown[] = [];
@@ -23,7 +34,8 @@ class TestStatement {
   }
 }
 
-const makeEnv = () => {
+const makeEnv = (options: MakeEnvOptions = {}) => {
+  const rateLimitKeys: string[] = [];
   const runs: StatementRun[] = [];
   return {
     env: {
@@ -42,13 +54,14 @@ const makeEnv = () => {
         },
       },
       ANALYTICS_RATE_LIMITER: {
-        async limit() {
-          return { success: true };
+        async limit({ key }: { key: string }) {
+          rateLimitKeys.push(key);
+          return { success: !options.rateLimitFailure?.(key) };
         },
       },
-      INSTALL_ID_HASH_SECRET: 'test-secret',
-      INGEST_TOKEN: 'test-token',
+      INSTALL_ID_HASH_SECRET: options.hashSecret ?? 'test-secret',
     },
+    rateLimitKeys,
     runs,
   };
 };
@@ -66,37 +79,181 @@ const payloadForCommand = (command: string) => ({
   osVersion: '15',
 });
 
-const eventRequest = (payload: ReturnType<typeof payloadForCommand>) => new Request('https://analytics.example.test/v1/events', {
-  method: 'POST',
-  headers: {
+const eventRequest = (
+  payload: Record<string, unknown> | string,
+  options: EventRequestOptions = {},
+) => {
+  const headers: Record<string, string> = {
     'content-type': 'application/json',
-    'x-ballin-analytics-token': 'test-token',
-  },
-  body: JSON.stringify(payload),
-});
+    ...options.headers,
+  };
+  if (options.legacyToken) {
+    headers['x-ballin-analytics-token'] = 'test-token';
+  }
+  if (options.sourceIp) {
+    headers['cf-connecting-ip'] = options.sourceIp;
+  }
+
+  return new Request('https://analytics.example.test/v1/events', {
+    method: 'POST',
+    headers,
+    body: typeof payload === 'string' ? payload : JSON.stringify(payload),
+  });
+};
 
 describe('analytics Worker', () => {
-  it('accepts canonical Ballin command names', async () => {
+  it('accepts valid unauthenticated events and stores only aggregate fields', async () => {
     const worker = require('../analytics-worker/src/index.ts').default;
-    const { env, runs } = makeEnv();
+    const { env, rateLimitKeys, runs } = makeEnv();
     const payload = payloadForCommand('ballin update');
 
-    const response = await worker.fetch(eventRequest(payload), env);
+    const response = await worker.fetch(eventRequest(payload, { sourceIp: '203.0.113.7' }), env);
 
     assert.equal(response.status, 204);
+    assert.deepEqual(rateLimitKeys.slice(0, 2), [
+      'v1-events:global',
+      'v1-events:source:203.0.113.7',
+    ]);
+    assert.match(rateLimitKeys[2], /^v1-events:install:[0-9a-f]{64}$/);
     assert.includeDeepMembers(runs.map(({ values }) => values), [
       [payload.dateBucket, 'ballin update', '1.0.0', '24', 'darwin', '15'],
     ]);
+    assert.notInclude(runs.flatMap(({ values }) => values), '203.0.113.7');
   });
 
-  it('rejects unsupported command names', async () => {
+  it('ignores the legacy ingest-token header from older clients', async () => {
     const worker = require('../analytics-worker/src/index.ts').default;
     const { env } = makeEnv();
 
-    const response = await worker.fetch(eventRequest(payloadForCommand('unknown command')), env);
+    const response = await worker.fetch(eventRequest(payloadForCommand('ballin'), {
+      legacyToken: true,
+    }), env);
+
+    assert.equal(response.status, 204);
+  });
+
+  it('rejects unsupported fields before D1 writes', async () => {
+    const worker = require('../analytics-worker/src/index.ts').default;
+    const { env, runs } = makeEnv();
+    const payload = {
+      ...payloadForCommand('ballin update'),
+      path: '/Users/example',
+    };
+
+    const response = await worker.fetch(eventRequest(payload), env);
     const body = await response.json() as { error?: string };
 
     assert.equal(response.status, 400);
-    assert.equal(body.error, 'command is not supported');
+    assert.equal(body.error, 'event payload contains unsupported fields');
+    assert.deepEqual(runs, []);
+  });
+
+  it('rejects high-cardinality version and runtime values', async () => {
+    const worker = require('../analytics-worker/src/index.ts').default;
+    const { env, runs } = makeEnv();
+    const payload = {
+      ...payloadForCommand('ballin update'),
+      appVersion: '1.0.0-nightly.20260627',
+    };
+
+    const response = await worker.fetch(eventRequest(payload), env);
+    const body = await response.json() as { error?: string };
+
+    assert.equal(response.status, 400);
+    assert.equal(body.error, 'appVersion must be a released semantic version');
+    assert.deepEqual(runs, []);
+  });
+
+  it('rejects date buckets outside the accepted skew', async () => {
+    const worker = require('../analytics-worker/src/index.ts').default;
+    const { env, runs } = makeEnv();
+    const staleDate = new Date(Date.now() - 3 * 24 * 60 * 60 * 1000).toISOString().slice(0, 10);
+    const payload = {
+      ...payloadForCommand('ballin update'),
+      dateBucket: staleDate,
+    };
+
+    const response = await worker.fetch(eventRequest(payload), env);
+    const body = await response.json() as { error?: string };
+
+    assert.equal(response.status, 400);
+    assert.equal(body.error, 'dateBucket is outside the accepted clock skew');
+    assert.deepEqual(runs, []);
+  });
+
+  it('rejects oversized bodies before rate limiting when Content-Length is known', async () => {
+    const worker = require('../analytics-worker/src/index.ts').default;
+    const { env, rateLimitKeys, runs } = makeEnv();
+
+    const response = await worker.fetch(eventRequest('{}', {
+      headers: {
+        'content-length': '2049',
+      },
+    }), env);
+    const body = await response.json() as { error?: string };
+
+    assert.equal(response.status, 400);
+    assert.equal(body.error, 'request body is too large');
+    assert.deepEqual(rateLimitKeys, []);
+    assert.deepEqual(runs, []);
+  });
+
+  it('applies source rate limits before parsing or D1 writes', async () => {
+    const worker = require('../analytics-worker/src/index.ts').default;
+    const { env, rateLimitKeys, runs } = makeEnv({
+      rateLimitFailure: (key) => key === 'v1-events:source:203.0.113.7',
+    });
+
+    const response = await worker.fetch(eventRequest(payloadForCommand('ballin update'), {
+      sourceIp: '203.0.113.7',
+    }), env);
+
+    assert.equal(response.status, 429);
+    assert.deepEqual(rateLimitKeys, [
+      'v1-events:global',
+      'v1-events:source:203.0.113.7',
+    ]);
+    assert.deepEqual(runs, []);
+  });
+
+  it('applies global rate limits before source keys, parsing, or D1 writes', async () => {
+    const worker = require('../analytics-worker/src/index.ts').default;
+    const { env, rateLimitKeys, runs } = makeEnv({
+      rateLimitFailure: (key) => key === 'v1-events:global',
+    });
+
+    const response = await worker.fetch(eventRequest(payloadForCommand('ballin update'), {
+      sourceIp: '203.0.113.7',
+    }), env);
+
+    assert.equal(response.status, 429);
+    assert.deepEqual(rateLimitKeys, ['v1-events:global']);
+    assert.deepEqual(runs, []);
+  });
+
+  it('applies install-hash rate limits before D1 writes', async () => {
+    const worker = require('../analytics-worker/src/index.ts').default;
+    const { env, rateLimitKeys, runs } = makeEnv({
+      rateLimitFailure: (key) => key.startsWith('v1-events:install:'),
+    });
+
+    const response = await worker.fetch(eventRequest(payloadForCommand('ballin update')), env);
+
+    assert.equal(response.status, 429);
+    assert.match(rateLimitKeys[2], /^v1-events:install:[0-9a-f]{64}$/);
+    assert.deepEqual(runs, []);
+  });
+
+  it('fails closed when the install ID hash secret is missing', async () => {
+    const worker = require('../analytics-worker/src/index.ts').default;
+    const { env, rateLimitKeys, runs } = makeEnv({ hashSecret: '' });
+
+    const response = await worker.fetch(eventRequest(payloadForCommand('ballin update')), env);
+    const body = await response.json() as { error?: string };
+
+    assert.equal(response.status, 500);
+    assert.equal(body.error, 'analytics backend is not configured');
+    assert.deepEqual(rateLimitKeys, []);
+    assert.deepEqual(runs, []);
   });
 });


### PR DESCRIPTION
## Summary

- remove the bundled production analytics ingest token from the CLI client
- make Worker ingestion explicitly public-but-abuse-limited with global/source/install rate-limit keys, early body-size rejection, stricter runtime/version bounds, and legacy header compatibility
- add directional analytics caveats to reports and docs

## Validation

- npm test

Closes #240