### PR TITLE
docs: clarify environment backup capabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 `ballin-scripts` helps developers maintain repeatable, inspectable macOS
 development environments. It snapshots shell and Git configuration, Homebrew
-package lists, editor settings, and local tool state, then automates routine
+state, editor settings, and local tool inventories while automating routine
 updates.
 
 ## What it does

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -41,6 +41,13 @@ It can snapshot:
 | Ballin config | `ballin_config` | Local `ballin.config.json` file. |
 | Mac App Store apps | `mas` | `mas` on `PATH`. |
 
+For Homebrew, Ballin generates the saved `Brewfile` from the current Mac through
+Homebrew Bundle by running `brew bundle dump --file=-`. It stores the Brewfile
+alongside separate inventories for formulae, leaves, casks, and services. This
+capability is capture/reference only: `ballin backup` does not use the Brewfile
+to check, install, clean up, or upgrade packages, or to run another apply/restore
+workflow.
+
 ### Output markers
 
 `ballin backup` prints one line per meaningful snapshot result:

--- a/docs/optional-capabilities.md
+++ b/docs/optional-capabilities.md
@@ -87,6 +87,11 @@ as sensitive. To make one discoverable, make it public in GitHub after reviewing
 it: backup snapshots can expose paths, usernames, tool choices, package lists,
 and other local config, and public Gists cannot be made secret again.
 
+When Ballin saves changed snapshots to the Gist, GitHub preserves the Gist's
+native revision history and diffs, so you can inspect changes between backup
+revisions through GitHub. Ballin does not currently provide its own history
+navigation, rollback, restore, or revision-selection commands.
+
 Use `ballin backup open` to open the configured backup Gist, or
 `ballin backup read <file>` to print one saved snapshot.
 


### PR DESCRIPTION
## Summary

- replace the README opening with the approved environment-maintenance wording
- explain that GitHub provides native Gist revision history and diffs while Ballin only saves changed snapshots
- document the exact Homebrew Bundle capture command and distinguish the saved Brewfile from separate Homebrew inventories and unsupported apply/restore workflows

## Validation

- confirmed the normalized README opening exactly matches the approved wording
- verified the Brewfile description against `commands/backup.ts` and `brew bundle dump --file=-`
- inspected the surrounding prose and Markdown structure
- ran `git diff --check`
- skipped `npm test` per the repository's docs-only validation guidance

## Scope

#261 remains open and was intentionally excluded as a separate documentation-inspiration exercise. #272 and #278 were also kept out of this focused documentation change.

Closes #260
Closes #262
Closes #270