### PR TITLE
docs: align package description

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ballin-scripts",
   "version": "2.0.0",
-  "description": "Useful scripts to save time",
+  "description": "Back up your dotfiles and update your macOS development environment",
   "scripts": {
     "lint": "eslint .",
     "analytics:report": "node analytics-worker/report.ts",


### PR DESCRIPTION
## Summary

Closes #288.

- replace the outdated package description with Ballin's current backup and macOS development-environment update capability tagline
- preserve the ballin-scripts package identity and all other package metadata
- leave package-lock.json unchanged because it does not duplicate the description

## Validation

- npm test (304 passing)
- git diff --check origin/main..HEAD