### PR TITLE
docs: remove README tagline period

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Ballin Scripts
 
-*Back up your dotfiles and update your macOS development environment.*
+*Back up your dotfiles and update your macOS development environment*
 
 ![Ballin README hero showing the Ballin identity and the line Back up dotfiles. Keep your tools current.](docs/assets/brand/readme-hero.png)
 


### PR DESCRIPTION
## Summary

- remove the trailing period from the README tagline

## Validation

- Not run (README-only change; repo guidance says to skip local validation for docs-only edits)
