### PR TITLE
feat: brand healthy doctor output

### DIFF
--- a/commands/doctor_report.ts
+++ b/commands/doctor_report.ts
@@ -57,7 +57,7 @@ const formatVerboseDoctorReport = (report: DoctorReport): string => {
 
 const formatDefaultDoctorReport = (report: DoctorReport): string => {
   if (report.status === 'pass') {
-    return 'Your Ballin-managed environment is healthy.\n';
+    return '😎 You\'re ballin.\n';
   }
 
   const visibleStatuses = report.status === 'fail' ? ['fail', 'warn'] : ['warn'];

--- a/test/ballin.test.ts
+++ b/test/ballin.test.ts
@@ -227,7 +227,7 @@ exit 17
     const result = runBallin(['doctor']);
 
     assert.equal(result.status, 0, result.stderr);
-    assert.equal(result.stdout, 'Your Ballin-managed environment is healthy.\n');
+    assert.equal(result.stdout, '😎 You\'re ballin.\n');
     assert.equal(result.stderr, '');
     assert.deepEqual(commandLog(), [
       'auth status --active --hostname example.test',
@@ -252,6 +252,7 @@ exit 17
       'OK    Configured Gist readability: The configured backup Gist exists and is readable. Write permission was not checked.',
     );
     assert.include(result.stdout, 'Result: Ballin-managed environment health looks good.');
+    assert.notInclude(result.stdout, '😎 You\'re ballin.');
     assert.equal(result.stderr, '');
     assert.deepEqual(commandLog(), [
       'auth status --active --hostname example.test',

--- a/test/update.test.ts
+++ b/test/update.test.ts
@@ -206,7 +206,7 @@ exit 0
     assert.include(result.stdout, 'simulated cleanup failure');
     assert.include(result.stdout, 'Checking Homebrew installation');
     assert.include(result.stdout, 'Updating ballin-scripts');
-    assert.include(result.stdout, 'Your Ballin-managed environment is healthy.');
+    assert.include(result.stdout, '😎 You\'re ballin.');
     assert.deepEqual(commandLog(), [
       'brew|1,1|upgrade',
       'brew|1,1|cleanup',
@@ -290,7 +290,7 @@ exit 0
     assert.include(result.stdout, 'Updating ballin-scripts');
     assert.include(result.stdout, 'updated ballin-scripts');
     assert.include(result.stdout, 'Checking Ballin readiness');
-    assert.include(result.stdout, 'Your Ballin-managed environment is healthy.');
+    assert.include(result.stdout, '😎 You\'re ballin.');
     assert.deepEqual(commandLog(), [
       'ballin|,|self-update',
       'gh|,|auth status --active --hostname example.test',
@@ -324,7 +324,7 @@ exit 2
 
     assert.equal(result.status, 0);
     assert.include(result.stdout, 'Checking Ballin readiness');
-    assert.include(result.stdout, 'Your Ballin-managed environment is healthy.');
+    assert.include(result.stdout, '😎 You\'re ballin.');
     assert.deepEqual(commandLog().slice(1), [
       'node|,|-e process.stdout.write(JSON.stringify(process.env))',
       'ballin|,|self-update',
@@ -354,7 +354,7 @@ exit 0
     assert.include(result.stdout, 'Checking Ballin readiness');
     assert.include(result.stdout, 'ERROR Command shims on PATH: Missing command shims on PATH: ballin.');
     assert.include(result.stdout, 'Next: Run the installer again or add the Ballin command directory to PATH.');
-    assert.notInclude(result.stdout, 'Your Ballin-managed environment is healthy.');
+    assert.notInclude(result.stdout, '😎 You\'re ballin.');
     assert.deepEqual(commandLog(), [
       'ballin|,|self-update',
       'gh|,|auth status --active --hostname example.test',
@@ -375,7 +375,7 @@ exit 0
     assert.equal(result.status, 23);
     assert.include(result.stdout, 'simulated update failure');
     assert.notInclude(result.stdout, 'Checking Ballin readiness');
-    assert.notInclude(result.stdout, 'Your Ballin-managed environment is healthy.');
+    assert.notInclude(result.stdout, '😎 You\'re ballin.');
     assert.deepEqual(commandLog(), [
       'ballin|,|self-update',
     ]);
@@ -438,7 +438,7 @@ exit 0
     });
 
     assert.equal(result.status, 17);
-    assert.include(result.stdout, 'Your Ballin-managed environment is healthy.');
+    assert.include(result.stdout, '😎 You\'re ballin.');
     assert.include(result.stdout, 'simulated backup failure');
     assert.deepEqual(commandLog(), [
       'ballin|,|self-update',


### PR DESCRIPTION
## Summary
- change the healthy default doctor result to `😎 You're ballin.`
- preserve verbose diagnostics, warnings, failures, and exit statuses
- update focused doctor and shared update-readiness expectations

## Validation
- `npm test` (304 passing)

Closes #289