### PR TITLE
fix: make update and doctor failures reliable

### DIFF
--- a/commands/doctor_report.ts
+++ b/commands/doctor_report.ts
@@ -25,6 +25,7 @@ const nextSteps: Record<string, string> = {
   'backup.gist': 'Run the installer to create or adopt a backup Gist.',
   'backup.gh': 'Install GitHub CLI and authenticate it for your backup host.',
   'backup.auth': 'Run gh auth login for the configured backup host.',
+  'backup.read': 'Confirm the configured Gist ID is readable on the backup host.',
 };
 
 const formatDoctorCheck = (check: DoctorCheck, nextPrefix = '      Next: '): string => {

--- a/commands/setup_readiness.ts
+++ b/commands/setup_readiness.ts
@@ -226,12 +226,20 @@ const guConfigChecks = (
   runCommand: RunCommand,
 ): SetupReadinessCheck[] => {
   if (!config) {
-    return [{
-      id: 'backup.config',
-      label: 'Gist backup config',
-      status: 'info',
-      summary: 'Skipping Gist backup config checks until config is readable.',
-    }];
+    return [
+      {
+        id: 'backup.config',
+        label: 'Gist backup config',
+        status: 'info',
+        summary: 'Skipping Gist backup config checks until config is readable.',
+      },
+      {
+        id: 'backup.read',
+        label: 'Configured Gist readability',
+        status: 'info',
+        summary: 'Skipping configured Gist readability check until config is readable.',
+      },
+    ];
   }
 
   const backupConfig = isConfigObject(config.backup) ? config.backup : null;
@@ -251,7 +259,7 @@ const guConfigChecks = (
     {
       id: 'backup.gist',
       label: 'Gist ID',
-      status: hasConfiguredId ? 'pass' : 'warn',
+      status: hasConfiguredId ? 'pass' : 'fail',
       summary: hasConfiguredId
         ? 'Backup Gist ID is configured.'
         : 'Backup Gist ID is not configured yet.',
@@ -263,7 +271,7 @@ const guConfigChecks = (
   checks.push({
     id: 'backup.gh',
     label: 'GitHub CLI',
-    status: ghAvailable ? 'pass' : 'warn',
+    status: ghAvailable ? 'pass' : 'fail',
     summary: ghAvailable
       ? 'GitHub CLI is discoverable on PATH.'
       : 'GitHub CLI is not discoverable on PATH.',
@@ -277,6 +285,12 @@ const guConfigChecks = (
       status: 'info',
       summary: 'Skipping GitHub CLI authentication check until backup.host is configured.',
     });
+    checks.push({
+      id: 'backup.read',
+      label: 'Configured Gist readability',
+      status: 'info',
+      summary: 'Skipping configured Gist readability check until backup.host is configured.',
+    });
     return checks;
   }
 
@@ -286,6 +300,13 @@ const guConfigChecks = (
       label: 'GitHub CLI authentication',
       status: 'info',
       summary: 'Skipping GitHub CLI authentication check because gh is not on PATH.',
+      data: { host },
+    });
+    checks.push({
+      id: 'backup.read',
+      label: 'Configured Gist readability',
+      status: 'info',
+      summary: 'Skipping configured Gist readability check because gh is not on PATH.',
       data: { host },
     });
     return checks;
@@ -299,14 +320,47 @@ const guConfigChecks = (
     stdio: ['ignore', 'ignore', 'pipe'],
   });
   const exitStatus = authResult.error ? 1 : spawnResultStatus(authResult);
+  const authenticated = !authResult.error && exitStatus === 0;
   checks.push({
     id: 'backup.auth',
     label: 'GitHub CLI authentication',
-    status: authResult.status === 0 && !authResult.error ? 'pass' : 'warn',
-    summary: authResult.status === 0 && !authResult.error
+    status: authenticated ? 'pass' : 'fail',
+    summary: authenticated
       ? `GitHub CLI is authenticated for ${host}.`
       : `GitHub CLI is not authenticated for ${host}.`,
     data: { host, exitStatus },
+  });
+
+  if (!authenticated || !hasConfiguredId) {
+    checks.push({
+      id: 'backup.read',
+      label: 'Configured Gist readability',
+      status: 'info',
+      summary: !authenticated
+        ? 'Skipping configured Gist readability check until GitHub CLI authentication succeeds.'
+        : 'Skipping configured Gist readability check until a backup Gist ID is configured.',
+      data: { host },
+    });
+    return checks;
+  }
+
+  const readResult = runCommand('gh', ['gist', 'view', id, '--files'], {
+    env: {
+      ...env,
+      GH_HOST: host,
+    },
+    stdio: ['ignore', 'ignore', 'pipe'],
+  });
+  const readExitStatus = readResult.error ? 1 : spawnResultStatus(readResult);
+  const readable = !readResult.error && readExitStatus === 0;
+  checks.push({
+    id: 'backup.read',
+    label: 'Configured Gist readability',
+    status: readable ? 'pass' : 'fail',
+    summary: readable
+      ? 'The configured backup Gist exists and is readable. Write permission was not checked.'
+      : 'The configured backup Gist could not be read.',
+    data: { host, exitStatus: readExitStatus },
   });
 
   return checks;

--- a/commands/setup_readiness.ts
+++ b/commands/setup_readiness.ts
@@ -312,7 +312,7 @@ const guConfigChecks = (
     return checks;
   }
 
-  const authResult = runCommand('gh', ['auth', 'status', '--hostname', host], {
+  const authResult = runCommand('gh', ['auth', 'status', '--active', '--hostname', host], {
     env: {
       ...env,
       GH_HOST: host,
@@ -344,7 +344,7 @@ const guConfigChecks = (
     return checks;
   }
 
-  const readResult = runCommand('gh', ['gist', 'view', id, '--files'], {
+  const readResult = runCommand('gh', ['gist', 'view', '--files', '--', id], {
     env: {
       ...env,
       GH_HOST: host,

--- a/commands/update.ts
+++ b/commands/update.ts
@@ -5,7 +5,7 @@ const {
   runWithCommandAnalytics,
 } = require('./analytics.ts');
 const {
-  getConfig,
+  configPath,
 } = require('../config/index.ts');
 const {
   formatDefaultDoctorReport,
@@ -27,23 +27,110 @@ const {
 import type { DoctorReport } from './doctor_report.ts';
 
 type NvmInstallResult = {
+  captureFailed: boolean;
   env: NodeJS.ProcessEnv | null;
   status: number;
 };
 
-const configValue = (key: string): string => {
-  try {
-    const value = getConfig(key);
-    if (typeof value === 'string' && value.startsWith('INVALID:')) {
-      return '';
-    }
-    return value === null ? '' : String(value).trim();
-  } catch (error) {
-    if (error instanceof Error) {
-      writeStderrLine(`Unable to read config: ${error.message}`);
-    }
-    return '';
+type ConfigObject = Record<string, unknown>;
+type UpdateSetting = 'cleanup' | 'nvm' | 'npm' | 'softwareupdate' | 'selfUpdate' | 'backup';
+type UpdateSettings = Record<UpdateSetting, boolean>;
+
+const updateSettingKeys: UpdateSetting[] = [
+  'cleanup',
+  'nvm',
+  'npm',
+  'softwareupdate',
+  'selfUpdate',
+  'backup',
+];
+
+const isConfigObject = (value: unknown): value is ConfigObject => (
+  typeof value === 'object' && value !== null && !Array.isArray(value)
+);
+
+const hasOwn = (value: ConfigObject, key: string): boolean => (
+  Object.prototype.hasOwnProperty.call(value, key)
+);
+
+const parseBooleanSetting = (value: unknown): boolean | null => {
+  if (typeof value === 'boolean') {
+    return value;
   }
+  if (value === 'true') {
+    return true;
+  }
+  if (value === 'false') {
+    return false;
+  }
+  return null;
+};
+
+const readConfigObject = (filePath: string, description: string): ConfigObject => {
+  let contents: string;
+  try {
+    contents = fs.readFileSync(filePath, 'utf8');
+  } catch (error) {
+    const message = error instanceof Error ? `: ${error.message}` : '';
+    throw new Error(`Unable to read ${description}${message}`);
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(contents);
+  } catch {
+    throw new Error(`${description} is not valid JSON.`);
+  }
+  if (!isConfigObject(parsed)) {
+    throw new Error(`${description} must contain a JSON object.`);
+  }
+  return parsed;
+};
+
+const resolveUpdateSettings = (): UpdateSettings => {
+  const defaultConfigPath = path.join(__dirname, '..', 'config', '.defaultConfig.json');
+  const defaults = readConfigObject(defaultConfigPath, 'bundled default config');
+  if (!isConfigObject(defaults.update)) {
+    throw new Error('Bundled default config must contain an update object.');
+  }
+
+  const defaultSettings = {} as UpdateSettings;
+  updateSettingKeys.forEach((key) => {
+    if (!hasOwn(defaults.update as ConfigObject, key)) {
+      throw new Error(`Bundled default config is missing update.${key}.`);
+    }
+    const value = parseBooleanSetting((defaults.update as ConfigObject)[key]);
+    if (value === null) {
+      throw new Error(`Bundled default update.${key} must be true or false.`);
+    }
+    defaultSettings[key] = value;
+  });
+
+  const userConfig = readConfigObject(configPath, 'Ballin config');
+  const hasUpdateSection = hasOwn(userConfig, 'update');
+  if (hasUpdateSection && !isConfigObject(userConfig.update)) {
+    throw new Error('Ballin config update section must contain a JSON object.');
+  }
+  const userUpdate = hasUpdateSection ? userConfig.update as ConfigObject : {};
+  const settings = { ...defaultSettings };
+  const defaultedKeys: string[] = [];
+
+  updateSettingKeys.forEach((key) => {
+    if (!hasOwn(userUpdate, key)) {
+      defaultedKeys.push(`update.${key}`);
+      return;
+    }
+    const value = parseBooleanSetting(userUpdate[key]);
+    if (value === null) {
+      throw new Error(`Ballin config update.${key} must be true or false.`);
+    }
+    settings[key] = value;
+  });
+
+  if (defaultedKeys.length > 0) {
+    writeStderrLine(`Warning: using bundled defaults for missing settings: ${defaultedKeys.join(', ')}.`);
+  }
+  return settings;
 };
 
 const parseEnvOutput = (output: string): NodeJS.ProcessEnv | null => {
@@ -74,6 +161,7 @@ const runNvmInstall = (env: NodeJS.ProcessEnv): NvmInstallResult => {
 
     if (result.error) {
       return {
+        captureFailed: false,
         env: null,
         status: reportSpawnError('bash', result.error),
       };
@@ -81,21 +169,24 @@ const runNvmInstall = (env: NodeJS.ProcessEnv): NvmInstallResult => {
     const status = spawnResultStatus(result);
     if (status !== 0 || !fs.existsSync(envPath)) {
       return {
+        captureFailed: status === 0,
         env: null,
-        status,
+        status: status === 0 ? 1 : status,
       };
     }
 
     const nextEnv = parseEnvOutput(fs.readFileSync(envPath, 'utf8'));
     if (!nextEnv) {
       return {
+        captureFailed: true,
         env: null,
-        status,
+        status: 1,
       };
     }
 
     delete nextEnv.BALLIN_UPDATE_ENV_PATH;
     return {
+      captureFailed: false,
       env: nextEnv,
       status,
     };
@@ -119,7 +210,7 @@ const ballinCommandPath = (): string => (
   process.env.BALLIN_TEST_BALLIN_PATH || path.join(__dirname, '..', 'bin', 'ballin')
 );
 
-const reportBallinReadiness = (env: NodeJS.ProcessEnv): void => {
+const reportBallinReadiness = (env: NodeJS.ProcessEnv): number => {
   const repoDir = path.join(__dirname, '..');
   const report = collectSetupReadiness({
     repoDir,
@@ -129,11 +220,28 @@ const reportBallinReadiness = (env: NodeJS.ProcessEnv): void => {
   }) as DoctorReport;
 
   process.stdout.write(formatDefaultDoctorReport(report));
+  return report.status === 'fail' ? 1 : 0;
 };
 
 function runUpdateCommand(): void {
+  let settings: UpdateSettings;
+  try {
+    settings = resolveUpdateSettings();
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unknown configuration error.';
+    writeStderrLine(`Unable to resolve update configuration: ${message}`);
+    process.exitCode = 1;
+    return;
+  }
+
   let childEnv = process.env;
   let exitStatus = 0;
+
+  const recordFailure = (status: number): void => {
+    if (status !== 0) {
+      exitStatus = status;
+    }
+  };
 
   const runIntegrationCommand = (
     command: string,
@@ -141,9 +249,7 @@ function runUpdateCommand(): void {
     options: { env?: NodeJS.ProcessEnv } = {},
   ): number => {
     const status = runVisibleCommand(command, args, options);
-    if (status !== 0) {
-      exitStatus = status;
-    }
+    recordFailure(status);
     return status;
   };
 
@@ -156,7 +262,7 @@ function runUpdateCommand(): void {
     };
     runIntegrationCommand('brew', ['upgrade'], { env: childEnv });
 
-    if (configValue('update.cleanup') === 'true') {
+    if (settings.cleanup) {
       progress('Cleaning up Homebrew packages');
       runIntegrationCommand('brew', ['cleanup'], { env: childEnv });
     }
@@ -165,26 +271,33 @@ function runUpdateCommand(): void {
     runIntegrationCommand('brew', ['doctor'], { env: childEnv });
   }
 
-  if (configValue('update.nvm') === 'true') {
+  if (settings.nvm) {
     progress('Updating Node.js LTS');
     const nvmDir = process.env.NVM_DIR ?? '';
     const nvmScript = path.join(nvmDir, 'nvm.sh');
     if (nvmDir && fs.existsSync(nvmScript) && fs.statSync(nvmScript).size > 0) {
       const result = runNvmInstall(childEnv);
-      if (result.status !== 0) {
-        exitStatus = result.status;
+      recordFailure(result.status);
+      if (result.captureFailed) {
+        writeStderrLine('Unable to capture the updated Node.js environment after running nvm.');
       }
       childEnv = result.env ?? childEnv;
     } else {
       writeStderrLine();
-      writeStderrLine('⚠️  Skipping Node.js LTS update: unable to load nvm.');
+      writeStderrLine('Unable to update Node.js LTS: unable to load nvm.');
       writeStderrLine('Set NVM_DIR to your nvm installation or disable this update with: ballin config set update.nvm false');
+      recordFailure(1);
     }
   }
 
-  if (commandExists('npm', { env: childEnv }) && configValue('update.npm') === 'true') {
-    progress('Updating global npm packages');
-    runIntegrationCommand('npm', ['update', '-g'], { env: childEnv });
+  if (settings.npm) {
+    if (commandExists('npm', { env: childEnv })) {
+      progress('Updating global npm packages');
+      runIntegrationCommand('npm', ['update', '-g'], { env: childEnv });
+    } else {
+      writeStderrLine('Unable to update global npm packages: npm is not available on PATH.');
+      recordFailure(1);
+    }
   }
 
   if (commandExists('mas', { env: childEnv })) {
@@ -192,21 +305,26 @@ function runUpdateCommand(): void {
     runIntegrationCommand('mas', ['upgrade'], { env: childEnv });
   }
 
-  if (commandExists('softwareupdate', { env: childEnv }) && configValue('update.softwareupdate') === 'true') {
-    progress('Installing macOS updates');
-    runIntegrationCommand('softwareupdate', ['-ia'], { env: childEnv });
+  if (settings.softwareupdate) {
+    if (commandExists('softwareupdate', { env: childEnv })) {
+      progress('Installing macOS updates');
+      runIntegrationCommand('softwareupdate', ['-ia'], { env: childEnv });
+    } else {
+      writeStderrLine('Unable to install macOS updates: softwareupdate is not available on PATH.');
+      recordFailure(1);
+    }
   }
 
-  if (configValue('update.selfUpdate') === 'true') {
+  if (settings.selfUpdate) {
     progress('Updating ballin-scripts');
     const updateStatus = runIntegrationCommand(ballinCommandPath(), ['self-update'], { env: childEnv });
     if (updateStatus === 0) {
       progress('Checking Ballin readiness');
-      reportBallinReadiness(childEnv);
+      recordFailure(reportBallinReadiness(childEnv));
     }
   }
 
-  if (configValue('update.backup') === 'true') {
+  if (settings.backup) {
     progress('Backing up development environment');
     runIntegrationCommand(ballinCommandPath(), ['backup'], { env: childEnv });
   }

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -1,23 +1,31 @@
 # Supported capabilities
 
 This reference lists the update and backup surfaces that `ballin-scripts`
-currently manages. Optional tools are used only when the matching command or
-setting is available.
+currently manages. Optional tools run according to the discovery and setting
+rules below; configured integrations that are enabled but unavailable are
+reported as failures.
 
 ## `ballin update`
 
 `ballin update` updates the local development environment through these
 integrations. If an integration command fails, it still runs any later
-integrations and exits nonzero at the end.
+integrations and exits nonzero at the end. When more than one stage fails, the
+last nonzero stage status is returned.
+
+Update settings are loaded and validated once before any integrations run.
+Missing settings in an older or partial `update` section use bundled defaults
+in memory for that run and produce one warning; `ballin update` does not rewrite
+the config. Invalid config structures or setting values fail before any
+integration runs.
 
 | Area | Behavior | Requirement |
 | --- | --- | --- |
 | Homebrew packages | Runs `brew upgrade`, optional `brew cleanup`, and `brew doctor`. | `brew` on `PATH`; `update.cleanup` controls cleanup. |
-| Node.js LTS | Runs `nvm install --lts`. | `update.nvm=true`, `NVM_DIR` set, and `nvm.sh` present. |
-| Global npm packages | Runs `npm update -g`. | `update.npm=true` and `npm` on `PATH`. |
+| Node.js LTS | Runs `nvm install --lts`; a missing nvm installation or failure to capture its updated environment records a failure while later stages continue. | `update.nvm=true`, `NVM_DIR` set, and `nvm.sh` present. |
+| Global npm packages | Runs `npm update -g`; a missing `npm` command records a failure while later stages continue. | `update.npm=true` and `npm` on `PATH`. |
 | Mac App Store apps | Runs `mas upgrade`. | `mas` on `PATH`. |
-| macOS updates | Runs `softwareupdate -ia`. | `update.softwareupdate=true` and `softwareupdate` on `PATH`. |
-| ballin-scripts | Runs Ballin self-update. | `update.selfUpdate=true`. |
+| macOS updates | Runs `softwareupdate -ia`; a missing command records a failure while later stages continue. | `update.softwareupdate=true` and `softwareupdate` on `PATH`. |
+| ballin-scripts | Runs Ballin self-update, then records a failed readiness result while continuing to a configured backup. | `update.selfUpdate=true`. |
 | Backups | Runs `ballin backup` as the final update step. | `update.backup=true`. |
 
 ## `ballin backup`
@@ -53,3 +61,15 @@ It can snapshot:
 | `✔` | Unchanged non-empty snapshot. |
 
 Unchanged empty snapshots do not print a line.
+
+### Current consistency boundary
+
+Use one active writer per backup Gist. Multiple machines can point at the same
+Gist, but Ballin does not currently synchronize or merge their snapshots, so a
+machine can overwrite another machine's changes.
+
+A backup currently uploads changed files with separate Gist edits. A failure
+between edits can leave one logical backup spread across multiple revisions or
+only partly uploaded. Staged collection, conflict detection, a single-request
+upload, and cache updates after remote success are tracked in
+[#282](https://github.com/JBallin/ballin-scripts/issues/282).

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -1,22 +1,19 @@
 # Supported capabilities
 
-This reference lists the update and backup surfaces that Ballin
-currently manages. Optional tools run according to the discovery and setting
-rules below; configured integrations that are enabled but unavailable are
-reported as failures.
+This reference lists Ballin's update and backup capabilities. Auto-discovered
+integrations run when available; configured integrations fail when enabled but
+unavailable.
 
 ## `ballin update`
 
-`ballin update` updates the local development environment through these
-integrations. If an integration command fails, it still runs any later
-integrations and exits nonzero at the end. When more than one stage fails, the
-last nonzero stage status is returned.
+`ballin update` runs these integrations in order. A failure does not stop later
+integrations. The command exits nonzero after all configured stages finish,
+using the last nonzero stage status when several stages fail.
 
-Update settings are loaded and validated once before any integrations run.
-Missing settings in an older or partial `update` section use bundled defaults
-in memory for that run and produce one warning; `ballin update` does not rewrite
-the config. Invalid config structures or setting values fail before any
-integration runs.
+Before starting, Ballin loads and validates the update settings once. Missing
+known settings use bundled defaults in memory and produce one warning; the
+config file remains unchanged. Invalid JSON, config structures, or known
+setting values fail before any integration runs.
 
 | Area | Behavior | Requirement |
 | --- | --- | --- |
@@ -71,12 +68,12 @@ Unchanged empty snapshots do not print a line.
 
 ### Current consistency boundary
 
-Use one active writer per backup Gist. Multiple machines can point at the same
-Gist, but Ballin does not currently synchronize or merge their snapshots, so a
-machine can overwrite another machine's changes.
+Use one active writer per backup Gist. Ballin does not synchronize or merge
+snapshots from multiple machines, so one machine can overwrite another's
+changes.
 
-A backup currently uploads changed files with separate Gist edits. A failure
-between edits can leave one logical backup spread across multiple revisions or
-only partly uploaded. Staged collection, conflict detection, a single-request
-upload, and cache updates after remote success are tracked in
+A backup currently uploads each changed file with a separate Gist edit. A
+failure between edits can leave the backup spread across revisions or only
+partly uploaded. The staged single-request backup work—including conflict
+detection and cache updates only after remote success—is tracked in
 [#282](https://github.com/JBallin/ballin-scripts/issues/282).

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -12,8 +12,8 @@ using the last nonzero stage status when several stages fail.
 
 Before starting, Ballin loads and validates the update settings once. Missing
 known settings use bundled defaults in memory and produce one warning; the
-config file remains unchanged. Invalid JSON, config structures, or known
-setting values fail before any integration runs.
+config file remains unchanged. Malformed JSON, invalid config structure, or
+invalid known setting values fail before any integration runs.
 
 | Area | Behavior | Requirement |
 | --- | --- | --- |
@@ -22,7 +22,7 @@ setting values fail before any integration runs.
 | Global npm packages | Runs `npm update -g`; a missing `npm` command records a failure while later stages continue. | `update.npm=true` and `npm` on `PATH`. |
 | Mac App Store apps | Runs `mas upgrade`. | `mas` on `PATH`. |
 | macOS updates | Runs `softwareupdate -ia`; a missing command records a failure while later stages continue. | `update.softwareupdate=true` and `softwareupdate` on `PATH`. |
-| ballin-scripts | Runs Ballin self-update, then records a failed readiness result while continuing to a configured backup. | `update.selfUpdate=true`. |
+| ballin-scripts | Runs Ballin self-update, then checks readiness. A failed check records a failure while a configured backup still runs. | `update.selfUpdate=true`. |
 | Backups | Runs `ballin backup` as the final update step. | `update.backup=true`. |
 
 ## `ballin backup`

--- a/docs/optional-capabilities.md
+++ b/docs/optional-capabilities.md
@@ -47,8 +47,9 @@ ballin config set update.nvm true
 `update.nvm` runs `nvm install --lts`; it does not update nvm itself. It defaults to
 `false` because enabling it opts into newer LTS releases, and installing a new
 Node.js version does not migrate your globally installed npm packages
-automatically. If nvm cannot be loaded, `ballin update` warns and continues
-with its remaining updates.
+automatically. If nvm cannot be loaded, `ballin update` reports the failure and
+continues with its remaining updates. A failure to capture nvm's updated
+environment is handled the same way; later stages use the previous environment.
 
 For a simpler setup, install Homebrew's current Node.js release instead:
 
@@ -90,11 +91,22 @@ and other local config, and public Gists cannot be made secret again.
 Use `ballin backup open` to open the configured backup Gist, or
 `ballin backup read <file>` to print one saved snapshot.
 
+Use one active writer per backup Gist. Ballin does not currently synchronize or
+merge snapshots from multiple machines. Changed files are also uploaded with
+separate Gist edits, so an interrupted run can leave a logical backup only
+partly uploaded. Conflict detection and a staged single-request backup are
+tracked in [#282](https://github.com/JBallin/ballin-scripts/issues/282).
+
 ## Readiness checks
 
 Use `ballin doctor` to check whether the Ballin-managed environment is healthy,
-including Node.js, installed commands, settings, and Gist backup setup. Add
-`--verbose` when you want the full check list.
+including Node.js, installed commands, settings, and known Gist backup
+prerequisites. For backups, doctor checks the configured host and Gist ID,
+`gh` availability, accepted authentication, and whether the configured Gist is
+readable. Readability does not verify write permission, freshness,
+completeness, cache consistency, or the absence of partial backup runs. Add
+`--verbose` when you want the full check list and the explicit read-only
+limitation.
 
 ```shell
 ballin doctor
@@ -116,6 +128,15 @@ ballin config set analytics.enabled false
 
 Change a setting with `ballin config set update.<name> true` or
 `ballin config set update.<name> false`.
+
+`ballin update` validates these settings before running any integration. If an
+older or partial config omits known update settings, their bundled defaults are
+used in memory for the current run and listed in one warning. The config is not
+rewritten, and correct behavior does not depend on self-update being enabled or
+succeeding. Invalid JSON, invalid config structures, and non-boolean known
+settings fail the command before integrations run. Enabled stages continue
+independently after failures; if several fail, the command returns the last
+nonzero stage status.
 
 | Setting | Default | Behavior |
 | --- | --- | --- |

--- a/docs/optional-capabilities.md
+++ b/docs/optional-capabilities.md
@@ -80,7 +80,7 @@ the configured backup Gist. During install, Ballin prompts for the
 GitHub host, including GitHub Enterprise hosts, checks `gh` authentication for
 that host, and either adopts an existing backup Gist or creates a new one. When
 an adopted backup includes a saved `ballin_config` snapshot, the installer restores
-them before continuing.
+it before continuing.
 
 Setup creates backup Gists as [secret Gists](https://docs.github.com/en/get-started/writing-on-github/editing-and-sharing-content-with-gists/creating-gists). Secret Gists are unlisted and not
 searchable, but anyone with the URL can view them, so treat the backup Gist URL
@@ -136,8 +136,8 @@ Change a setting with `ballin config set update.<name> true` or
 `ballin update` validates these settings before running any integration. Missing
 known settings use bundled defaults in memory for the current run and appear in
 one warning. The config file remains unchanged, and this behavior does not
-depend on self-update. Invalid JSON, config structures, or known values other
-than booleans and canonical `"true"` or `"false"` strings fail before any
+depend on self-update. Malformed JSON, invalid config structure, or known values
+other than booleans and canonical `"true"` or `"false"` strings fail before any
 integration runs. Later stages continue after failures; if several fail, the
 command returns the last nonzero stage status.
 

--- a/docs/optional-capabilities.md
+++ b/docs/optional-capabilities.md
@@ -96,22 +96,21 @@ navigation, rollback, restore, or revision-selection commands.
 Use `ballin backup open` to open the configured backup Gist, or
 `ballin backup read <file>` to print one saved snapshot.
 
-Use one active writer per backup Gist. Ballin does not currently synchronize or
-merge snapshots from multiple machines. Changed files are also uploaded with
-separate Gist edits, so an interrupted run can leave a logical backup only
-partly uploaded. Conflict detection and a staged single-request backup are
-tracked in [#282](https://github.com/JBallin/ballin-scripts/issues/282).
+Use one active writer per backup Gist. Ballin does not synchronize or merge
+snapshots from multiple machines. It also uploads each changed file with a
+separate Gist edit, so an interrupted run can leave a backup only partly
+uploaded. The staged single-request backup work is tracked in
+[#282](https://github.com/JBallin/ballin-scripts/issues/282).
 
 ## Readiness checks
 
 Use `ballin doctor` to check whether the Ballin-managed environment is healthy,
 including Node.js, installed commands, settings, and known Gist backup
 prerequisites. For backups, doctor checks the configured host and Gist ID,
-`gh` availability, accepted authentication, and whether the configured Gist is
-readable. Readability does not verify write permission, freshness,
-completeness, cache consistency, or the absence of partial backup runs. Add
-`--verbose` when you want the full check list and the explicit read-only
-limitation.
+`gh` availability, whether `gh auth status` succeeds for that host, and whether
+the Gist is readable. These checks do not verify write permission, freshness,
+completeness, cache consistency, or the absence of partial backup runs. Use
+`--verbose` to see every check and the explicit write-permission limitation.
 
 ```shell
 ballin doctor
@@ -134,20 +133,19 @@ ballin config set analytics.enabled false
 Change a setting with `ballin config set update.<name> true` or
 `ballin config set update.<name> false`.
 
-`ballin update` validates these settings before running any integration. If an
-older or partial config omits known update settings, their bundled defaults are
-used in memory for the current run and listed in one warning. The config is not
-rewritten, and correct behavior does not depend on self-update being enabled or
-succeeding. Invalid JSON, invalid config structures, and non-boolean known
-settings fail the command before integrations run. Enabled stages continue
-independently after failures; if several fail, the command returns the last
-nonzero stage status.
+`ballin update` validates these settings before running any integration. Missing
+known settings use bundled defaults in memory for the current run and appear in
+one warning. The config file remains unchanged, and this behavior does not
+depend on self-update. Invalid JSON, config structures, or known values other
+than booleans and canonical `"true"` or `"false"` strings fail before any
+integration runs. Later stages continue after failures; if several fail, the
+command returns the last nonzero stage status.
 
 | Setting | Default | Behavior |
 | --- | --- | --- |
 | `update.cleanup` | `true` | Runs `brew cleanup` after upgrading Homebrew packages. |
 | `update.selfUpdate` | `true` | Updates `ballin-scripts` when `ballin update` runs, then checks Ballin readiness if the update succeeds. |
-| `update.backup` | `false` | Runs `ballin backup` to back up your development environment. Enable it when you want each update to also modify your backup gist. |
+| `update.backup` | `false` | Runs `ballin backup` to back up your development environment. Enable it when you want each update to also modify your backup Gist. |
 | `update.softwareupdate` | `true` | Installs available macOS updates with `softwareupdate`. |
 | `update.nvm` | `false` | Installs the latest Node.js LTS release through a configured nvm installation. See [Node.js](#nodejs) for the setup and tradeoffs. |
 | `update.npm` | `false` | Runs `npm update -g` across globally installed packages. This is a separate update step from the npm version supplied with Node.js. It defaults to `false` because it can change all global tools at once, while many tools can instead stay project-local or run through `npx`. |

--- a/test/ballin.test.ts
+++ b/test/ballin.test.ts
@@ -71,7 +71,10 @@ describe('ballin', () => {
     });
   };
 
-  const runBallin = (args: string[] = []): StringSpawnResult => spawnSync(process.execPath, [
+  const runBallin = (
+    args: string[] = [],
+    env: NodeJS.ProcessEnv = {},
+  ): StringSpawnResult => spawnSync(process.execPath, [
     ballinPath,
     ...args,
   ], {
@@ -83,6 +86,7 @@ describe('ballin', () => {
       BALLIN_TEST_BALLIN_PATH: path.join(binDir, 'ballin'),
       FAKE_COMMAND_LOG: commandLogPath,
       PATH: binDir,
+      ...env,
     },
   });
 
@@ -100,6 +104,10 @@ case "$1:$2" in
   auth:status)
     if [ "$*" != "auth status --hostname example.test" ]; then exit 2; fi
     exit "\${FAKE_GH_AUTH_STATUS:-0}"
+    ;;
+  gist:view)
+    if [ "$*" != "gist view test-gist-id --files" ]; then exit 2; fi
+    exit "\${FAKE_GH_GIST_STATUS:-0}"
     ;;
   *) exit 2 ;;
 esac
@@ -221,7 +229,10 @@ exit 17
     assert.equal(result.status, 0, result.stderr);
     assert.equal(result.stdout, 'Your Ballin-managed environment is healthy.\n');
     assert.equal(result.stderr, '');
-    assert.equal(fs.readFileSync(commandLogPath, 'utf8'), 'auth status --hostname example.test\n');
+    assert.deepEqual(commandLog(), [
+      'auth status --hostname example.test',
+      'gist view test-gist-id --files',
+    ]);
   });
 
   it('reports full Ballin-managed environment checks through verbose doctor', () => {
@@ -236,49 +247,95 @@ exit 17
     assert.include(result.stdout, 'OK    Gist ID:');
     assert.include(result.stdout, 'OK    GitHub CLI:');
     assert.include(result.stdout, 'OK    GitHub CLI authentication:');
+    assert.include(
+      result.stdout,
+      'OK    Configured Gist readability: The configured backup Gist exists and is readable. Write permission was not checked.',
+    );
     assert.include(result.stdout, 'Result: Ballin-managed environment health looks good.');
     assert.equal(result.stderr, '');
-    assert.equal(fs.readFileSync(commandLogPath, 'utf8'), 'auth status --hostname example.test\n');
+    assert.deepEqual(commandLog(), [
+      'auth status --hostname example.test',
+      'gist view test-gist-id --files',
+    ]);
   });
 
   it('reports doctor warnings without failing the command', () => {
-    fs.rmSync(path.join(binDir, 'gh'));
     writeConfig({
       update: {},
       backup: {
-        id: null,
+        id: 'test-gist-id',
         host: 'example.test',
-      },
-      analytics: {
-        enabled: 'false',
       },
     });
 
     const result = runBallin(['doctor']);
 
     assert.equal(result.status, 0, result.stderr);
-    assert.include(result.stdout, 'WARN  Gist ID: Backup Gist ID is not configured yet.');
-    assert.include(result.stdout, '\nNext: Run the installer to create or adopt a backup Gist.');
-    assert.include(result.stdout, 'WARN  GitHub CLI: GitHub CLI is not discoverable on PATH.');
-    assert.include(result.stdout, '\nNext: Install GitHub CLI and authenticate it for your backup host.');
+    assert.include(result.stdout, 'WARN  Config readability: Config is readable but missing sections: analytics.');
+    assert.include(result.stdout, '\nNext: Run ballin config reset to recreate the config.');
     assert.notInclude(result.stdout, '      Next:');
     assert.notInclude(result.stdout, 'OK    Node.js runtime:');
     assert.notInclude(result.stdout, 'OK    Command shims on PATH:');
-    assert.notInclude(result.stdout, 'OK    Config readability:');
     assert.notInclude(result.stdout, 'OK    Gist host:');
-    assert.notInclude(result.stdout, 'INFO  GitHub CLI authentication: Skipping GitHub CLI authentication check because gh is not on PATH.');
     assert.notInclude(result.stdout, 'Result: Ballin-managed environment has warnings. Warnings do not fail this command.');
     assert.equal(result.stderr, '');
-    assert.isFalse(fs.existsSync(commandLogPath));
 
     const verboseResult = runBallin(['doctor', '--verbose']);
 
     assert.equal(verboseResult.status, 0, verboseResult.stderr);
     assert.include(verboseResult.stdout, 'OK    Node.js runtime:');
-    assert.include(verboseResult.stdout, 'WARN  Gist ID: Backup Gist ID is not configured yet.');
-    assert.include(verboseResult.stdout, '      Next: Run the installer to create or adopt a backup Gist.');
-    assert.include(verboseResult.stdout, 'INFO  GitHub CLI authentication: Skipping GitHub CLI authentication check because gh is not on PATH.');
+    assert.include(verboseResult.stdout, 'WARN  Config readability: Config is readable but missing sections: analytics.');
+    assert.include(verboseResult.stdout, 'OK    Configured Gist readability:');
     assert.include(verboseResult.stdout, 'Result: Ballin-managed environment has warnings. Warnings do not fail this command.');
+  });
+
+  it('fails doctor for unusable backup prerequisites and unreadable Gists', () => {
+    writeConfig({
+      update: {},
+      backup: {
+        id: null,
+        host: 'example.test',
+      },
+      analytics: {},
+    });
+    const missingId = runBallin(['doctor']);
+    assert.equal(missingId.status, 1);
+    assert.include(missingId.stdout, 'ERROR Gist ID: Backup Gist ID is not configured yet.');
+    assert.notInclude(missingId.stdout, 'Configured Gist readability:');
+
+    fs.rmSync(path.join(binDir, 'gh'));
+    const missingGh = runBallin(['doctor']);
+    assert.equal(missingGh.status, 1);
+    assert.include(missingGh.stdout, 'ERROR GitHub CLI: GitHub CLI is not discoverable on PATH.');
+
+    writeExecutable('gh', `#!/bin/bash
+printf '%s\\n' "$*" >> "$FAKE_COMMAND_LOG"
+case "$1:$2" in
+  auth:status) exit "\${FAKE_GH_AUTH_STATUS:-0}" ;;
+  gist:view) exit "\${FAKE_GH_GIST_STATUS:-0}" ;;
+  *) exit 2 ;;
+esac
+`);
+    writeConfig({
+      update: {},
+      backup: {
+        id: 'test-gist-id',
+        host: 'example.test',
+      },
+      analytics: {},
+    });
+
+    const failedAuth = runBallin(['doctor'], { FAKE_GH_AUTH_STATUS: '4' });
+    assert.equal(failedAuth.status, 1);
+    assert.include(failedAuth.stdout, 'ERROR GitHub CLI authentication:');
+    assert.notInclude(failedAuth.stdout, 'Configured Gist readability:');
+
+    const unreadableGist = runBallin(['doctor'], { FAKE_GH_GIST_STATUS: '4' });
+    assert.equal(unreadableGist.status, 1);
+    assert.include(
+      unreadableGist.stdout,
+      'ERROR Configured Gist readability: The configured backup Gist could not be read.',
+    );
   });
 
   it('fails doctor when a required health check fails', () => {
@@ -299,7 +356,7 @@ exit 17
     assert.equal(missingShim.status, 1);
     assert.include(missingShim.stdout, 'ERROR Command shims on PATH: Missing command shims on PATH: ballin.');
     assert.include(missingShim.stdout, '\nNext: Run the installer again or add the Ballin command directory to PATH.');
-    assert.include(missingShim.stdout, 'WARN  Gist ID: Backup Gist ID is not configured yet.');
+    assert.include(missingShim.stdout, 'ERROR Gist ID: Backup Gist ID is not configured yet.');
     assert.include(missingShim.stdout, '\nNext: Run the installer to create or adopt a backup Gist.');
     assert.notInclude(missingShim.stdout, '      Next:');
     assert.notInclude(missingShim.stdout, 'OK    Node.js runtime:');

--- a/test/ballin.test.ts
+++ b/test/ballin.test.ts
@@ -102,11 +102,11 @@ describe('ballin', () => {
 printf '%s\\n' "$*" >> "$FAKE_COMMAND_LOG"
 case "$1:$2" in
   auth:status)
-    if [ "$*" != "auth status --hostname example.test" ]; then exit 2; fi
+    if [ "$*" != "auth status --active --hostname example.test" ]; then exit 2; fi
     exit "\${FAKE_GH_AUTH_STATUS:-0}"
     ;;
   gist:view)
-    if [ "$*" != "gist view test-gist-id --files" ]; then exit 2; fi
+    if [ "$*" != "gist view --files -- test-gist-id" ]; then exit 2; fi
     exit "\${FAKE_GH_GIST_STATUS:-0}"
     ;;
   *) exit 2 ;;
@@ -230,8 +230,8 @@ exit 17
     assert.equal(result.stdout, 'Your Ballin-managed environment is healthy.\n');
     assert.equal(result.stderr, '');
     assert.deepEqual(commandLog(), [
-      'auth status --hostname example.test',
-      'gist view test-gist-id --files',
+      'auth status --active --hostname example.test',
+      'gist view --files -- test-gist-id',
     ]);
   });
 
@@ -254,8 +254,8 @@ exit 17
     assert.include(result.stdout, 'Result: Ballin-managed environment health looks good.');
     assert.equal(result.stderr, '');
     assert.deepEqual(commandLog(), [
-      'auth status --hostname example.test',
-      'gist view test-gist-id --files',
+      'auth status --active --hostname example.test',
+      'gist view --files -- test-gist-id',
     ]);
   });
 

--- a/test/setup_readiness.test.ts
+++ b/test/setup_readiness.test.ts
@@ -31,7 +31,9 @@ describe('setup readiness', () => {
   let binDir: string;
   let configPath: string;
   let commandLog: string[];
+  let commandHosts: (string | undefined)[];
   let authStatus: number;
+  let gistReadStatus: number;
 
   const writeExecutable = (name: string, contents = '#!/usr/bin/env bash\nexit 0\n') => {
     fs.writeFileSync(path.join(binDir, name), contents, { mode: 0o755 });
@@ -50,13 +52,16 @@ describe('setup readiness', () => {
   const fakeRunCommand = (
     command: string,
     args: string[] = [],
+    options: { env?: NodeJS.ProcessEnv } = {},
   ): FakeRunResult => {
     commandLog.push([command, ...args].join(' '));
+    commandHosts.push(options.env?.GH_HOST);
+    const status = args[0] === 'gist' ? gistReadStatus : authStatus;
     return {
-      status: authStatus,
+      status,
       signal: null,
       stdout: '',
-      stderr: authStatus === 0 ? '' : 'simulated auth failure\n',
+      stderr: status === 0 ? '' : 'simulated gh failure\n',
     };
   };
 
@@ -81,7 +86,9 @@ describe('setup readiness', () => {
     binDir = path.join(tempDir, 'bin');
     configPath = path.join(repoDir, 'ballin.config.json');
     commandLog = [];
+    commandHosts = [];
     authStatus = 0;
+    gistReadStatus = 0;
 
     fs.mkdirSync(repoDir, { recursive: true });
     fs.mkdirSync(binDir, { recursive: true });
@@ -151,14 +158,23 @@ describe('setup readiness', () => {
     assert.equal(checkById(report, 'backup.gist').status, 'pass');
     assert.equal(checkById(report, 'backup.gh').status, 'pass');
     assert.equal(checkById(report, 'backup.auth').status, 'pass');
-    assert.deepEqual(commandLog, ['gh auth status --hostname example.test']);
+    assert.equal(checkById(report, 'backup.read').status, 'pass');
+    assert.equal(
+      checkById(report, 'backup.read').summary,
+      'The configured backup Gist exists and is readable. Write permission was not checked.',
+    );
+    assert.deepEqual(commandLog, [
+      'gh auth status --hostname example.test',
+      'gh gist view test-gist-id --files',
+    ]);
+    assert.deepEqual(commandHosts, ['example.test', 'example.test']);
     assert.equal(fs.readFileSync(configPath, 'utf8'), beforeConfig);
     assert.notInclude(commandLog.join('\n'), 'gist create');
     assert.notInclude(commandLog.join('\n'), 'gist edit');
     assert.notInclude(commandLog.join('\n'), 'ballin config set');
   });
 
-  it('reports unconfigured Gist ID and missing gh as non-mutating warnings', () => {
+  it('reports unconfigured Gist ID and missing gh as failures', () => {
     fs.rmSync(path.join(binDir, 'gh'));
     writeConfig({
       update: {},
@@ -171,11 +187,32 @@ describe('setup readiness', () => {
 
     const report = collect();
 
-    assert.equal(report.status, 'warn');
-    assert.equal(checkById(report, 'backup.gist').status, 'warn');
-    assert.equal(checkById(report, 'backup.gh').status, 'warn');
+    assert.equal(report.status, 'fail');
+    assert.equal(checkById(report, 'backup.gist').status, 'fail');
+    assert.equal(checkById(report, 'backup.gh').status, 'fail');
     assert.equal(checkById(report, 'backup.auth').status, 'info');
+    assert.equal(checkById(report, 'backup.read').status, 'info');
     assert.deepEqual(commandLog, []);
+  });
+
+  it('authenticates but skips Gist readability when the Gist ID is missing', () => {
+    writeConfig({
+      update: {},
+      backup: {
+        id: null,
+        host: 'example.test',
+      },
+      analytics: {},
+    });
+
+    const report = collect();
+
+    assert.equal(report.status, 'fail');
+    assert.equal(checkById(report, 'backup.gist').status, 'fail');
+    assert.equal(checkById(report, 'backup.auth').status, 'pass');
+    assert.equal(checkById(report, 'backup.read').status, 'info');
+    assert.include(checkById(report, 'backup.read').summary, 'until a backup Gist ID is configured');
+    assert.deepEqual(commandLog, ['gh auth status --hostname example.test']);
   });
 
   it('reports missing Gist host and failed gh auth', () => {
@@ -190,6 +227,7 @@ describe('setup readiness', () => {
     const missingHost = collect();
     assert.equal(checkById(missingHost, 'backup.host').status, 'fail');
     assert.equal(checkById(missingHost, 'backup.auth').status, 'info');
+    assert.equal(checkById(missingHost, 'backup.read').status, 'info');
     assert.deepEqual(commandLog, []);
 
     writeConfig({
@@ -203,8 +241,25 @@ describe('setup readiness', () => {
     authStatus = 4;
     const authFailed = collect();
 
-    assert.equal(checkById(authFailed, 'backup.auth').status, 'warn');
-    assert.equal(authFailed.status, 'warn');
+    assert.equal(checkById(authFailed, 'backup.auth').status, 'fail');
+    assert.equal(checkById(authFailed, 'backup.read').status, 'info');
+    assert.equal(authFailed.status, 'fail');
     assert.deepEqual(commandLog, ['gh auth status --hostname example.test']);
+  });
+
+  it('fails when the configured Gist cannot be read', () => {
+    gistReadStatus = 4;
+
+    const report = collect();
+    const readCheck = checkById(report, 'backup.read');
+
+    assert.equal(report.status, 'fail');
+    assert.equal(readCheck.status, 'fail');
+    assert.equal(readCheck.summary, 'The configured backup Gist could not be read.');
+    assert.deepEqual(commandLog, [
+      'gh auth status --hostname example.test',
+      'gh gist view test-gist-id --files',
+    ]);
+    assert.deepEqual(commandHosts, ['example.test', 'example.test']);
   });
 });

--- a/test/setup_readiness.test.ts
+++ b/test/setup_readiness.test.ts
@@ -164,8 +164,8 @@ describe('setup readiness', () => {
       'The configured backup Gist exists and is readable. Write permission was not checked.',
     );
     assert.deepEqual(commandLog, [
-      'gh auth status --hostname example.test',
-      'gh gist view test-gist-id --files',
+      'gh auth status --active --hostname example.test',
+      'gh gist view --files -- test-gist-id',
     ]);
     assert.deepEqual(commandHosts, ['example.test', 'example.test']);
     assert.equal(fs.readFileSync(configPath, 'utf8'), beforeConfig);
@@ -212,7 +212,7 @@ describe('setup readiness', () => {
     assert.equal(checkById(report, 'backup.auth').status, 'pass');
     assert.equal(checkById(report, 'backup.read').status, 'info');
     assert.include(checkById(report, 'backup.read').summary, 'until a backup Gist ID is configured');
-    assert.deepEqual(commandLog, ['gh auth status --hostname example.test']);
+    assert.deepEqual(commandLog, ['gh auth status --active --hostname example.test']);
   });
 
   it('reports missing Gist host and failed gh auth', () => {
@@ -244,7 +244,7 @@ describe('setup readiness', () => {
     assert.equal(checkById(authFailed, 'backup.auth').status, 'fail');
     assert.equal(checkById(authFailed, 'backup.read').status, 'info');
     assert.equal(authFailed.status, 'fail');
-    assert.deepEqual(commandLog, ['gh auth status --hostname example.test']);
+    assert.deepEqual(commandLog, ['gh auth status --active --hostname example.test']);
   });
 
   it('fails when the configured Gist cannot be read', () => {
@@ -257,9 +257,28 @@ describe('setup readiness', () => {
     assert.equal(readCheck.status, 'fail');
     assert.equal(readCheck.summary, 'The configured backup Gist could not be read.');
     assert.deepEqual(commandLog, [
-      'gh auth status --hostname example.test',
-      'gh gist view test-gist-id --files',
+      'gh auth status --active --hostname example.test',
+      'gh gist view --files -- test-gist-id',
     ]);
     assert.deepEqual(commandHosts, ['example.test', 'example.test']);
+  });
+
+  it('terminates gh flags before reading a configured Gist ID', () => {
+    writeConfig({
+      update: {},
+      backup: {
+        id: '--help',
+        host: 'example.test',
+      },
+      analytics: {},
+    });
+
+    const report = collect();
+
+    assert.equal(checkById(report, 'backup.read').status, 'pass');
+    assert.deepEqual(commandLog, [
+      'gh auth status --active --hostname example.test',
+      'gh gist view --files -- --help',
+    ]);
   });
 });

--- a/test/update.test.ts
+++ b/test/update.test.ts
@@ -99,9 +99,7 @@ exit ${status}
     });
   };
 
-  const runUpdate = (env: NodeJS.ProcessEnv = {}) => {
-    writeUpdateConfig(env);
-    return spawnSync(ballinPath, ['update'], {
+  const spawnUpdate = (env: NodeJS.ProcessEnv = {}) => spawnSync(ballinPath, ['update'], {
       encoding: 'utf8',
       env: {
         HOME: tempDir,
@@ -114,6 +112,10 @@ exit ${status}
         ...env,
       },
     });
+
+  const runUpdate = (env: NodeJS.ProcessEnv = {}) => {
+    writeUpdateConfig(env);
+    return spawnUpdate(env);
   };
 
   const installNvmStub = (nvmDir: string) => {
@@ -211,6 +213,7 @@ exit 0
       'brew|1,1|doctor',
       'ballin|1,1|self-update',
       'gh|1,1|auth status --hostname example.test',
+      'gh|1,1|gist view test-gist-id --files',
     ]);
   });
 
@@ -230,6 +233,7 @@ exit 0
       'brew|1,1|doctor',
       'ballin|1,1|self-update',
       'gh|1,1|auth status --hostname example.test',
+      'gh|1,1|gist view test-gist-id --files',
     ]);
   });
 
@@ -268,6 +272,7 @@ exit 0
       'softwareupdate|,|-ia',
       'ballin|,|self-update',
       'gh|,|auth status --hostname example.test',
+      'gh|,|gist view test-gist-id --files',
       'ballin|,|backup',
     ]);
   });
@@ -289,6 +294,7 @@ exit 0
     assert.deepEqual(commandLog(), [
       'ballin|,|self-update',
       'gh|,|auth status --hostname example.test',
+      'gh|,|gist view test-gist-id --files',
     ]);
   });
 
@@ -324,10 +330,11 @@ exit 2
       'ballin|,|self-update',
       'node|,|-p process.versions.node',
       'gh|,|auth status --hostname example.test',
+      'gh|,|gist view test-gist-id --files',
     ]);
   });
 
-  it('keeps Ballin readiness failures informational after update', () => {
+  it('records Ballin readiness failures and still runs configured backup', () => {
     const selfUpdatePath = path.join(tempDir, 'self-update-ballin');
     fs.writeFileSync(selfUpdatePath, `#!/usr/bin/env bash
 printf '%s|%s|%s\\n' "ballin" "$HOMEBREW_NO_ENV_HINTS,$HOMEBREW_NO_ASK" "$*" >> "$UPDATE_TEST_LOG"
@@ -339,10 +346,11 @@ exit 0
     const result = runUpdate({
       TEST_UPDATE_NVM: 'false',
       TEST_UPDATE_BALLIN: 'true',
+      TEST_UPDATE_BACKUP: 'true',
       BALLIN_TEST_BALLIN_PATH: selfUpdatePath,
     });
 
-    assert.equal(result.status, 0);
+    assert.equal(result.status, 1);
     assert.include(result.stdout, 'Checking Ballin readiness');
     assert.include(result.stdout, 'ERROR Command shims on PATH: Missing command shims on PATH: ballin.');
     assert.include(result.stdout, 'Next: Run the installer again or add the Ballin command directory to PATH.');
@@ -350,6 +358,8 @@ exit 0
     assert.deepEqual(commandLog(), [
       'ballin|,|self-update',
       'gh|,|auth status --hostname example.test',
+      'gh|,|gist view test-gist-id --files',
+      'ballin|,|backup',
     ]);
   });
 
@@ -405,11 +415,12 @@ exit 0
       'npm|,|update -g',
       'ballin|,|self-update',
       'gh|,|auth status --hostname example.test',
+      'gh|,|gist view test-gist-id --files',
       'ballin|,|backup',
     ]);
   });
 
-  it('still uses final backup status after informational Ballin readiness', () => {
+  it('still uses final backup status after Ballin readiness', () => {
     writeTestExecutable('ballin', `#!/usr/bin/env bash
 printf '%s|%s|%s\\n' "ballin" "$HOMEBREW_NO_ENV_HINTS,$HOMEBREW_NO_ASK" "$*" >> "$UPDATE_TEST_LOG"
 if [ "$1" = 'backup' ]; then
@@ -432,6 +443,7 @@ exit 0
     assert.deepEqual(commandLog(), [
       'ballin|,|self-update',
       'gh|,|auth status --hostname example.test',
+      'gh|,|gist view test-gist-id --files',
       'ballin|,|backup',
     ]);
   });
@@ -548,7 +560,7 @@ printf 'backup-npm|%s\\n' "$(command -v npm)" >> "$UPDATE_TEST_LOG"
     ]);
   });
 
-  it('keeps running later integrations when nvm env capture fails', () => {
+  it('records a failure and keeps running later integrations when nvm env capture fails', () => {
     const nvmDir = path.join(tempDir, 'custom-nvm');
     const brokenNodeDir = path.join(tempDir, 'broken-node');
     fs.mkdirSync(brokenNodeDir);
@@ -565,17 +577,18 @@ printf '%s\\n' 'backup still ran' >> "$UPDATE_TEST_LOG"
       TEST_UPDATE_BACKUP: 'true',
     });
 
-    assert.equal(result.status, 0);
+    assert.equal(result.status, 1);
     assert.include(result.stdout, 'Updating Node.js LTS');
+    assert.include(result.stderr, 'Unable to capture the updated Node.js environment');
     assert.deepEqual(commandLog().slice(1), [
       'backup still ran',
     ]);
   });
 
-  it('warns when nvm is enabled but cannot be loaded', () => {
+  it('fails when nvm is enabled but cannot be loaded', () => {
     const result = runUpdate();
 
-    assert.equal(result.status, 0);
+    assert.equal(result.status, 1);
     assert.include(result.stdout, 'Updating Node.js LTS');
     assert.include(result.stderr, 'unable to load nvm');
     assert.include(result.stderr, 'Set NVM_DIR');
@@ -595,6 +608,198 @@ printf '%s\\n' 'backup still ran' >> "$UPDATE_TEST_LOG"
     assert.isFalse(fs.existsSync(logPath));
   });
 
+  it('exits successfully when a valid configuration has no applicable work', () => {
+    writeConfig({
+      update: {
+        cleanup: false,
+        nvm: false,
+        npm: false,
+        softwareupdate: false,
+        selfUpdate: false,
+        backup: false,
+        unknownFutureSetting: 'ignored',
+      },
+    });
+
+    const result = spawnUpdate();
+
+    assert.equal(result.status, 0);
+    assert.equal(result.stdout, '');
+    assert.equal(result.stderr, '');
+    assert.deepEqual(commandLog(), []);
+  });
+
+  it('uses bundled update defaults in memory when the update section is missing', () => {
+    writeConfig({
+      backup: {
+        id: 'test-gist-id',
+        host: 'example.test',
+      },
+      analytics: {},
+    });
+    installCommandStub('softwareupdate');
+    installHealthyReadinessCommands();
+    const beforeConfig = fs.readFileSync(configPath, 'utf8');
+
+    const result = spawnUpdate();
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(
+      result.stderr,
+      'Warning: using bundled defaults for missing settings: update.cleanup, update.nvm, update.npm, update.softwareupdate, update.selfUpdate, update.backup.\n',
+    );
+    assert.deepEqual(commandLog(), [
+      'softwareupdate|,|-ia',
+      'ballin|,|self-update',
+      'gh|,|auth status --hostname example.test',
+      'gh|,|gist view test-gist-id --files',
+    ]);
+    assert.equal(fs.readFileSync(configPath, 'utf8'), beforeConfig);
+  });
+
+  it('uses a missing setting default without persisting when self-update is disabled', () => {
+    writeConfig({
+      update: {
+        cleanup: false,
+        nvm: false,
+        npm: false,
+        softwareupdate: false,
+        selfUpdate: false,
+      },
+    });
+    const beforeConfig = fs.readFileSync(configPath, 'utf8');
+
+    const result = spawnUpdate();
+
+    assert.equal(result.status, 0);
+    assert.equal(
+      result.stderr,
+      'Warning: using bundled defaults for missing settings: update.backup.\n',
+    );
+    assert.deepEqual(commandLog(), []);
+    assert.equal(fs.readFileSync(configPath, 'utf8'), beforeConfig);
+  });
+
+  it('keeps in-memory defaults authoritative when a defaulted self-update is unavailable', () => {
+    writeConfig({
+      update: {
+        cleanup: false,
+        nvm: false,
+        npm: false,
+        softwareupdate: false,
+        backup: false,
+      },
+    });
+    const beforeConfig = fs.readFileSync(configPath, 'utf8');
+
+    const result = spawnUpdate();
+
+    assert.equal(result.status, 127);
+    assert.include(result.stderr, 'using bundled defaults for missing settings: update.selfUpdate.');
+    assert.include(result.stderr, 'ballin: command not found');
+    assert.include(result.stdout, 'Updating ballin-scripts');
+    assert.equal(fs.readFileSync(configPath, 'utf8'), beforeConfig);
+  });
+
+  it('keeps in-memory defaults authoritative when a defaulted self-update fails', () => {
+    writeConfig({
+      update: {
+        cleanup: false,
+        nvm: false,
+        npm: false,
+        softwareupdate: false,
+        backup: false,
+      },
+    });
+    installCommandStub('ballin', { status: 23 });
+    const beforeConfig = fs.readFileSync(configPath, 'utf8');
+
+    const result = spawnUpdate();
+
+    assert.equal(result.status, 23);
+    assert.include(result.stderr, 'using bundled defaults for missing settings: update.selfUpdate.');
+    assert.deepEqual(commandLog(), ['ballin|,|self-update']);
+    assert.equal(fs.readFileSync(configPath, 'utf8'), beforeConfig);
+  });
+
+  [
+    {
+      name: 'nvm',
+      env: { TEST_UPDATE_NVM: 'true' },
+      diagnostic: 'unable to load nvm',
+    },
+    {
+      name: 'npm',
+      env: { TEST_UPDATE_NVM: 'false', TEST_UPDATE_NPM: 'true' },
+      diagnostic: 'npm is not available on PATH',
+    },
+    {
+      name: 'softwareupdate',
+      env: { TEST_UPDATE_NVM: 'false', TEST_UPDATE_SOFTWAREUPDATE: 'true' },
+      diagnostic: 'softwareupdate is not available on PATH',
+    },
+  ].forEach(({ name, env, diagnostic }) => {
+    it(`records enabled but unavailable ${name} as a failure and continues through backup`, () => {
+      installCommandStub('ballin');
+
+      const result = runUpdate({ ...env, TEST_UPDATE_BACKUP: 'true' });
+
+      assert.equal(result.status, 1);
+      assert.include(result.stderr, diagnostic);
+      assert.deepEqual(commandLog(), ['ballin|,|backup']);
+    });
+  });
+
+  it('returns the last nonzero status after multiple independent failures', () => {
+    installCommandStub('npm', { output: 'simulated npm failure', status: 23 });
+    writeTestExecutable('ballin', `#!/usr/bin/env bash
+printf '%s|%s|%s\\n' "ballin" "$HOMEBREW_NO_ENV_HINTS,$HOMEBREW_NO_ASK" "$*" >> "$UPDATE_TEST_LOG"
+printf '%s\\n' 'simulated backup failure'
+exit 17
+`);
+
+    const result = runUpdate({
+      TEST_UPDATE_NVM: 'false',
+      TEST_UPDATE_NPM: 'true',
+      TEST_UPDATE_BACKUP: 'true',
+    });
+
+    assert.equal(result.status, 17);
+    assert.include(result.stdout, 'simulated npm failure');
+    assert.include(result.stdout, 'simulated backup failure');
+    assert.deepEqual(commandLog(), [
+      'npm|,|update -g',
+      'ballin|,|backup',
+    ]);
+  });
+
+  it('rejects non-object configuration structures before running integrations', () => {
+    writeConfig([]);
+    const arrayResult = spawnUpdate();
+    assert.equal(arrayResult.status, 1);
+    assert.include(arrayResult.stderr, 'Ballin config must contain a JSON object.');
+
+    writeConfig({ update: null });
+    const updateResult = spawnUpdate();
+    assert.equal(updateResult.status, 1);
+    assert.include(updateResult.stderr, 'Ballin config update section must contain a JSON object.');
+    assert.deepEqual(commandLog(), []);
+  });
+
+  it('rejects invalid known update booleans before running integrations', () => {
+    writeConfig({
+      update: {
+        cleanup: 'yes',
+      },
+    });
+
+    const result = spawnUpdate();
+
+    assert.equal(result.status, 1);
+    assert.include(result.stderr, 'Ballin config update.cleanup must be true or false.');
+    assert.deepEqual(commandLog(), []);
+  });
+
   it('surfaces config read failures', () => {
     fs.writeFileSync(configPath, '{not json\n');
 
@@ -608,8 +813,19 @@ printf '%s\\n' 'backup still ran' >> "$UPDATE_TEST_LOG"
       },
     });
 
-    assert.equal(result.status, 0);
-    assert.isNotEmpty(result.stderr);
+    assert.equal(result.status, 1);
+    assert.include(result.stderr, 'Ballin config is not valid JSON.');
+    assert.deepEqual(commandLog(), []);
+  });
+
+  it('reports unreadable config before running integrations', () => {
+    fs.chmodSync(configPath, 0o000);
+
+    const result = spawnUpdate();
+
+    fs.chmodSync(configPath, 0o600);
+    assert.equal(result.status, 1);
+    assert.include(result.stderr, 'Unable to read Ballin config');
     assert.deepEqual(commandLog(), []);
   });
 
@@ -626,8 +842,8 @@ printf '%s\\n' 'backup still ran' >> "$UPDATE_TEST_LOG"
       },
     });
 
-    assert.equal(result.status, 0);
-    assert.include(result.stderr, 'Unable to read');
+    assert.equal(result.status, 1);
+    assert.include(result.stderr, 'Unable to read Ballin config');
     assert.deepEqual(commandLog(), []);
   });
 });

--- a/test/update.test.ts
+++ b/test/update.test.ts
@@ -212,8 +212,8 @@ exit 0
       'brew|1,1|cleanup',
       'brew|1,1|doctor',
       'ballin|1,1|self-update',
-      'gh|1,1|auth status --hostname example.test',
-      'gh|1,1|gist view test-gist-id --files',
+      'gh|1,1|auth status --active --hostname example.test',
+      'gh|1,1|gist view --files -- test-gist-id',
     ]);
   });
 
@@ -232,8 +232,8 @@ exit 0
       'brew|1,1|upgrade',
       'brew|1,1|doctor',
       'ballin|1,1|self-update',
-      'gh|1,1|auth status --hostname example.test',
-      'gh|1,1|gist view test-gist-id --files',
+      'gh|1,1|auth status --active --hostname example.test',
+      'gh|1,1|gist view --files -- test-gist-id',
     ]);
   });
 
@@ -271,8 +271,8 @@ exit 0
       'npm|,|update -g',
       'softwareupdate|,|-ia',
       'ballin|,|self-update',
-      'gh|,|auth status --hostname example.test',
-      'gh|,|gist view test-gist-id --files',
+      'gh|,|auth status --active --hostname example.test',
+      'gh|,|gist view --files -- test-gist-id',
       'ballin|,|backup',
     ]);
   });
@@ -293,8 +293,8 @@ exit 0
     assert.include(result.stdout, 'Your Ballin-managed environment is healthy.');
     assert.deepEqual(commandLog(), [
       'ballin|,|self-update',
-      'gh|,|auth status --hostname example.test',
-      'gh|,|gist view test-gist-id --files',
+      'gh|,|auth status --active --hostname example.test',
+      'gh|,|gist view --files -- test-gist-id',
     ]);
   });
 
@@ -329,8 +329,8 @@ exit 2
       'node|,|-e process.stdout.write(JSON.stringify(process.env))',
       'ballin|,|self-update',
       'node|,|-p process.versions.node',
-      'gh|,|auth status --hostname example.test',
-      'gh|,|gist view test-gist-id --files',
+      'gh|,|auth status --active --hostname example.test',
+      'gh|,|gist view --files -- test-gist-id',
     ]);
   });
 
@@ -357,8 +357,8 @@ exit 0
     assert.notInclude(result.stdout, 'Your Ballin-managed environment is healthy.');
     assert.deepEqual(commandLog(), [
       'ballin|,|self-update',
-      'gh|,|auth status --hostname example.test',
-      'gh|,|gist view test-gist-id --files',
+      'gh|,|auth status --active --hostname example.test',
+      'gh|,|gist view --files -- test-gist-id',
       'ballin|,|backup',
     ]);
   });
@@ -414,8 +414,8 @@ exit 0
     assert.deepEqual(commandLog(), [
       'npm|,|update -g',
       'ballin|,|self-update',
-      'gh|,|auth status --hostname example.test',
-      'gh|,|gist view test-gist-id --files',
+      'gh|,|auth status --active --hostname example.test',
+      'gh|,|gist view --files -- test-gist-id',
       'ballin|,|backup',
     ]);
   });
@@ -442,8 +442,8 @@ exit 0
     assert.include(result.stdout, 'simulated backup failure');
     assert.deepEqual(commandLog(), [
       'ballin|,|self-update',
-      'gh|,|auth status --hostname example.test',
-      'gh|,|gist view test-gist-id --files',
+      'gh|,|auth status --active --hostname example.test',
+      'gh|,|gist view --files -- test-gist-id',
       'ballin|,|backup',
     ]);
   });
@@ -651,8 +651,8 @@ printf '%s\\n' 'backup still ran' >> "$UPDATE_TEST_LOG"
     assert.deepEqual(commandLog(), [
       'softwareupdate|,|-ia',
       'ballin|,|self-update',
-      'gh|,|auth status --hostname example.test',
-      'gh|,|gist view test-gist-id --files',
+      'gh|,|auth status --active --hostname example.test',
+      'gh|,|gist view --files -- test-gist-id',
     ]);
     assert.equal(fs.readFileSync(configPath, 'utf8'), beforeConfig);
   });
@@ -819,11 +819,11 @@ exit 17
   });
 
   it('reports unreadable config before running integrations', () => {
-    fs.chmodSync(configPath, 0o000);
+    fs.rmSync(configPath);
+    fs.symlinkSync(path.join(tempDir, 'missing-config-target'), configPath);
 
     const result = spawnUpdate();
 
-    fs.chmodSync(configPath, 0o600);
     assert.equal(result.status, 1);
     assert.include(result.stderr, 'Unable to read Ballin config');
     assert.deepEqual(commandLog(), []);


### PR DESCRIPTION
## Summary

- validate update configuration once before integrations, merge missing known keys from bundled defaults in memory, and fail clearly on unreadable or invalid values
- record enabled-but-unavailable update stages and failed post-self-update readiness while continuing later independent stages and preserving last-nonzero status
- make backup prerequisites core doctor health and add a read-only `backup.read` check that explicitly does not claim write permission
- document the current one-active-writer and partial per-file backup boundary, with consistency work deferred to #282

## Compatibility

Older or partial configs remain supported: valid present values are preserved, missing known update settings use bundled defaults for the current run, unknown keys are ignored, and `ballin update` does not rewrite the config. Invalid known values and malformed config now fail before integrations instead of silently doing no work.

Doctor verifies the configured Gist is readable through the authenticated host. It does not verify write permission, freshness, completeness, cache consistency, or the absence of partial backup runs.

## Validation

- `npx mocha test/update.test.ts test/setup_readiness.test.ts test/ballin.test.ts` (60 passing)
- `npm test`
- `git diff --check`

Implementation began from `origin/main` at `020cb957dbd592691b03d16c4a8ef2ab24262315`. The branch was refreshed with current `main` at `c17895c757c5e612d9573f508b173e31eb2250ef`; the naming-alignment conflict was resolved in favor of the settled Ballin product terminology while preserving the new reliability semantics, then the integrated tree was fully revalidated.

Closes #274

Follow-up: #282
