### PR TITLE
Add Python tooling backup snapshots

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ when moving between Macs or rebuilding a development machine:
 - Git config and global ignore files
 - Homebrew formulae, casks, services, and Brewfile output
 - global npm packages and Node.js version preference
+- Python tool inventories from pipx, uv, and pyenv
 - VS Code and VS Code Insiders settings, keybindings, and extensions
 - optional Mac App Store app inventory through `mas`
 - local `ballin-scripts` configuration
@@ -143,8 +144,9 @@ the full list of update integrations.
 
 `ballin backup` uploads changed snapshots to a configured private Gist. It can
 include shell dotfiles, Git config, Homebrew formulae and casks, global npm
-packages, nvm settings, editor settings, editor extensions, bash completions,
-and Mac App Store apps when the supporting tools are installed.
+packages, Python tool inventories, nvm settings, editor settings, editor
+extensions, bash completions, and Mac App Store apps when the supporting tools
+are installed.
 
 See the [supported capabilities reference](docs/capabilities.md) for the full
 list of backup snapshots.

--- a/commands/backup.ts
+++ b/commands/backup.ts
@@ -96,7 +96,10 @@ const fileSuggestions = `
   nanorc
   npm_global
   nvmrc
+  pipx
   profile.sh
+  pyenv_versions
+  uv_tools
   vimrc
   vs_extensions
   vs_keybindings
@@ -580,6 +583,21 @@ const collectSnapshots = (homeDir: string): SnapshotCommand[] => {
 
   if (commandExists('npm')) {
     addShellCommand('npm_global', 'npm list -g --depth=0');
+  }
+
+  if (commandExists('pipx')) {
+    addShellCommand('pipx', 'pipx list --json');
+  }
+
+  if (commandExists('uv')) {
+    addShellCommand(
+      'uv_tools',
+      'uv tool list --show-version-specifiers --show-with --show-extras --show-python --no-progress --color never --no-config',
+    );
+  }
+
+  if (commandExists('pyenv')) {
+    addShellCommand('pyenv_versions', 'pyenv versions --bare');
   }
 
   addFile('.nvmrc', 'nvmrc');

--- a/commands/backup.ts
+++ b/commands/backup.ts
@@ -588,13 +588,21 @@ const collectSnapshots = (homeDir: string): SnapshotCommand[] => {
   }
 
   if (commandExists('pipx')) {
-    addShellCommand('pipx', 'pipx list --json');
+    addShellCommand('pipx', 'pipx list --json', homeDir, {
+      env: {
+        ...process.env,
+        PIPX_DISABLE_SHARED_LIBS_AUTO_UPGRADE: '1',
+      },
+      suppressStderrOnSuccess: true,
+    });
   }
 
   if (commandExists('uv')) {
     addShellCommand(
       'uv_tools',
       'uv tool list --show-version-specifiers --show-with --show-extras --no-progress --color never --no-config',
+      homeDir,
+      { suppressStderrOnSuccess: true },
     );
   }
 

--- a/commands/backup.ts
+++ b/commands/backup.ts
@@ -588,13 +588,13 @@ const collectSnapshots = (homeDir: string): SnapshotCommand[] => {
   }
 
   if (commandExists('pipx')) {
-    addShellCommand('pipx', 'pipx list --json');
+    addShellCommand('pipx', 'pipx list --json --skip-maintenance');
   }
 
   if (commandExists('uv')) {
     addShellCommand(
       'uv_tools',
-      'uv tool list --show-version-specifiers --show-with --show-extras --show-python --no-progress --color never --no-config',
+      'uv tool list --show-version-specifiers --show-with --show-extras --no-progress --color never --no-config',
     );
   }
 

--- a/commands/backup.ts
+++ b/commands/backup.ts
@@ -588,7 +588,7 @@ const collectSnapshots = (homeDir: string): SnapshotCommand[] => {
   }
 
   if (commandExists('pipx')) {
-    addShellCommand('pipx', 'pipx list --json --skip-maintenance');
+    addShellCommand('pipx', 'pipx list --json');
   }
 
   if (commandExists('uv')) {

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -32,6 +32,7 @@ can snapshot:
 | Homebrew inventory | `brew_list`, `brew_leaves`, `brew_cask`, `brew_services`, `Brewfile` | `brew` on `PATH`. |
 | Git config | `gitconfig`, `gitignore_global` | Matching dotfiles in `HOME`. |
 | Global npm packages | `npm_global` | `npm` on `PATH`. |
+| Python tooling | `pipx`, `uv_tools`, `pyenv_versions` | `pipx`, `uv`, or `pyenv` on `PATH`. |
 | Node version preference | `nvmrc` | `.nvmrc` in `HOME`. |
 | VS Code | `vs_settings`, `vs_keybindings`, `vs_extensions` | VS Code user files; `code` for extension list. |
 | VS Code Insiders | `vsI_settings`, `vsI_keybindings`, `vsI_extensions` | VS Code Insiders user files; `code-insiders` for extension list. |

--- a/test/backup.test.ts
+++ b/test/backup.test.ts
@@ -215,7 +215,7 @@ esac
   const installFakePythonToolCommands = () => {
     writeTestExecutable('pipx', `#!/usr/bin/env bash
 printf 'pipx|%s\\n' "$*" >> "$FAKE_PYTHON_TOOL_LOG"
-if [ "$*" != 'list --json --skip-maintenance' ]; then exit 2; fi
+if [ "$*" != 'list --json' ]; then exit 2; fi
 printf '%s\\n' '{"venvs":{"black":{"metadata":{"main_package":{"package":"black","package_version":"25.1.0"}}}}}'
 `);
     writeTestExecutable('uv', `#!/usr/bin/env bash
@@ -828,7 +828,7 @@ printf '%s\\n' '123456 Example App'
       '💾 pyenv_versions',
     ]);
     assert.deepEqual(pythonToolCalls(), [
-      'pipx|list --json --skip-maintenance',
+      'pipx|list --json',
       'uv|tool list --show-version-specifiers --show-with --show-extras --no-progress --color never --no-config',
       'pyenv|versions --bare',
     ]);

--- a/test/backup.test.ts
+++ b/test/backup.test.ts
@@ -215,12 +215,12 @@ esac
   const installFakePythonToolCommands = () => {
     writeTestExecutable('pipx', `#!/usr/bin/env bash
 printf 'pipx|%s\\n' "$*" >> "$FAKE_PYTHON_TOOL_LOG"
-if [ "$*" != 'list --json' ]; then exit 2; fi
+if [ "$*" != 'list --json --skip-maintenance' ]; then exit 2; fi
 printf '%s\\n' '{"venvs":{"black":{"metadata":{"main_package":{"package":"black","package_version":"25.1.0"}}}}}'
 `);
     writeTestExecutable('uv', `#!/usr/bin/env bash
 printf 'uv|%s\\n' "$*" >> "$FAKE_PYTHON_TOOL_LOG"
-if [ "$*" != 'tool list --show-version-specifiers --show-with --show-extras --show-python --no-progress --color never --no-config' ]; then exit 2; fi
+if [ "$*" != 'tool list --show-version-specifiers --show-with --show-extras --no-progress --color never --no-config' ]; then exit 2; fi
 printf '%s\\n' 'ruff v0.14.8 (Python 3.13.7)'
 `);
     writeTestExecutable('pyenv', `#!/usr/bin/env bash
@@ -828,8 +828,8 @@ printf '%s\\n' '123456 Example App'
       '💾 pyenv_versions',
     ]);
     assert.deepEqual(pythonToolCalls(), [
-      'pipx|list --json',
-      'uv|tool list --show-version-specifiers --show-with --show-extras --show-python --no-progress --color never --no-config',
+      'pipx|list --json --skip-maintenance',
+      'uv|tool list --show-version-specifiers --show-with --show-extras --no-progress --color never --no-config',
       'pyenv|versions --bare',
     ]);
     assert.equal(

--- a/test/backup.test.ts
+++ b/test/backup.test.ts
@@ -47,6 +47,7 @@ describe('ballin backup', () => {
   let scratchDir: string;
   let gistUploadLogPath: string;
   let brewLogPath: string;
+  let pythonToolLogPath: string;
   let openLogPath: string;
   let ballinLogPath: string;
   let realCatPath: string;
@@ -211,6 +212,24 @@ esac
     fs.writeFileSync(path.join(testBinDir, 'brew'), 'not executable\n', { mode: 0o644 });
   };
 
+  const installFakePythonToolCommands = () => {
+    writeTestExecutable('pipx', `#!/usr/bin/env bash
+printf 'pipx|%s\\n' "$*" >> "$FAKE_PYTHON_TOOL_LOG"
+if [ "$*" != 'list --json' ]; then exit 2; fi
+printf '%s\\n' '{"venvs":{"black":{"metadata":{"main_package":{"package":"black","package_version":"25.1.0"}}}}}'
+`);
+    writeTestExecutable('uv', `#!/usr/bin/env bash
+printf 'uv|%s\\n' "$*" >> "$FAKE_PYTHON_TOOL_LOG"
+if [ "$*" != 'tool list --show-version-specifiers --show-with --show-extras --show-python --no-progress --color never --no-config' ]; then exit 2; fi
+printf '%s\\n' 'ruff v0.14.8 (Python 3.13.7)'
+`);
+    writeTestExecutable('pyenv', `#!/usr/bin/env bash
+printf 'pyenv|%s\\n' "$*" >> "$FAKE_PYTHON_TOOL_LOG"
+if [ "$*" != 'versions --bare' ]; then exit 2; fi
+printf '%s\\n' '3.12.12' '3.13.11'
+`);
+  };
+
   const installControllableCatCommand = () => {
     const catPath = fs.realpathSync(path.join(testBinDir, 'cat'));
     fs.unlinkSync(path.join(testBinDir, 'cat'));
@@ -239,6 +258,7 @@ done
     scratchDir = path.join(testHomeDir, 'tmp');
     gistUploadLogPath = path.join(testHomeDir, 'fake-gist-uploads.log');
     brewLogPath = path.join(testHomeDir, 'fake-brew.log');
+    pythonToolLogPath = path.join(testHomeDir, 'fake-python-tools.log');
     openLogPath = path.join(testHomeDir, 'fake-open.log');
     ballinLogPath = path.join(testHomeDir, 'fake-ballin.log');
 
@@ -297,6 +317,7 @@ done
       FAKE_GH_EDIT_MISSING_FILE: ghEditMissingFile ? 'true' : 'false',
       FAKE_GH_UPLOAD_FAIL: ghUploadFail ? 'true' : 'false',
       FAKE_BREW_LOG: brewLogPath,
+      FAKE_PYTHON_TOOL_LOG: pythonToolLogPath,
       FAKE_OPEN_LOG: openLogPath,
       FAKE_BALLIN_LOG: ballinLogPath,
       FAKE_BREW_PREFIX: brewPrefix,
@@ -331,6 +352,7 @@ done
   const gistReads = () => readLogLines(gistReadLogPath);
   const gistUploads = () => readLogLines(gistUploadLogPath);
   const brewCalls = () => readLogLines(brewLogPath);
+  const pythonToolCalls = () => readLogLines(pythonToolLogPath);
   const openCalls = () => readLogLines(openLogPath);
   const ballinCalls = () => readLogLines(ballinLogPath);
 
@@ -528,6 +550,9 @@ exit 2
     assert.equal(result.status, 1);
     assert.include(result.stdout, '\nOptions: ');
     assert.include(result.stdout, 'ballin_config');
+    assert.include(result.stdout, 'pipx');
+    assert.include(result.stdout, 'uv_tools');
+    assert.include(result.stdout, 'pyenv_versions');
     assert.include(result.stdout, 'vsI_settings');
     assert.deepEqual(gistReads(), ['missing_file']);
   });
@@ -538,6 +563,9 @@ exit 2
     assert.equal(result.status, 1);
     assert.include(result.stdout, "Error: 'read' needs a filename.");
     assert.include(result.stdout, '\nOptions: ');
+    assert.include(result.stdout, 'pipx');
+    assert.include(result.stdout, 'uv_tools');
+    assert.include(result.stdout, 'pyenv_versions');
     assert.deepEqual(gistReads(), []);
   });
 
@@ -775,6 +803,42 @@ printf '%s\\n' '123456 Example App'
     );
     assert.equal(fs.readFileSync(path.join(backupCacheDir, 'mas'), 'utf8'), '123456 Example App\n');
     assert.deepEqual(gistUploads(), ['npm_global', 'mas']);
+  });
+
+  it('skips Python tooling snapshots when commands are unavailable', () => {
+    const result = runBackup();
+
+    assertBackupSucceeded(result);
+    assert.equal(result.stdout, '');
+    assert.isFalse(fs.existsSync(path.join(backupCacheDir, 'pipx')));
+    assert.isFalse(fs.existsSync(path.join(backupCacheDir, 'uv_tools')));
+    assert.isFalse(fs.existsSync(path.join(backupCacheDir, 'pyenv_versions')));
+    assert.deepEqual(pythonToolCalls(), []);
+  });
+
+  it('snapshots Python tooling inventories when commands are available', () => {
+    installFakePythonToolCommands();
+
+    const result = runBackup();
+
+    assertBackupSucceeded(result);
+    assert.deepEqual(result.stdout.trim().split('\n'), [
+      '💾 pipx',
+      '💾 uv_tools',
+      '💾 pyenv_versions',
+    ]);
+    assert.deepEqual(pythonToolCalls(), [
+      'pipx|list --json',
+      'uv|tool list --show-version-specifiers --show-with --show-extras --show-python --no-progress --color never --no-config',
+      'pyenv|versions --bare',
+    ]);
+    assert.equal(
+      fs.readFileSync(path.join(backupCacheDir, 'pipx'), 'utf8'),
+      '{"venvs":{"black":{"metadata":{"main_package":{"package":"black","package_version":"25.1.0"}}}}}\n',
+    );
+    assert.equal(fs.readFileSync(path.join(backupCacheDir, 'uv_tools'), 'utf8'), 'ruff v0.14.8 (Python 3.13.7)\n');
+    assert.equal(fs.readFileSync(path.join(backupCacheDir, 'pyenv_versions'), 'utf8'), '3.12.12\n3.13.11\n');
+    assert.deepEqual(gistUploads(), ['pipx', 'uv_tools', 'pyenv_versions']);
   });
 
   ([

--- a/test/backup.test.ts
+++ b/test/backup.test.ts
@@ -214,13 +214,15 @@ esac
 
   const installFakePythonToolCommands = () => {
     writeTestExecutable('pipx', `#!/usr/bin/env bash
-printf 'pipx|%s\\n' "$*" >> "$FAKE_PYTHON_TOOL_LOG"
+printf 'pipx|%s|%s\\n' "$PIPX_DISABLE_SHARED_LIBS_AUTO_UPGRADE" "$*" >> "$FAKE_PYTHON_TOOL_LOG"
 if [ "$*" != 'list --json' ]; then exit 2; fi
+printf '%s\\n' 'nothing has been installed with pipx' >&2
 printf '%s\\n' '{"venvs":{"black":{"metadata":{"main_package":{"package":"black","package_version":"25.1.0"}}}}}'
 `);
     writeTestExecutable('uv', `#!/usr/bin/env bash
 printf 'uv|%s\\n' "$*" >> "$FAKE_PYTHON_TOOL_LOG"
 if [ "$*" != 'tool list --show-version-specifiers --show-with --show-extras --no-progress --color never --no-config' ]; then exit 2; fi
+printf '%s\\n' 'No tools installed' >&2
 printf '%s\\n' 'ruff v0.14.8 (Python 3.13.7)'
 `);
     writeTestExecutable('pyenv', `#!/usr/bin/env bash
@@ -828,7 +830,7 @@ printf '%s\\n' '123456 Example App'
       '✚ pyenv_versions',
     ]);
     assert.deepEqual(pythonToolCalls(), [
-      'pipx|list --json',
+      'pipx|1|list --json',
       'uv|tool list --show-version-specifiers --show-with --show-extras --no-progress --color never --no-config',
       'pyenv|versions --bare',
     ]);

--- a/test/backup.test.ts
+++ b/test/backup.test.ts
@@ -823,9 +823,9 @@ printf '%s\\n' '123456 Example App'
 
     assertBackupSucceeded(result);
     assert.deepEqual(result.stdout.trim().split('\n'), [
-      '💾 pipx',
-      '💾 uv_tools',
-      '💾 pyenv_versions',
+      '✚ pipx',
+      '✚ uv_tools',
+      '✚ pyenv_versions',
     ]);
     assert.deepEqual(pythonToolCalls(), [
       'pipx|list --json',


### PR DESCRIPTION
## Summary

- Add command-present `ballin backup` snapshots for `pipx`, `uv tool`, and `pyenv` inventories
- Include the new snapshot filenames in `ballin backup read` suggestions
- Document the Python tooling backup surface in the README and supported capabilities reference

Closes #160.

## Validation

- `npm test`