### PR TITLE
Finalize backup status icons

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ ballin backup
 
 Backup status markers:
 
-- `💾` newly saved or newly meaningful snapshot
+- `✚` newly saved or newly meaningful snapshot
 - `✎` existing snapshot content changed
 - `✖︎` existing snapshot became empty
 - `✔` unchanged non-empty snapshot

--- a/README.md
+++ b/README.md
@@ -153,6 +153,14 @@ list of backup snapshots.
 ballin backup
 ```
 
+Backup status markers:
+
+- `💾` newly saved or newly meaningful snapshot
+- `✎` existing snapshot content changed
+- `✖︎` existing snapshot became empty
+- `✔` unchanged non-empty snapshot
+- unchanged empty snapshots do not print a line
+
 Open the configured backup Gist:
 
 ```shell

--- a/commands/backup.ts
+++ b/commands/backup.ts
@@ -429,7 +429,7 @@ const writeSnapshotStatus = (
   } else if (resultState === 'removed') {
     writeStdoutLine(`✖︎ ${fileWithoutExtension}`);
   } else {
-    writeStdoutLine(`✚ ${fileWithoutExtension}`);
+    writeStdoutLine(`✎ ${fileWithoutExtension}`);
   }
 };
 

--- a/commands/backup.ts
+++ b/commands/backup.ts
@@ -425,7 +425,7 @@ const writeSnapshotStatus = (
       writeStdoutLine(`✔ ${fileWithoutExtension}`);
     }
   } else if (resultState === 'created') {
-    writeStdoutLine(`💾 ${fileWithoutExtension}`);
+    writeStdoutLine(`✚ ${fileWithoutExtension}`);
   } else if (resultState === 'removed') {
     writeStdoutLine(`✖︎ ${fileWithoutExtension}`);
   } else {

--- a/test/backup.test.ts
+++ b/test/backup.test.ts
@@ -993,7 +993,7 @@ printf '%s\\n' '123456 Example App'
     const result = runBackup();
 
     assertBackupSucceeded(result);
-    assert.equal(result.stdout, '✚ zshrc\n');
+    assert.equal(result.stdout, '✎ zshrc\n');
     assert.equal(fs.readFileSync(cachedSnapshotPath(), 'utf8'), 'new value\n');
     assert.equal(fs.readFileSync(fakeGistFilePath(), 'utf8'), 'new value\n');
     assert.deepEqual(gistReads(), [snapshotFileName]);
@@ -1018,7 +1018,7 @@ printf '%s\\n' '123456 Example App'
     const result = runBackup();
 
     assertBackupSucceeded(result);
-    assert.equal(result.stdout, '✚ zshrc\n');
+    assert.equal(result.stdout, '✎ zshrc\n');
     assert.equal(fs.readFileSync(cachedSnapshotPath(), 'utf8'), 'export COLOR=blue\n');
     assert.deepEqual(gistUploads(), [snapshotFileName]);
   });
@@ -1030,7 +1030,7 @@ printf '%s\\n' '123456 Example App'
     const result = runBackup({ ghEditMissingFile: true });
 
     assertBackupSucceeded(result);
-    assert.equal(result.stdout, '✚ zshrc\n');
+    assert.equal(result.stdout, '✎ zshrc\n');
     assert.equal(fs.readFileSync(cachedSnapshotPath(), 'utf8'), 'export COLOR=blue\n');
     assert.equal(fs.readFileSync(fakeGistFilePath(), 'utf8'), 'export COLOR=blue\n');
     assert.deepEqual(gistUploads(), [snapshotFileName]);
@@ -1062,7 +1062,7 @@ printf '%s\\n' '123456 Example App'
 
     assert.equal(failedResult.status, 1);
     assertBackupSucceeded(retriedResult);
-    assert.equal(retriedResult.stdout, '✚ zshrc\n');
+    assert.equal(retriedResult.stdout, '✎ zshrc\n');
     assert.equal(fs.readFileSync(cachedSnapshotPath(), 'utf8'), 'export COLOR=blue\n');
     assert.equal(fs.readFileSync(fakeGistFilePath(), 'utf8'), 'export COLOR=blue\n');
     assert.deepEqual(gistUploads(), [snapshotFileName]);
@@ -1223,7 +1223,7 @@ printf '%*s\\n' 1048577 '' >&2
 
     assert.equal(failedResult.status, 1);
     assertBackupSucceeded(recoveredResult);
-    assert.equal(recoveredResult.stdout, '✚ zshrc\n');
+    assert.equal(recoveredResult.stdout, '✎ zshrc\n');
     assert.equal(fs.readFileSync(cachedSnapshotPath(), 'utf8'), 'recovered\n');
     assert.equal(fs.readFileSync(fakeGistFilePath(), 'utf8'), 'recovered\n');
     assert.deepEqual(gistUploads(), [snapshotFileName]);

--- a/test/backup.test.ts
+++ b/test/backup.test.ts
@@ -678,12 +678,12 @@ printf '%s\\n' 'publisher.insiders-extension'
 
     assertBackupSucceeded(result);
     assert.deepEqual(result.stdout.trim().split('\n'), [
-      '💾 vs_settings',
-      '💾 vs_keybindings',
-      '💾 vs_extensions',
-      '💾 vsI_settings',
-      '💾 vsI_keybindings',
-      '💾 vsI_extensions',
+      '✚ vs_settings',
+      '✚ vs_keybindings',
+      '✚ vs_extensions',
+      '✚ vsI_settings',
+      '✚ vsI_keybindings',
+      '✚ vsI_extensions',
     ]);
     assert.equal(fs.readFileSync(path.join(backupCacheDir, 'vs_settings'), 'utf8'), '{"fontSize":14}\n');
     assert.equal(
@@ -726,10 +726,10 @@ printf '%s\\n' 'publisher.insiders-extension'
 
     assertBackupSucceeded(result);
     assert.deepEqual(result.stdout.trim().split('\n'), [
-      '💾 brackets_settings',
-      '💾 brackets_keymap',
-      '💾 brackets_extensions',
-      '💾 brackets_disabled_extensions',
+      '✚ brackets_settings',
+      '✚ brackets_keymap',
+      '✚ brackets_extensions',
+      '✚ brackets_disabled_extensions',
     ]);
     assert.equal(
       fs.readFileSync(path.join(backupCacheDir, 'brackets_settings.json'), 'utf8'),
@@ -766,8 +766,8 @@ printf '%s\\n' '123456 Example App'
 
     assertBackupSucceeded(result);
     assert.deepEqual(result.stdout.trim().split('\n'), [
-      '💾 npm_global',
-      '💾 mas',
+      '✚ npm_global',
+      '✚ mas',
     ]);
     assert.equal(
       fs.readFileSync(path.join(backupCacheDir, 'npm_global'), 'utf8'),
@@ -790,7 +790,7 @@ printf '%s\\n' '123456 Example App'
       const result = runBackup({ brewPrefix });
 
       assertBackupSucceeded(result);
-      assert.include(result.stdout, '💾 bash_completions\n');
+      assert.include(result.stdout, '✚ bash_completions\n');
       assert.equal(
         fs.readFileSync(path.join(backupCacheDir, 'bash_completions'), 'utf8'),
         'git\nnpm\n',
@@ -835,7 +835,7 @@ printf '%s\\n' '123456 Example App'
     const result = runBackup({ completionDir });
 
     assertBackupSucceeded(result);
-    assert.equal(result.stdout, '💾 bash_completions\n');
+    assert.equal(result.stdout, '✚ bash_completions\n');
     assert.equal(
       fs.readFileSync(path.join(backupCacheDir, 'bash_completions'), 'utf8'),
       'apple-silicon-tool\n',
@@ -888,11 +888,11 @@ printf '%s\\n' '123456 Example App'
 
     assertBackupSucceeded(result);
     assert.deepEqual(result.stdout.trim().split('\n'), [
-      '💾 brew_list',
-      '💾 brew_leaves',
-      '💾 brew_cask',
-      '💾 brew_services',
-      '💾 Brewfile',
+      '✚ brew_list',
+      '✚ brew_leaves',
+      '✚ brew_cask',
+      '✚ brew_services',
+      '✚ Brewfile',
     ]);
     assert.deepEqual(brewCalls(), [
       '1|1|--prefix',
@@ -939,20 +939,20 @@ printf '%s\\n' '123456 Example App'
     const result = runBackup();
 
     assertBackupSucceeded(result);
-    assert.equal(result.stdout, '💾 zshrc\n');
+    assert.equal(result.stdout, '✚ zshrc\n');
     assert.equal(fs.readFileSync(cachedSnapshotPath(), 'utf8'), 'alias hello="world"\n');
     assert.equal(fs.readFileSync(fakeGistFilePath(), 'utf8'), 'alias hello="world"\n');
     assert.deepEqual(gistReads(), [snapshotFileName]);
     assert.deepEqual(gistUploads(), [snapshotFileName]);
   });
 
-  it('uses the current new-file icon for a first empty snapshot', () => {
+  it('uses the final new-file marker for a first empty snapshot', () => {
     writeSnapshot('');
 
     const result = runBackup();
 
     assertBackupSucceeded(result);
-    assert.equal(result.stdout, '💾 zshrc\n');
+    assert.equal(result.stdout, '✚ zshrc\n');
     assert.equal(fs.readFileSync(cachedSnapshotPath(), 'utf8'), 'empty\n');
     assert.equal(fs.readFileSync(fakeGistFilePath(), 'utf8'), 'empty\n');
     assert.deepEqual(gistReads(), [snapshotFileName]);
@@ -1075,7 +1075,7 @@ printf '%s\\n' '123456 Example App'
     const result = runBackup();
 
     assertBackupSucceeded(result);
-    assert.equal(result.stdout, '💾 zshrc\n');
+    assert.equal(result.stdout, '✚ zshrc\n');
     assert.equal(fs.statSync(cachedSnapshotPath()).size, largeSnapshot.length);
     assert.equal(fs.statSync(fakeGistFilePath()).size, largeSnapshot.length);
     assert.deepEqual(gistUploads(), [snapshotFileName]);
@@ -1091,7 +1091,7 @@ printf '%*s\\n' 1048577 '' >&2
     const result = runBackup();
 
     assert.equal(result.status, 0);
-    assert.include(result.stdout, '💾 vs_extensions\n');
+    assert.include(result.stdout, '✚ vs_extensions\n');
     assert.equal(result.stderr.length, 1024 * 1024 + 2);
     assert.equal(result.stderr.slice(0, 1), ' ');
     assert.equal(result.stderr.slice(-1), '\n');
@@ -1126,14 +1126,14 @@ printf '%*s\\n' 1048577 '' >&2
     assert.deepEqual(gistUploads(), []);
   });
 
-  it('uses the new-file icon when empty becomes non-empty', () => {
+  it('uses the new-file marker when empty becomes non-empty', () => {
     writeSnapshot('restored\n');
     seedBackupCache('empty\n');
 
     const result = runBackup();
 
     assertBackupSucceeded(result);
-    assert.equal(result.stdout, '💾 zshrc\n');
+    assert.equal(result.stdout, '✚ zshrc\n');
     assert.deepEqual(gistUploads(), [snapshotFileName]);
   });
 
@@ -1182,7 +1182,7 @@ printf '%*s\\n' 1048577 '' >&2
     });
 
     assert.equal(result.status, 1);
-    assert.equal(result.stdout, '💾 gitconfig\n');
+    assert.equal(result.stdout, '✚ gitconfig\n');
     assert.equal(
       result.stderr,
       'cat: simulated failure reading .zshrc\n'


### PR DESCRIPTION
## Summary

- Use the text marker `✚` for newly saved or newly meaningful backup snapshots instead of the emoji `💾`.
- Use `✎` for changed existing backup snapshots so add vs edit states are distinct.
- Document the final backup status marker meanings in the README and update backup output expectations.

Closes #248

## Validation

- `npm test`