### PR TITLE
docs: align Ballin terminology

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# Ballin Scripts
+# Ballin
 
 *Back up your dotfiles and update your macOS development environment*
 
 ![Ballin README hero showing the Ballin identity and the line Back up dotfiles. Keep your tools current.](docs/assets/brand/readme-hero.png)
 
-`ballin-scripts` helps developers maintain repeatable, inspectable macOS
+Ballin helps developers maintain repeatable, inspectable macOS
 development environments. It snapshots shell and Git configuration, Homebrew
 state, editor settings, and local tool inventories while automating routine
 updates.
@@ -56,10 +56,10 @@ Your system is ready to brew.
 
 ## New Mac setup
 
-On a new Mac, install `ballin-scripts` and create or adopt the backup Gist. Use
+On a new Mac, install Ballin and create or adopt the backup Gist. Use
 existing snapshots as a rebuild reference.
 
-`ballin-scripts` makes rebuilds more repeatable and auditable, but it is not a
+Ballin makes rebuilds more repeatable and auditable, but it is not a
 full disk backup or one-command restore system.
 
 ## Commands
@@ -82,7 +82,7 @@ Backups are stored in a configured secret GitHub Gist. Secret Gists are
 unlisted, but anyone with the URL can view them. Treat the Gist URL and
 snapshots as sensitive.
 
-`ballin-scripts` is not a secrets manager; review snapshots before sharing the
+Ballin is not a secrets manager; review snapshots before sharing the
 Gist URL or making the Gist public.
 
 ## Documentation

--- a/analytics-worker/README.md
+++ b/analytics-worker/README.md
@@ -1,6 +1,6 @@
 # Analytics Worker
 
-This is the backend for the minimal `ballin-scripts` active-install analytics.
+This is the backend for Ballin's minimal active-install analytics.
 It is intentionally isolated from the CLI so the command package does not gain
 runtime analytics SDK dependencies.
 

--- a/commands/analytics.ts
+++ b/commands/analytics.ts
@@ -83,7 +83,7 @@ const installIdPattern = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-
 const defaultAnalyticsDocsUrl = 'https://github.com/JBallin/ballin-scripts/blob/main/docs/analytics.md';
 const productionAnalyticsEndpoint = 'https://ballin-scripts-analytics.jballin.workers.dev/v1/events';
 const analyticsNoticeFor = (docsUrl = defaultAnalyticsDocsUrl): string => [
-  'ballin-scripts collects minimal anonymous usage analytics after this notice.',
+  'Ballin collects minimal anonymous usage analytics after this notice.',
   'Disable: ballin config set analytics.enabled false',
   `Details: ${docsUrl}`,
 ].join('\n');

--- a/commands/install_setup.ts
+++ b/commands/install_setup.ts
@@ -272,7 +272,7 @@ const configureGist = (repoDir: string, docsUrl: string, backupHostExisted: bool
     return true;
   }
 
-  const hasBackup = readPrompt('\n🤔 Do you already have a ballin-scripts backup gist? [y/N] ');
+  const hasBackup = readPrompt('\n🤔 Do you already have a Ballin backup Gist? [y/N] ');
   if (hasBackup === 'y' || hasBackup === 'Y') {
     writeStdoutLine('\nWelcome Back!');
     let validGistId = false;

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # Documentation
 
-Start here when setting up or auditing what `ballin-scripts` manages.
+Start here when setting up or auditing what Ballin manages.
 
 ## User guides
 

--- a/docs/analytics-backend.md
+++ b/docs/analytics-backend.md
@@ -1,6 +1,6 @@
 # Analytics Backend
 
-`ballin-scripts` uses a small Cloudflare Worker backed by D1 for usage
+Ballin uses a small Cloudflare Worker backed by D1 for usage
 analytics. The backend records only the minimal signals needed for active
 installs, top-level command usage, and command success or failure.
 

--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -1,6 +1,6 @@
 # Analytics
 
-`ballin-scripts` can send minimal anonymous usage analytics after the installer
+Ballin can send minimal anonymous usage analytics after the installer
 shows a first-run notice. Analytics show active installs, top-level command
 usage, and command success or failure.
 

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -1,6 +1,6 @@
 # Supported capabilities
 
-This reference lists the update and backup surfaces that `ballin-scripts`
+This reference lists the update and backup surfaces that Ballin
 currently manages. Optional tools are used only when the matching command or
 setting is available.
 

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -28,9 +28,9 @@ For repository-specific assets, `>_ ballin-scripts` may be used when the asset
 is explicitly representing the repository or package rather than the product
 identity alone.
 
-Use Ballin for user-facing product language. Use `ballin-scripts` when precision
-matters for the repository, package, local checkout, install paths, or
-self-update behavior.
+Use Ballin for user-facing product or tool language, `ballin` for the executable
+and command examples, and `ballin-scripts` when precision matters for the
+repository, package, local checkout, install paths, or self-update behavior.
 
 Prompt and cursor motifs are useful accents, but they do not need to appear in
 every asset. Avoid mascot-first, badge-first, or complex logo-first branding for

--- a/docs/optional-capabilities.md
+++ b/docs/optional-capabilities.md
@@ -1,7 +1,7 @@
 # Optional capabilities
 
 This guide covers choices for the required Node.js setup, plus optional tools
-and settings that extend `ballin-scripts`. The defaults keep updates predictable
+and settings that extend Ballin. The defaults keep updates predictable
 while letting you opt in to broader automation.
 
 ## Working with settings
@@ -21,7 +21,7 @@ an existing setting, and `reset` restores the default config.
 
 ## Node.js
 
-Node.js is required by `ballin-scripts`; install it using whichever method fits
+Node.js is required by Ballin; install it using whichever method fits
 your environment. For development, we recommend [nvm](https://github.com/nvm-sh/nvm)
 with the latest Node.js long-term support (LTS) release. It supports switching
 versions, project-specific `.nvmrc` files, and a user-local installation.
@@ -37,7 +37,7 @@ nvm install --lts
 Installed commands use the `node` found on your shell `PATH`, so make sure new
 terminal sessions use a supported Node.js version too.
 
-After installing `ballin-scripts`, optionally let `ballin update` install newer
+After installing Ballin, optionally let `ballin update` install newer
 LTS releases:
 
 ```shell
@@ -75,7 +75,7 @@ setting is required.
 ## Gist backups
 
 `ballin backup` uses [GitHub CLI](https://cli.github.com/) to read and update
-the configured backup Gist. During install, `ballin-scripts` prompts for the
+the configured backup Gist. During install, Ballin prompts for the
 GitHub host, including GitHub Enterprise hosts, checks `gh` authentication for
 that host, and either adopts an existing backup Gist or creates a new one. When
 an adopted backup includes a saved `ballin_config` snapshot, the installer restores
@@ -107,7 +107,7 @@ ballin doctor
 
 ## Analytics
 
-`ballin-scripts` can send minimal anonymous usage analytics after a first-run
+Ballin can send minimal anonymous usage analytics after a first-run
 notice. See [Analytics](analytics.md) for what is sent, what is never sent, and
 how long it is kept.
 

--- a/test/install_setup.test.ts
+++ b/test/install_setup.test.ts
@@ -298,6 +298,7 @@ esac
 
     assert.isTrue(result);
     assert.equal(output, `\n${analyticsNotice}\n`);
+    assert.include(output, 'Ballin collects minimal anonymous usage analytics after this notice.');
     assert.match(readInstallId(), /^[0-9a-f-]{36}\n$/);
   });
 
@@ -574,6 +575,7 @@ esac
     const result = runGistSetup({ input: '\ny\nreturning-gist-id\n' });
 
     assert.equal(result.status, 0, result.stderr);
+    assert.include(result.stdout, 'Do you already have a Ballin backup Gist? [y/N]');
     assert.include(result.stdout, 'Restored ballin.config.json from your backup gist');
     assert.include(commandLog(), 'gh:gist view returning-gist-id --raw --filename ballin_config');
     const restoredConfig = JSON.parse(fs.readFileSync(path.join(repoDir, 'ballin.config.json'), 'utf8'));


### PR DESCRIPTION
## Summary

Closes #283.

- apply the settled naming policy across maintained user-facing documentation: Ballin for the product/tool, `ballin` for the executable and command examples, and `ballin-scripts` for repository/package/checkout/install-path/self-update precision
- update the analytics notice and installer backup-Gist prompt to use the Ballin product name
- add focused exact-output assertions for the two intentional CLI wording changes
- preserve repository URLs, package/version fields, `.ballin-scripts` paths, Cloudflare resource names, self-update wording, and the historical backup marker

## Validation

- `npm test` (`288 passing`)
- `git diff --check`
- repeated terminology audit confirming every remaining `ballin-scripts` occurrence is a deliberate technical reference
- final diff review against issue #283 with no unrelated behavior, identifier, routing, package, or copy changes