### PR TITLE
Polish README onboarding and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 *Back up your dotfiles and update your macOS development environment.*
 
 `ballin-scripts` helps you recreate and maintain a macOS development environment
-with minimal manual setup. It backs up the files, package lists, editor settings,
-and local configuration that define your setup, then automates routine updates.
+with minimal manual setup. It stores a private backup of the state that defines
+your setup, then automates routine updates.
 
 It is built for people who want a repeatable macOS development environment with
 low-friction updates.
@@ -16,9 +16,9 @@ Core commands:
 
 ## What it manages
 
-`ballin-scripts` manages development-environment state that is easy to lose
-or tedious to maintain by backing up dotfiles, package and tool lists, and
-editor settings, then automating routine update tasks.
+`ballin-scripts` covers two related jobs: preserving development-environment
+state and keeping common tooling up to date. Backups focus on dotfiles, package
+and tool lists, and editor settings; updates handle routine maintenance tasks.
 
 See the [supported capabilities reference](docs/capabilities.md) for the exact
 snapshot files and update integrations.

--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 *Back up your dotfiles and update your macOS development environment.*
 
-`ballin-scripts` helps developers keep macOS development environments repeatable
-and inspectable. It snapshots shell and Git configuration, Homebrew package
-lists, editor settings, and local tool state, then automates routine
-maintenance.
+`ballin-scripts` helps developers maintain repeatable, inspectable macOS
+development environments. It snapshots shell and Git configuration, Homebrew
+package lists, editor settings, and local tool state, then automates routine
+updates.
 
 ## What it does
 

--- a/README.md
+++ b/README.md
@@ -3,8 +3,9 @@
 *Back up your dotfiles and update your macOS development environment.*
 
 `ballin-scripts` helps you recreate and maintain a macOS development environment
-with minimal manual setup. It stores a private backup of the state that defines
-your setup, then automates routine updates.
+with minimal manual setup. It stores a private backup of state such as shell
+configuration, Git configuration, Homebrew package lists, editor settings, and
+local tool state, then automates routine updates.
 
 It is built for people who want a repeatable macOS development environment with
 low-friction updates.
@@ -13,6 +14,25 @@ Core commands:
 
 - `ballin update` updates the development environment.
 - `ballin backup` snapshots the development environment to a private Gist.
+
+## Quick start
+
+```shell
+bash <(curl -fsSL https://raw.githubusercontent.com/JBallin/ballin-scripts/main/install.sh)
+ballin doctor
+ballin backup
+ballin update
+```
+
+`ballin doctor` checks whether the Ballin-managed environment is healthy.
+Run `ballin backup` once to create the initial snapshot, then use
+`ballin update` for ongoing maintenance.
+
+## What this is
+
+`ballin-scripts` is a backup and update toolkit for repeatable macOS
+development environments. It is not a full disk backup, a secrets manager, or a
+complete one-command machine restore system.
 
 ## Backup and update behavior
 
@@ -26,20 +46,26 @@ The tools split backup from broader system updates:
 - Installation adds the command shims to your shell path and configures the
   private Gist used by backups.
 
-Optional update behavior is controlled through `ballin config`; see the
-[optional capabilities guide](docs/optional-capabilities.md) for the defaults
-and tradeoffs.
+Optional update behavior is controlled through `ballin config`.
 
 ## Fresh Mac setup
 
 On a new Mac, install `ballin-scripts` and let the installer create or adopt the
-private backup Gist used by `ballin backup`. Future snapshots provide the
-reference for recreating shell files, Git settings, package lists, editor
+private backup Gist used by `ballin backup`. If you adopt an existing backup,
+use `ballin backup open` or `ballin backup read <file>` to inspect saved
+snapshots while you recreate shell files, Git settings, package lists, editor
 settings, and other development-environment state.
 
 This is currently a backup and update toolkit, not a full one-command
 machine restore system. The backed-up snapshots make rebuilds more repeatable
 and auditable.
+
+## Privacy and security
+
+Backups are stored in the configured private GitHub Gist. Treat them as
+developer-environment metadata: paths, usernames, package and tool choices,
+editor settings, and local configuration can reveal details about your setup.
+Review snapshots before sharing a Gist or making it public.
 
 ## Before you install
 
@@ -55,7 +81,15 @@ Optional integrations and setup tradeoffs are covered in the
 Install with:
 
 ```shell
-bash <(curl -s https://raw.githubusercontent.com/JBallin/ballin-scripts/main/install.sh)
+bash <(curl -fsSL https://raw.githubusercontent.com/JBallin/ballin-scripts/main/install.sh)
+```
+
+To inspect the installer first:
+
+```shell
+curl -fsSL https://raw.githubusercontent.com/JBallin/ballin-scripts/main/install.sh -o /tmp/ballin-install.sh
+less /tmp/ballin-install.sh
+bash /tmp/ballin-install.sh
 ```
 
 See the [documentation index](docs/README.md) for Node.js setup, update
@@ -63,8 +97,8 @@ settings, optional integrations, and the full list of managed capabilities.
 
 ## Example output
 
-With optional integrations enabled, `ballin update` updates the machine and
-finishes by backing up the development environment. Output varies by installed
+With optional integrations enabled, `ballin update` updates the machine and can
+finish by backing up the development environment. Output varies by installed
 tools and settings.
 
 ```shell
@@ -77,23 +111,16 @@ $ ballin update
 ==> Checking Homebrew installation
 Your system is ready to brew.
 
-==> Updating Node.js LTS
-Installing latest LTS version.
-v24.18.0 is already installed.
-Now using node v24.18.0 (npm v11.16.0)
-
 ==> Updating App Store apps
 
 ==> Installing macOS updates
-Software Update Tool
-
-Finding available software
-No updates are available.
+...
 
 ==> Backing up development environment
 ✔ zprofile
 ✔ zshrc
 ✔ bash_completions
+...
 ✔ brew_list
 ✔ brew_leaves
 ✔ brew_cask
@@ -101,8 +128,6 @@ No updates are available.
 ✔ gitconfig
 ✔ npm_global
 ✔ vs_settings
-✔ vs_extensions
-✔ ballin_config
 ✔ mas
 ```
 

--- a/README.md
+++ b/README.md
@@ -14,15 +14,6 @@ Core commands:
 - `ballin update` updates the development environment.
 - `ballin backup` snapshots the development environment to a private Gist.
 
-## What it manages
-
-`ballin-scripts` covers two related jobs: preserving development-environment
-state and keeping common tooling up to date. Backups focus on dotfiles, package
-and tool lists, and editor settings; updates handle routine maintenance tasks.
-
-See the [supported capabilities reference](docs/capabilities.md) for the exact
-snapshot files and update integrations.
-
 ## Backup and update behavior
 
 The tools split backup from broader system updates:

--- a/README.md
+++ b/README.md
@@ -20,30 +20,20 @@ The installer adds command shims to your shell path, configures the backup Gist,
 and guides you through missing setup. For the smoothest first run, use macOS
 with Node.js LTS, Homebrew, and an authenticated GitHub CLI.
 
-Install with:
+Run the [install script](https://raw.githubusercontent.com/JBallin/ballin-scripts/main/install.sh):
 
 ```shell
 bash <(curl -fsSL https://raw.githubusercontent.com/JBallin/ballin-scripts/main/install.sh)
 ```
 
-Inspect first:
-
-```shell
-curl -fsSL https://raw.githubusercontent.com/JBallin/ballin-scripts/main/install.sh -o /tmp/ballin-install.sh
-less /tmp/ballin-install.sh
-bash /tmp/ballin-install.sh
-```
-
-After installation:
+Then create the initial backup:
 
 ```shell
 ballin doctor
 ballin backup
-ballin update
 ```
 
-`ballin doctor` checks the managed environment. `ballin backup` creates the
-initial snapshot. `ballin update` handles ongoing maintenance.
+Use `ballin update` for ongoing maintenance.
 
 ## Example output
 

--- a/README.md
+++ b/README.md
@@ -3,60 +3,38 @@
 *Back up your dotfiles and update your macOS development environment.*
 
 `ballin-scripts` helps you recreate and maintain a macOS development environment
-with minimal manual setup. It stores a private backup of state such as shell
-configuration, Git configuration, Homebrew package lists, editor settings, and
-local tool state, then automates routine updates.
+with minimal manual setup. It stores snapshots of shell configuration, Git
+configuration, Homebrew package lists, editor settings, and local tool state,
+then automates routine updates.
 
 It is built for people who want a repeatable macOS development environment with
 low-friction updates.
-
-## Quick start
-
-Install `ballin-scripts`, then run the first health check and backup:
-
-```shell
-ballin doctor
-ballin backup
-ballin update
-```
-
-`ballin doctor` checks whether the Ballin-managed environment is healthy.
-Run `ballin backup` once to create the initial snapshot, then use
-`ballin update` for ongoing maintenance.
 
 ## What this is
 
 `ballin-scripts` is a backup and update toolkit for repeatable macOS
 development environments. It is not a full disk backup, a secrets manager, or a
-complete one-command machine restore system.
+one-command machine restore system.
 
 ## Backup and update behavior
 
 The tools split backup from broader system updates:
 
 - `ballin backup` reads local development-environment state and uploads changed
-  snapshots to the configured private Gist.
+  snapshots to the configured secret GitHub Gist.
 - `ballin update` runs update tasks such as Homebrew upgrades, optional Node.js/npm
   updates, optional macOS and App Store updates, optional `ballin-scripts`
   updates, and optional backups.
-- Installation adds the command shims to your shell path and configures the
-  private Gist used by backups.
-
-Optional update behavior is controlled through `ballin config`.
-
-## Fresh Mac setup
-
-On a new Mac, install `ballin-scripts` and let the installer create or adopt the
-private backup Gist used by `ballin backup`. If you adopt an existing backup,
-use `ballin backup open` or `ballin backup read <file>` to inspect saved
-snapshots and use them as a rebuild reference.
+- Installation adds command shims to your shell path and configures the
+  secret Gist used by backups.
 
 ## Privacy and security
 
-Backups are stored in the configured private GitHub Gist. Treat them as
+Backups are stored in the configured secret GitHub Gist. Secret Gists are
+unlisted, but anyone with the URL can view them. Treat backup snapshots as
 developer-environment metadata: paths, usernames, package and tool choices,
 editor settings, and local configuration can reveal details about your setup.
-Review snapshots before sharing a Gist or making it public.
+Review snapshots before sharing the Gist URL or making the Gist public.
 
 ## Installation
 
@@ -80,6 +58,25 @@ bash /tmp/ballin-install.sh
 
 See the [documentation index](docs/README.md) for Node.js setup, update
 settings, optional integrations, and managed capabilities.
+
+After installation:
+
+```shell
+ballin doctor
+ballin backup
+ballin update
+```
+
+`ballin doctor` checks the Ballin-managed environment. Run `ballin backup` once
+to create the initial snapshot, then use `ballin update` for ongoing
+maintenance.
+
+## Fresh Mac setup
+
+On a new Mac, install `ballin-scripts` and let the installer create or adopt the
+secret Gist used by backups. If you adopt an existing backup, use
+`ballin backup open` or `ballin backup read <file>` to inspect saved snapshots
+and use them as a rebuild reference.
 
 ## Example output
 
@@ -129,7 +126,7 @@ the full list of update integrations.
 
 ### Back up with `ballin backup`
 
-`ballin backup` uploads changed snapshots to a configured private Gist. It can
+`ballin backup` uploads changed snapshots to the configured secret Gist. It can
 include local files and tool state when the supporting tools are installed.
 
 See the [supported capabilities reference](docs/capabilities.md) for the full
@@ -165,7 +162,7 @@ ballin backup read zshrc.sh
 | --- | --- |
 | `ballin` | Shows available commands and common usage. |
 | `ballin update` | Updates Homebrew, macOS, App Store apps, optional Node.js/npm tools, `ballin-scripts`, and optional backups. |
-| `ballin backup` | Backs up dotfiles, editor settings, package lists, and tool state to a private Gist. |
+| `ballin backup` | Backs up dotfiles, editor settings, package lists, and tool state to a secret Gist. |
 | `ballin doctor` | Checks whether the Ballin-managed environment is healthy. |
 | `ballin config` | Reads and updates local Ballin settings. |
 | `ballin self-update` | Updates the local `ballin-scripts` checkout and refreshes installed commands and configuration. |

--- a/README.md
+++ b/README.md
@@ -17,15 +17,9 @@ Core commands:
 ## What it manages
 
 `ballin-scripts` backs up development-environment state that is easy to lose
-when moving between Macs or rebuilding a development machine:
-
-- shell startup files and common editor config files
-- Git config and global ignore files
-- Homebrew formulae, casks, services, and Brewfile output
-- global npm packages and Node.js version preference
-- VS Code and VS Code Insiders settings, keybindings, and extensions
-- optional Mac App Store app inventory through `mas`
-- local `ballin-scripts` configuration
+when moving between Macs or rebuilding a development machine, including
+dotfiles, package and tool inventories, editor settings, and local Ballin
+configuration.
 
 See the [supported capabilities reference](docs/capabilities.md) for the exact
 snapshot files and update integrations.
@@ -142,9 +136,8 @@ the full list of update integrations.
 ### Back up with `ballin backup`
 
 `ballin backup` uploads changed snapshots to a configured private Gist. It can
-include shell dotfiles, Git config, Homebrew formulae and casks, global npm
-packages, nvm settings, editor settings, editor extensions, bash completions,
-and Mac App Store apps when the supporting tools are installed.
+include local files and optional tool output from the supported backup
+surfaces.
 
 See the [supported capabilities reference](docs/capabilities.md) for the full
 list of backup snapshots.

--- a/README.md
+++ b/README.md
@@ -7,32 +7,24 @@ environments with minimal manual setup. It snapshots shell and Git
 configuration, Homebrew package lists, editor settings, and local tool state,
 then automates routine updates.
 
-## Scope
+It is designed for developers who want their Mac setup to be repeatable,
+inspectable, and easy to keep current.
 
-`ballin-scripts` is a backup and update toolkit for repeatable macOS
-development environments. It is not a full disk backup, a secrets manager, or a
-one-command machine restore system.
+## What it does
 
-- `ballin backup` snapshots local development-environment state to the
-  configured secret GitHub Gist.
-- `ballin update` runs update tasks such as Homebrew upgrades, optional Node.js/npm
-  updates, optional macOS and App Store updates, optional `ballin-scripts`
-  updates, and optional backups.
+- `ballin backup` snapshots local development-environment state to a configured
+  secret GitHub Gist.
+- `ballin update` runs common maintenance tasks such as Homebrew upgrades,
+  optional Node.js/npm updates, optional macOS and App Store updates, optional
+  `ballin-scripts` updates, and optional backups.
 - The installer adds command shims to your shell path and configures the backup
   Gist.
-
-## Privacy and security
-
-Backups are stored in a configured secret GitHub Gist. Secret Gists are
-unlisted, but anyone with the URL can view them. Treat both the Gist URL and
-backup snapshots as sensitive: paths, usernames, package choices, editor
-settings, and local configuration can reveal details about your setup.
 
 ## Installation
 
 The installer is interactive and guides you through missing setup. For the
-smoothest first run, use macOS with current Node.js LTS, authenticated GitHub
-CLI, and Homebrew available.
+smoothest first run, use macOS with Node.js LTS, Homebrew, and an authenticated
+GitHub CLI.
 
 Install with:
 
@@ -40,7 +32,7 @@ Install with:
 bash <(curl -fsSL https://raw.githubusercontent.com/JBallin/ballin-scripts/main/install.sh)
 ```
 
-To inspect the installer first:
+Inspect first:
 
 ```shell
 curl -fsSL https://raw.githubusercontent.com/JBallin/ballin-scripts/main/install.sh -o /tmp/ballin-install.sh
@@ -58,12 +50,6 @@ ballin update
 
 `ballin doctor` checks the managed environment. `ballin backup` creates the
 initial snapshot. `ballin update` handles ongoing maintenance.
-
-## Fresh Mac setup
-
-On a new Mac, install `ballin-scripts` and create or adopt the backup Gist. If
-you adopt an existing backup, inspect saved snapshots with `ballin backup open`
-or `ballin backup read <file>` and use them as a rebuild reference.
 
 ## Example output
 
@@ -92,21 +78,40 @@ Your system is ready to brew.
 ✔ mas
 ```
 
+## Fresh Mac setup
+
+On a new Mac, install `ballin-scripts` and create or adopt the backup Gist. If
+you adopt an existing backup, inspect saved snapshots with `ballin backup open`
+or `ballin backup read <file>` and use them as a rebuild reference.
+
+`ballin-scripts` makes rebuilds more repeatable and auditable, but it is not a
+full disk backup or one-command machine restore system.
+
 ## Commands
 
 | Command | Purpose |
 | --- | --- |
 | `ballin` | Shows available commands and common usage. |
 | `ballin doctor` | Checks the managed environment. |
-| `ballin update` | Runs configured update tasks. |
 | `ballin backup` | Updates backup snapshots in the configured secret Gist. |
 | `ballin backup open` | Opens the configured backup Gist. |
 | `ballin backup read <file>` | Prints one backed-up file from the Gist. |
+| `ballin update` | Runs configured update tasks. |
 | `ballin config` | Reads and updates local Ballin settings. |
-| `ballin self-update` | Updates the local checkout and refreshes installed commands and configuration. |
-| `ballin uninstall` | Removes installed command symlinks and the local checkout. |
+| `ballin self-update` | Updates the local checkout and refreshes installed commands/configuration. |
+| `ballin uninstall` | Removes installed command shims and the local checkout. |
 
 ## Documentation
 
-See the [documentation index](docs/README.md) for Node.js setup, update
-settings, optional integrations, and managed capabilities.
+See the [documentation index](docs/README.md) for Node.js setup, update settings,
+optional integrations, and managed capabilities.
+
+## Privacy and security
+
+Backups are stored in a configured secret GitHub Gist. Secret Gists are
+unlisted, but anyone with the URL can view them. Treat the Gist URL and backup
+snapshots as sensitive: paths, usernames, package choices, editor settings, and
+local configuration can reveal details about your setup.
+
+`ballin-scripts` is not a secrets manager. Review snapshots before sharing the
+Gist URL or making the Gist public.

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ lists, editor settings, and local tool state, then automates routine updates.
 ## Installation
 
 The installer adds command shims, configures the backup Gist, and guides you
-through missing setup. For the smoothest first run, use macOS with Node.js LTS,
-Homebrew, and an authenticated GitHub CLI.
+through missing setup. For the smoothest first run, have Node.js LTS, Homebrew,
+and an authenticated GitHub CLI available.
 
 Run the [install script](https://raw.githubusercontent.com/JBallin/ballin-scripts/main/install.sh):
 
@@ -79,8 +79,8 @@ full disk backup or one-command restore system.
 
 Backups are stored in a configured secret GitHub Gist. Secret Gists are
 unlisted, but anyone with the URL can view them. Treat the Gist URL and
-snapshots as sensitive: paths, usernames, package choices, editor settings, and
-local configuration can reveal details about your setup.
+snapshots as sensitive: they can reveal paths, usernames, package choices,
+editor settings, and local configuration.
 
 `ballin-scripts` is not a secrets manager. Review snapshots before sharing the
 Gist URL or making the Gist public.

--- a/README.md
+++ b/README.md
@@ -2,13 +2,9 @@
 
 *Back up your dotfiles and update your macOS development environment.*
 
-`ballin-scripts` helps developers maintain and recreate macOS development
-environments with minimal manual setup. It snapshots shell and Git
-configuration, Homebrew package lists, editor settings, and local tool state,
-then automates routine updates.
-
-It is designed for developers who want their Mac setup to be repeatable,
-inspectable, and easy to keep current.
+`ballin-scripts` helps developers keep macOS setup repeatable, inspectable, and
+easy to maintain. It snapshots shell and Git configuration, Homebrew package
+lists, editor settings, and local tool state, then automates routine updates.
 
 ## What it does
 
@@ -17,14 +13,12 @@ inspectable, and easy to keep current.
 - `ballin update` runs common maintenance tasks such as Homebrew upgrades,
   optional Node.js/npm updates, optional macOS and App Store updates, optional
   `ballin-scripts` updates, and optional backups.
-- The installer adds command shims to your shell path and configures the backup
-  Gist.
 
 ## Installation
 
-The installer is interactive and guides you through missing setup. For the
-smoothest first run, use macOS with Node.js LTS, Homebrew, and an authenticated
-GitHub CLI.
+The installer adds command shims to your shell path, configures the backup Gist,
+and guides you through missing setup. For the smoothest first run, use macOS
+with Node.js LTS, Homebrew, and an authenticated GitHub CLI.
 
 Install with:
 
@@ -80,12 +74,12 @@ Your system is ready to brew.
 
 ## Fresh Mac setup
 
-On a new Mac, install `ballin-scripts` and create or adopt the backup Gist. If
-you adopt an existing backup, inspect saved snapshots with `ballin backup open`
-or `ballin backup read <file>` and use them as a rebuild reference.
+On a new Mac, install `ballin-scripts` and create or adopt the backup Gist.
+Inspect existing snapshots with `ballin backup open` or
+`ballin backup read <file>`, then use them as a rebuild reference.
 
 `ballin-scripts` makes rebuilds more repeatable and auditable, but it is not a
-full disk backup or one-command machine restore system.
+full disk backup or one-command restore system.
 
 ## Commands
 
@@ -93,9 +87,9 @@ full disk backup or one-command machine restore system.
 | --- | --- |
 | `ballin` | Shows available commands and common usage. |
 | `ballin doctor` | Checks the managed environment. |
-| `ballin backup` | Updates backup snapshots in the configured secret Gist. |
+| `ballin backup` | Updates snapshots in the configured secret Gist. |
 | `ballin backup open` | Opens the configured backup Gist. |
-| `ballin backup read <file>` | Prints one backed-up file from the Gist. |
+| `ballin backup read <file>` | Prints a backed-up file from the Gist. |
 | `ballin update` | Runs configured update tasks. |
 | `ballin config` | Reads and updates local Ballin settings. |
 | `ballin self-update` | Updates the local checkout and refreshes installed commands/configuration. |
@@ -109,7 +103,7 @@ optional integrations, and managed capabilities.
 ## Privacy and security
 
 Backups are stored in a configured secret GitHub Gist. Secret Gists are
-unlisted, but anyone with the URL can view them. Treat the Gist URL and backup
+unlisted, but anyone with the URL can view them. Treat the Gist URL and
 snapshots as sensitive: paths, usernames, package choices, editor settings, and
 local configuration can reveal details about your setup.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Ballin Scripts
 
-*Back up dotfiles. Keep your tools current.*
+*Back up your dotfiles and update your macOS development environment.*
 
 `ballin-scripts` helps developers maintain repeatable, inspectable macOS
 development environments. It snapshots shell and Git configuration, Homebrew

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ include local files and optional tool output from the supported backup
 surfaces.
 
 See the [supported capabilities reference](docs/capabilities.md) for the full
-list of backup snapshots.
+list of snapshot files, optional tool output, and requirements.
 
 ```shell
 ballin backup

--- a/README.md
+++ b/README.md
@@ -10,15 +10,11 @@ local tool state, then automates routine updates.
 It is built for people who want a repeatable macOS development environment with
 low-friction updates.
 
-Core commands:
-
-- `ballin update` updates the development environment.
-- `ballin backup` snapshots the development environment to a private Gist.
-
 ## Quick start
 
+Install `ballin-scripts`, then run the first health check and backup:
+
 ```shell
-bash <(curl -fsSL https://raw.githubusercontent.com/JBallin/ballin-scripts/main/install.sh)
 ballin doctor
 ballin backup
 ballin update
@@ -53,12 +49,7 @@ Optional update behavior is controlled through `ballin config`.
 On a new Mac, install `ballin-scripts` and let the installer create or adopt the
 private backup Gist used by `ballin backup`. If you adopt an existing backup,
 use `ballin backup open` or `ballin backup read <file>` to inspect saved
-snapshots while you recreate shell files, Git settings, package lists, editor
-settings, and other development-environment state.
-
-This is currently a backup and update toolkit, not a full one-command
-machine restore system. The backed-up snapshots make rebuilds more repeatable
-and auditable.
+snapshots and use them as a rebuild reference.
 
 ## Privacy and security
 
@@ -67,16 +58,11 @@ developer-environment metadata: paths, usernames, package and tool choices,
 editor settings, and local configuration can reveal details about your setup.
 Review snapshots before sharing a Gist or making it public.
 
-## Before you install
+## Installation
 
 The installer is interactive and guides you through missing setup. For the
 smoothest first run, use macOS with current Node.js LTS, authenticated GitHub
 CLI, and Homebrew available.
-
-Optional integrations and setup tradeoffs are covered in the
-[optional capabilities guide](docs/optional-capabilities.md).
-
-## Installation
 
 Install with:
 
@@ -93,7 +79,7 @@ bash /tmp/ballin-install.sh
 ```
 
 See the [documentation index](docs/README.md) for Node.js setup, update
-settings, optional integrations, and the full list of managed capabilities.
+settings, optional integrations, and managed capabilities.
 
 ## Example output
 
@@ -119,14 +105,7 @@ Your system is ready to brew.
 ==> Backing up development environment
 ✔ zprofile
 ✔ zshrc
-✔ bash_completions
 ...
-✔ brew_list
-✔ brew_leaves
-✔ brew_cask
-✔ Brewfile
-✔ gitconfig
-✔ npm_global
 ✔ vs_settings
 ✔ mas
 ```
@@ -151,8 +130,7 @@ the full list of update integrations.
 ### Back up with `ballin backup`
 
 `ballin backup` uploads changed snapshots to a configured private Gist. It can
-include local files and package, tool, and editor state when the supporting
-tools are installed.
+include local files and tool state when the supporting tools are installed.
 
 See the [supported capabilities reference](docs/capabilities.md) for the full
 list of backup snapshots.

--- a/README.md
+++ b/README.md
@@ -10,9 +10,8 @@ lists, editor settings, and local tool state, then automates routine updates.
 
 - `ballin backup` snapshots local development-environment state to a configured
   secret GitHub Gist.
-- `ballin update` runs common maintenance tasks such as Homebrew upgrades,
-  optional Node.js/npm updates, optional macOS and App Store updates, optional
-  `ballin-scripts` updates, and optional backups.
+- `ballin update` runs configured maintenance tasks such as Homebrew upgrades,
+  Node.js/npm updates, macOS and App Store updates, self-updates, and backups.
 
 ## Installation
 
@@ -25,16 +24,6 @@ Run the [install script](https://raw.githubusercontent.com/JBallin/ballin-script
 ```shell
 bash <(curl -fsSL https://raw.githubusercontent.com/JBallin/ballin-scripts/main/install.sh)
 ```
-
-Then verify setup and create the initial backup:
-
-```shell
-ballin doctor
-ballin backup
-```
-
-`ballin doctor` checks the managed environment. `ballin backup` creates the
-initial snapshot. Use `ballin update` for ongoing maintenance.
 
 ## Example output
 
@@ -63,7 +52,7 @@ Your system is ready to brew.
 ✔ mas
 ```
 
-## Fresh Mac setup
+## New Mac setup
 
 On a new Mac, install `ballin-scripts` and create or adopt the backup Gist.
 Inspect existing snapshots with `ballin backup open` or
@@ -78,18 +67,13 @@ full disk backup or one-command restore system.
 | --- | --- |
 | `ballin` | Shows available commands and common usage. |
 | `ballin doctor` | Checks the managed environment. |
-| `ballin backup` | Updates snapshots in the configured secret Gist. |
+| `ballin backup` | Updates snapshots in the configured backup Gist. |
 | `ballin backup open` | Opens the configured backup Gist. |
 | `ballin backup read <file>` | Prints a backed-up file from the Gist. |
 | `ballin update` | Runs configured update tasks. |
 | `ballin config` | Reads and updates local Ballin settings. |
-| `ballin self-update` | Updates the local checkout and refreshes installed commands/configuration. |
+| `ballin self-update` | Updates the local checkout and refreshes installed commands and configuration. |
 | `ballin uninstall` | Removes installed command shims and the local checkout. |
-
-## Documentation
-
-See the [documentation index](docs/README.md) for Node.js setup, update settings,
-optional integrations, and managed capabilities.
 
 ## Privacy and security
 
@@ -100,3 +84,8 @@ local configuration can reveal details about your setup.
 
 `ballin-scripts` is not a secrets manager. Review snapshots before sharing the
 Gist URL or making the Gist public.
+
+## Documentation
+
+See the [documentation index](docs/README.md) for Node.js setup, update settings,
+optional integrations, and managed capabilities.

--- a/README.md
+++ b/README.md
@@ -18,8 +18,7 @@ Core commands:
 
 `ballin-scripts` backs up development-environment state that is easy to lose
 when moving between Macs or rebuilding a development machine, including
-dotfiles, package and tool inventories, editor settings, and local Ballin
-configuration.
+dotfiles, package and tool lists, and editor settings.
 
 See the [supported capabilities reference](docs/capabilities.md) for the exact
 snapshot files and update integrations.
@@ -136,11 +135,11 @@ the full list of update integrations.
 ### Back up with `ballin backup`
 
 `ballin backup` uploads changed snapshots to a configured private Gist. It can
-include local files and optional tool output from the supported backup
-surfaces.
+include local files and package, tool, and editor state when the supporting
+tools are installed.
 
 See the [supported capabilities reference](docs/capabilities.md) for the full
-list of snapshot files, optional tool output, and requirements.
+list of backup snapshots.
 
 ```shell
 ballin backup

--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@ lists, editor settings, and local tool state, then automates routine updates.
 
 ## Installation
 
-The installer adds command shims to your shell path, configures the backup Gist,
-and guides you through missing setup. For the smoothest first run, use macOS
-with Node.js LTS, Homebrew, and an authenticated GitHub CLI.
+The installer adds command shims, configures the backup Gist, and guides you
+through missing setup. For the smoothest first run, use macOS with Node.js LTS,
+Homebrew, and an authenticated GitHub CLI.
 
 Run the [install script](https://raw.githubusercontent.com/JBallin/ballin-scripts/main/install.sh):
 
@@ -26,14 +26,15 @@ Run the [install script](https://raw.githubusercontent.com/JBallin/ballin-script
 bash <(curl -fsSL https://raw.githubusercontent.com/JBallin/ballin-scripts/main/install.sh)
 ```
 
-Then create the initial backup:
+Then verify setup and create the initial backup:
 
 ```shell
 ballin doctor
 ballin backup
 ```
 
-Use `ballin update` for ongoing maintenance.
+`ballin doctor` checks the managed environment. `ballin backup` creates the
+initial snapshot. Use `ballin update` for ongoing maintenance.
 
 ## Example output
 

--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@ Core commands:
 
 ## What it manages
 
-`ballin-scripts` backs up development-environment state that is easy to lose
-when moving between Macs or rebuilding a development machine, including
-dotfiles, package and tool lists, and editor settings.
+`ballin-scripts` manages development-environment state that is easy to lose
+or tedious to maintain by backing up dotfiles, package and tool lists, and
+editor settings, then automating routine update tasks.
 
 See the [supported capabilities reference](docs/capabilities.md) for the exact
 snapshot files and update integrations.

--- a/README.md
+++ b/README.md
@@ -42,7 +42,6 @@ Your system is ready to brew.
 ==> Updating App Store apps
 
 ==> Installing macOS updates
-...
 
 ==> Backing up development environment
 ✔ zprofile

--- a/README.md
+++ b/README.md
@@ -2,9 +2,10 @@
 
 *Back up your dotfiles and update your macOS development environment.*
 
-`ballin-scripts` helps developers keep macOS setup repeatable, inspectable, and
-easy to maintain. It snapshots shell and Git configuration, Homebrew package
-lists, editor settings, and local tool state, then automates routine updates.
+`ballin-scripts` helps developers keep macOS development environments repeatable
+and inspectable. It snapshots shell and Git configuration, Homebrew package
+lists, editor settings, and local tool state, then automates routine
+maintenance.
 
 ## What it does
 
@@ -53,9 +54,8 @@ Your system is ready to brew.
 
 ## New Mac setup
 
-On a new Mac, install `ballin-scripts` and create or adopt the backup Gist.
-Inspect existing snapshots with `ballin backup open` or
-`ballin backup read <file>`, then use them as a rebuild reference.
+On a new Mac, install `ballin-scripts` and create or adopt the backup Gist. Use
+existing snapshots as a rebuild reference.
 
 `ballin-scripts` makes rebuilds more repeatable and auditable, but it is not a
 full disk backup or one-command restore system.
@@ -78,13 +78,12 @@ full disk backup or one-command restore system.
 
 Backups are stored in a configured secret GitHub Gist. Secret Gists are
 unlisted, but anyone with the URL can view them. Treat the Gist URL and
-snapshots as sensitive: they can reveal paths, usernames, package choices,
-editor settings, and local configuration.
+snapshots as sensitive.
 
-`ballin-scripts` is not a secrets manager. Review snapshots before sharing the
+`ballin-scripts` is not a secrets manager; review snapshots before sharing the
 Gist URL or making the Gist public.
 
 ## Documentation
 
-See the [documentation index](docs/README.md) for Node.js setup, update settings,
+See the [documentation](docs/README.md) for Node.js setup, update settings,
 optional integrations, and managed capabilities.

--- a/README.md
+++ b/README.md
@@ -2,39 +2,31 @@
 
 *Back up your dotfiles and update your macOS development environment.*
 
-`ballin-scripts` helps you recreate and maintain a macOS development environment
-with minimal manual setup. It stores snapshots of shell configuration, Git
+`ballin-scripts` helps developers maintain and recreate macOS development
+environments with minimal manual setup. It snapshots shell and Git
 configuration, Homebrew package lists, editor settings, and local tool state,
 then automates routine updates.
 
-It is built for people who want a repeatable macOS development environment with
-low-friction updates.
-
-## What this is
+## Scope
 
 `ballin-scripts` is a backup and update toolkit for repeatable macOS
 development environments. It is not a full disk backup, a secrets manager, or a
 one-command machine restore system.
 
-## Backup and update behavior
-
-The tools split backup from broader system updates:
-
-- `ballin backup` reads local development-environment state and uploads changed
-  snapshots to the configured secret GitHub Gist.
+- `ballin backup` snapshots local development-environment state to the
+  configured secret GitHub Gist.
 - `ballin update` runs update tasks such as Homebrew upgrades, optional Node.js/npm
   updates, optional macOS and App Store updates, optional `ballin-scripts`
   updates, and optional backups.
-- Installation adds command shims to your shell path and configures the
-  secret Gist used by backups.
+- The installer adds command shims to your shell path and configures the backup
+  Gist.
 
 ## Privacy and security
 
-Backups are stored in the configured secret GitHub Gist. Secret Gists are
-unlisted, but anyone with the URL can view them. Treat backup snapshots as
-developer-environment metadata: paths, usernames, package and tool choices,
-editor settings, and local configuration can reveal details about your setup.
-Review snapshots before sharing the Gist URL or making the Gist public.
+Backups are stored in a configured secret GitHub Gist. Secret Gists are
+unlisted, but anyone with the URL can view them. Treat both the Gist URL and
+backup snapshots as sensitive: paths, usernames, package choices, editor
+settings, and local configuration can reveal details about your setup.
 
 ## Installation
 
@@ -56,9 +48,6 @@ less /tmp/ballin-install.sh
 bash /tmp/ballin-install.sh
 ```
 
-See the [documentation index](docs/README.md) for Node.js setup, update
-settings, optional integrations, and managed capabilities.
-
 After installation:
 
 ```shell
@@ -67,22 +56,18 @@ ballin backup
 ballin update
 ```
 
-`ballin doctor` checks the Ballin-managed environment. Run `ballin backup` once
-to create the initial snapshot, then use `ballin update` for ongoing
-maintenance.
+`ballin doctor` checks the managed environment. `ballin backup` creates the
+initial snapshot. `ballin update` handles ongoing maintenance.
 
 ## Fresh Mac setup
 
-On a new Mac, install `ballin-scripts` and let the installer create or adopt the
-secret Gist used by backups. If you adopt an existing backup, use
-`ballin backup open` or `ballin backup read <file>` to inspect saved snapshots
-and use them as a rebuild reference.
+On a new Mac, install `ballin-scripts` and create or adopt the backup Gist. If
+you adopt an existing backup, inspect saved snapshots with `ballin backup open`
+or `ballin backup read <file>` and use them as a rebuild reference.
 
 ## Example output
 
-With optional integrations enabled, `ballin update` updates the machine and can
-finish by backing up the development environment. Output varies by installed
-tools and settings.
+`ballin update` output depends on installed tools and enabled integrations.
 
 ```shell
 $ ballin update
@@ -107,63 +92,21 @@ Your system is ready to brew.
 ✔ mas
 ```
 
-## Usage
-
-### Update with `ballin update`
-
-`ballin update` automates common update tasks for a macOS development machine,
-including Homebrew upgrades, App Store and macOS updates, `ballin-scripts`
-updates, optional Node.js/npm updates, and optional backups.
-
-```shell
-ballin update
-```
-
-Most optional behavior is controlled through `ballin config`; see the
-[optional capabilities guide](docs/optional-capabilities.md) for update
-settings, and the [supported capabilities reference](docs/capabilities.md) for
-the full list of update integrations.
-
-### Back up with `ballin backup`
-
-`ballin backup` uploads changed snapshots to the configured secret Gist. It can
-include local files and tool state when the supporting tools are installed.
-
-See the [supported capabilities reference](docs/capabilities.md) for the full
-list of backup snapshots.
-
-```shell
-ballin backup
-```
-
-Backup status markers:
-
-- `✚` newly saved or newly meaningful snapshot
-- `✎` existing snapshot content changed
-- `✖︎` existing snapshot became empty
-- `✔` unchanged non-empty snapshot
-- unchanged empty snapshots do not print a line
-
-Open the configured backup Gist:
-
-```shell
-ballin backup open
-```
-
-Read one backed-up file from the Gist:
-
-```shell
-ballin backup read zshrc.sh
-```
-
 ## Commands
 
 | Command | Purpose |
 | --- | --- |
 | `ballin` | Shows available commands and common usage. |
-| `ballin update` | Updates Homebrew, macOS, App Store apps, optional Node.js/npm tools, `ballin-scripts`, and optional backups. |
-| `ballin backup` | Backs up dotfiles, editor settings, package lists, and tool state to a secret Gist. |
-| `ballin doctor` | Checks whether the Ballin-managed environment is healthy. |
+| `ballin doctor` | Checks the managed environment. |
+| `ballin update` | Runs configured update tasks. |
+| `ballin backup` | Updates backup snapshots in the configured secret Gist. |
+| `ballin backup open` | Opens the configured backup Gist. |
+| `ballin backup read <file>` | Prints one backed-up file from the Gist. |
 | `ballin config` | Reads and updates local Ballin settings. |
-| `ballin self-update` | Updates the local `ballin-scripts` checkout and refreshes installed commands and configuration. |
+| `ballin self-update` | Updates the local checkout and refreshes installed commands and configuration. |
 | `ballin uninstall` | Removes installed command symlinks and the local checkout. |
+
+## Documentation
+
+See the [documentation index](docs/README.md) for Node.js setup, update
+settings, optional integrations, and managed capabilities.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Ballin Scripts
 
-*Back up your development environment and keep your macOS tooling up to date.*
+*Back up dotfiles. Keep your tools current.*
 
 `ballin-scripts` helps developers maintain repeatable, inspectable macOS
 development environments. It snapshots shell and Git configuration, Homebrew

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Ballin Scripts
 
-*Back up your dotfiles and update your macOS development environment.*
+*Back up your development environment and keep your macOS tooling up to date.*
 
 `ballin-scripts` helps developers maintain repeatable, inspectable macOS
 development environments. It snapshots shell and Git configuration, Homebrew

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,12 +2,17 @@
 
 Start here when setting up or auditing what `ballin-scripts` manages.
 
-- [Design system](design-system.md): Ballin identity, product messaging,
-  visual guidance, and brand asset conventions.
+## User guides
+
 - [Optional capabilities](optional-capabilities.md): Node.js setup, optional
   tool setup, analytics opt-out, and configurable `ballin update` settings.
 - [Analytics](analytics.md): analytics consent, payload, opt-out, and retention.
 - [Supported capabilities](capabilities.md): the current `ballin update`
   integrations and `ballin backup` snapshots.
+
+## Maintainer guides
+
+- [Design system](design-system.md): Ballin identity, product messaging,
+  visual guidance, and brand asset conventions.
 - [Analytics backend](analytics-backend.md): backend deployment and data-policy
   notes for usage analytics.

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -22,8 +22,8 @@ integrations and exits nonzero at the end.
 
 ## `ballin backup`
 
-`ballin backup` backs up changed snapshots to the configured private Gist. It
-can snapshot:
+`ballin backup` backs up changed snapshots to the configured secret GitHub Gist.
+It can snapshot:
 
 | Area | Snapshot files | Requirement |
 | --- | --- | --- |
@@ -40,3 +40,16 @@ can snapshot:
 | Editor config files | `vimrc`, `nanorc` | Matching dotfiles in `HOME`. |
 | Ballin config | `ballin_config` | Local `ballin.config.json` file. |
 | Mac App Store apps | `mas` | `mas` on `PATH`. |
+
+### Output markers
+
+`ballin backup` prints one line per meaningful snapshot result:
+
+| Marker | Meaning |
+| --- | --- |
+| `✚` | Newly saved or newly meaningful snapshot. |
+| `✎` | Existing snapshot content changed. |
+| `✖︎` | Existing snapshot became empty. |
+| `✔` | Unchanged non-empty snapshot. |
+
+Unchanged empty snapshots do not print a line.

--- a/docs/optional-capabilities.md
+++ b/docs/optional-capabilities.md
@@ -90,10 +90,6 @@ again.
 Use `ballin backup open` to open the configured backup Gist, or
 `ballin backup read <file>` to print one saved snapshot.
 
-On a new Mac, install `ballin-scripts` and adopt the existing backup Gist. Use
-the saved snapshots as a rebuild reference; `ballin-scripts` is not a full disk
-backup or one-command machine restore system.
-
 ## Readiness checks
 
 Use `ballin doctor` to check whether the Ballin-managed environment is healthy,

--- a/docs/optional-capabilities.md
+++ b/docs/optional-capabilities.md
@@ -82,8 +82,17 @@ an adopted backup includes a saved `ballin_config` snapshot, the installer resto
 them before continuing.
 
 Setup creates backup Gists as secret. To share one publicly, make it public in
-GitHub after reviewing it: public backups can expose paths, usernames, tool
-choices, package lists, and other local config, and cannot be made secret again.
+GitHub after reviewing it: secret Gists are unlisted, but anyone with the URL
+can view them. Backup snapshots can expose paths, usernames, tool choices,
+package lists, and other local config, and public Gists cannot be made secret
+again.
+
+Use `ballin backup open` to open the configured backup Gist, or
+`ballin backup read <file>` to print one saved snapshot.
+
+On a new Mac, install `ballin-scripts` and adopt the existing backup Gist. Use
+the saved snapshots as a rebuild reference; `ballin-scripts` is not a full disk
+backup or one-command machine restore system.
 
 ## Readiness checks
 


### PR DESCRIPTION
## Summary
- polish the README around value, installation, example output, new Mac setup, commands, privacy, and docs
- remove duplicated detailed backup inventory from the root README and keep docs/capabilities.md as the detailed reference
- document `ballin backup` output markers in docs/capabilities.md
- preserve backup Gist usage details in docs/optional-capabilities.md, including `backup open`, `backup read`, and secret Gist visibility
- organize docs/README.md into user and maintainer guide groups

Closes #250

## Validation
- git diff --check origin/main...HEAD
- Skipped local tests because this is documentation-only.