### PR TITLE
docs: link README install script to GitHub view

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The installer adds command shims, configures the backup Gist, and guides you
 through missing setup. For the smoothest first run, have Node.js LTS, Homebrew,
 and an authenticated GitHub CLI available.
 
-Run the [install script](https://raw.githubusercontent.com/JBallin/ballin-scripts/main/install.sh):
+Run the [install script](https://github.com/JBallin/ballin-scripts/blob/main/install.sh):
 
 ```shell
 bash <(curl -fsSL https://raw.githubusercontent.com/JBallin/ballin-scripts/main/install.sh)


### PR DESCRIPTION
## Summary

- Update the README's browsable install script link to open the GitHub file view with syntax highlighting.
- Keep the executable `curl` command pointed at the raw install script URL.

## Impact

Readers who click the install script link now land on the rendered GitHub source view, while the copy-paste install command keeps using the raw URL required for shell execution.

## Validation

- `git diff --check`
- Skipped the full test suite because this is a docs-only link change.